### PR TITLE
docs: anonymize SYNC.md examples + refresh status/roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ navigate. It's a lightweight, **read-only** architecture browser for source
 code that pairs bidirectionally with LLM-driven coding agents (Claude Code,
 etc.) via the **Model Context Protocol (MCP)**.
 
-> **Status:** Early MVP — the **MCP server** and a basic **Tauri UI** both work. Java + Rust language plugins, Spring + Lombok framework recognisers, Mermaid bean graph and package tree, plus an HTML browser that renders `.html` / `.xhtml` / `.jsp` files and embedded HTML snippets in a sandboxed iframe.
+> **Status:** Phase 1 MVP — the **MCP server** and the **Tauri UI** both work. Java + Rust language plugins, Spring + Lombok framework recognisers, Mermaid bean graph + package tree + folder map, Markdown browser, HTML browser (renders `.html` / `.xhtml` / `.jsp` files and embedded HTML snippets in a sandboxed iframe), walkthrough mode and bidirectional MCP sync between LLM and GUI.
 
 ## Why
 
@@ -166,7 +166,7 @@ Add to your project's `.mcp.json` (or your global Claude Code config):
 
 Restart Claude Code. From a session, you can then ask things like:
 
-- *"Open the repo at `/home/me/codeplain/plaintext-app` and tell me how many services and controllers there are per module."*
+- *"Open the repo at `/home/me/projects/my-spring-app` and tell me how many services and controllers there are per module."*
 - *"Find any class containing `Auszahl` and outline the most relevant one."*
 - *"Show me the `UserService` class — highlight lines 80-95."*
 - *"Which files changed since HEAD~5? Group them by module."*
@@ -228,8 +228,8 @@ See [`docs/plan/`](docs/plan/) for the full design notes:
 
 ## Roadmap
 
-- **Phase 1 (in progress):** MCP server with Java + Spring + Lombok plugins, package tree, bean graph, pom dependency graph, diff view, Markdown viewer, core MCP tools.
-- **Phase 2:** Tauri shell with a graphical browser, annotation round-trip, draw.io embed, Confluence MCP bridge.
+- **Phase 1 (done):** MCP server with Java + Spring + Lombok plugins, Rust plugin, package tree, bean graph, folder map, diff view, Markdown + HTML browsers, walkthrough mode, core MCP tools, Tauri shell with bidirectional MCP sync.
+- **Phase 2 (in progress):** Annotation round-trip, draw.io embed, Confluence MCP bridge, dynamic plugin loading from `./plugins/`.
 - **Phase 3:** Plugin marketplace, more languages, JSF / PrimeFaces preview, C4 diagram generator.
 
 ## Contributing

--- a/docs/SYNC.md
+++ b/docs/SYNC.md
@@ -25,10 +25,10 @@ Schema (`crates/core/src/state.rs`):
 ```jsonc
 {
   "version": 1,
-  "repo_root": "/Users/mad/codeplain/plaintext-app",
+  "repo_root": "/path/to/repo",
   "view": {
     "kind": "classes",                  // or "diagram" | "diff" | "file"
-    "selected_fqn": "ch.plaintext.UserService"
+    "selected_fqn": "com.example.UserService"
   },
   "seq": 42                              // monotonic; bumped on every write
 }
@@ -160,12 +160,12 @@ already a parseable line stream.
 With Claude Code wired to `projectmind-mcp`:
 
 ```
-You: Open /Users/mad/codeplain/plaintext-app, then show me UserService.
-LLM: → open_repo  → view_class("ch.plaintext.UserService")
-GUI: jumps to plaintext-app, switches to classes view, opens UserService.
+You: Open ~/projects/example-app, then show me UserService.
+LLM: → open_repo  → view_class("com.example.UserService")
+GUI: jumps to example-app, switches to classes view, opens UserService.
 
 You: Show me the README.
-LLM: → view_file("/…/plaintext-app/README.md")
+LLM: → view_file("/…/example-app/README.md")
 GUI: switches to file view, renders markdown with embedded mermaid.
 
 You: What did I change since main?


### PR DESCRIPTION
## Summary
Repo wurde public — kleine Bereinigungen für den Public-Zustand.

- `docs/SYNC.md`: persönliche Pfade `/Users/mad/codeplain/plaintext-app` und Klassennamen `ch.plaintext.UserService` durch generische Platzhalter ersetzt.
- `README.md`: Status von „Early MVP" auf „Phase 1 MVP" gehoben (Tauri Shell, Walkthrough, Folder-Map, MCP-Sync sind alle live), Roadmap aktualisiert: Phase 1 als done markiert, Phase 2 fokussiert auf Annotation Round-Trip + dynamic plugin loading.
- README-Beispielpfad von `plaintext-app` auf generisches `my-spring-app` umgestellt.

## Test plan
- [x] `grep -rn '/Users/mad' docs/ README.md` ergibt keine Treffer mehr
- [x] CI grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)