### PR TITLE
chore(security): scoped permissions + skip dist/ in CodeQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,17 @@ env:
   RUSTFLAGS: -D warnings
   RUST_BACKTRACE: 1
 
+# Workflow runs only ever read the repo and write to the cache — no need
+# for GITHUB_TOKEN write scopes anywhere here.
+permissions:
+  contents: read
+
 jobs:
   rust:
     name: Rust ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -64,6 +71,8 @@ jobs:
     name: Release build (Linux)
     runs-on: ubuntu-22.04
     needs: rust
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,6 +38,13 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
+          # Skip generated / vendored / 3rd-party JS so CodeQL doesn't flag
+          # findings in minified Mermaid bundles or in dist/ build output.
+          config: |
+            paths-ignore:
+              - app/dist/**
+              - app/node_modules/**
+              - target/**
 
       # Rust + JS/TS need autobuild so CodeQL can extract semantic info.
       # Frontend autobuild needs the SPA built (same generate_context!()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,17 @@ on:
       - 'v*.*.*'
   workflow_dispatch:
 
+# Default to read-only. The release-publish job re-elevates to
+# `contents: write` to upload assets — see below.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
Erste Runde Security-Hardening nach dem Public-Switch:

- **`actions/missing-workflow-permissions` (×3)**: GITHUB_TOKEN default-mässig auf read-only gesetzt in ci.yml + release.yml (workflow- und job-level). Release-Publish-Job hat schon eine eigene `contents: write` Re-Elevation.
- **12× JS-Findings in `app/dist/`** (gebaute Mermaid-Bundles): `paths-ignore` im CodeQL-Init, damit generierte Artefakte aus dem Scan rausfallen.

**Offen (Follow-up):** 8× `actions/unpinned-tag` — kommt später, Dependabot managt Versionen sowieso.

## Test plan
- [ ] CI grün
- [ ] CodeQL-Run zeigt nach Merge keine `app/dist/`-Findings mehr
- [ ] 3× `missing-workflow-permissions` weg

🤖 Generated with [Claude Code](https://claude.com/claude-code)