### PR TITLE
fix(ci): build frontend before clippy + switch release.yml to pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,26 @@ jobs:
         if: runner.os == 'Linux'
         run: ./scripts/ci.sh install-deps
 
+      # tauri::generate_context!() validates frontendDist: "../dist" at compile
+      # time. Without app/dist, clippy panics on the projectmind-app crate.
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+          cache-dependency-path: app/pnpm-lock.yaml
+
+      - name: Build frontend (required for tauri::generate_context!)
+        working-directory: app
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+
       - name: Format + clippy
         run: ./scripts/ci.sh check
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -75,7 +75,7 @@ cmd_release_smoke() {
     cmd_release_build
     local bin="target/release/projectmind-mcp"
     local tmp
-    tmp="$(mktemp -t projectmind-smoke)"
+    tmp="$(mktemp -t projectmind-smoke.XXXXXX)"
     trap 'rm -f "$tmp"' RETURN
 
     # Pipe stays open until the server reads EOF and exits cleanly. Using `grep -q` in


### PR DESCRIPTION
## Summary
- CI hat seit dem Rebrand zu ProjectMind auf jedem Push gefailt, weil `cargo clippy --workspace` den Tauri-App-Crate kompiliert und `tauri::generate_context!()` zur Compile-Zeit `frontendDist: \"../dist\"` validiert — das Verzeichnis existiert in CI aber nicht, also panicked das Proc-Macro.
- Frontend wird jetzt in CI vor clippy/test gebaut (pnpm install + pnpm build).
- `release.yml` und der zugehörige `ci.sh app-build`-Helper sind von npm auf pnpm umgestellt — das Repo hat nur `pnpm-lock.yaml`, also würde `npm ci` mangels `package-lock.json` scheitern und `npm install` die Dep-Resolution neu machen.

## Test plan
- [ ] CI-Run auf diesem Branch läuft grün durch (Rust-Job auf Linux + macOS, Release-Build-Job).
- [ ] Nach Merge: Tag `v0.2.0` pushen und prüfen, ob `release.yml` 7 Assets erzeugt (4× `projectmind-mcp-*.tar.gz`, 3× `projectmind-app-*.tar.gz`).
- [ ] `scripts/install.sh` lokal gegen das neue Release testen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)