### PR TITLE
chore(release): bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-app"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "notify",
  "parking_lot",
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3031,7 +3031,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-framework-lombok"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "projectmind-plugin-api",
  "serde_json",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-framework-spring"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "projectmind-plugin-api",
  "tracing",
@@ -3047,7 +3047,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-lang-java"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "projectmind-plugin-api",
  "tracing",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-lang-rust"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "projectmind-plugin-api",
  "tracing",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-mcp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3088,7 +3088,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-plugin-api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/Plaintext-Gmbh/projectmind"
@@ -48,8 +48,8 @@ struct_field_names = "allow"
 ignored_unit_patterns = "allow"
 
 [workspace.dependencies]
-projectmind-plugin-api = { path = "crates/plugin-api", version = "0.1.0" }
-projectmind-core       = { path = "crates/core",       version = "0.1.0" }
+projectmind-plugin-api = { path = "crates/plugin-api", version = "0.2.0" }
+projectmind-core       = { path = "crates/core",       version = "0.2.0" }
 
 # General
 anyhow      = "1.0"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "projectmind-app",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -21,10 +21,10 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 projectmind-plugin-api = { workspace = true }
 projectmind-core       = { workspace = true }
-projectmind-lang-java  = { path = "../../plugins/lang-java", version = "0.1.0" }
-projectmind-lang-rust  = { path = "../../plugins/lang-rust", version = "0.1.0" }
-projectmind-framework-spring = { path = "../../plugins/framework-spring", version = "0.1.0" }
-projectmind-framework-lombok = { path = "../../plugins/framework-lombok", version = "0.1.0" }
+projectmind-lang-java  = { path = "../../plugins/lang-java", version = "0.2.0" }
+projectmind-lang-rust  = { path = "../../plugins/lang-rust", version = "0.2.0" }
+projectmind-framework-spring = { path = "../../plugins/framework-spring", version = "0.2.0" }
+projectmind-framework-lombok = { path = "../../plugins/framework-lombok", version = "0.2.0" }
 
 tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-dialog = "2"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "ProjectMind",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "ch.plaintext.projectmind",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/crates/mcp-server/Cargo.toml
+++ b/crates/mcp-server/Cargo.toml
@@ -20,10 +20,10 @@ projectmind-plugin-api = { workspace = true }
 projectmind-core       = { workspace = true }
 
 # Local plugins linked statically for Phase 1
-projectmind-lang-java         = { path = "../../plugins/lang-java", version = "0.1.0" }
-projectmind-lang-rust         = { path = "../../plugins/lang-rust", version = "0.1.0" }
-projectmind-framework-spring  = { path = "../../plugins/framework-spring", version = "0.1.0" }
-projectmind-framework-lombok  = { path = "../../plugins/framework-lombok", version = "0.1.0" }
+projectmind-lang-java         = { path = "../../plugins/lang-java", version = "0.2.0" }
+projectmind-lang-rust         = { path = "../../plugins/lang-rust", version = "0.2.0" }
+projectmind-framework-spring  = { path = "../../plugins/framework-spring", version = "0.2.0" }
+projectmind-framework-lombok  = { path = "../../plugins/framework-lombok", version = "0.2.0" }
 
 anyhow      = { workspace = true }
 clap        = { workspace = true }


### PR DESCRIPTION
Bumpt alle Versions-Strings (workspace, app, tauri.conf, internal-dep specs) auf 0.2.0. Release-Pipeline triggert bei Tag-Push v0.2.0 nach dem Merge.