### PR TITLE
chore(docs): real SECURITY.md + frontier-model wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@
 ProjectMind uses AI-ready project maps to explain software architecture,
 classes, modules and relationships in a way humans and coding agents can
 navigate. It's a lightweight, **read-only** architecture browser for source
-code that pairs bidirectionally with LLM-driven coding agents (Claude Code,
-etc.) via the **Model Context Protocol (MCP)**.
+code that pairs bidirectionally with LLM-driven coding agents — Claude Code,
+ChatGPT / OpenAI Codex, Gemini CLI, Cursor, and any other frontier model
+that speaks the **Model Context Protocol (MCP)**.
 
 > **Status:** Phase 1 MVP — the **MCP server** and the **Tauri UI** both work. Java + Rust language plugins, Spring + Lombok framework recognisers, Mermaid bean graph + package tree + folder map, Markdown browser, HTML browser (renders `.html` / `.xhtml` / `.jsp` files and embedded HTML snippets in a sandboxed iframe), walkthrough mode and bidirectional MCP sync between LLM and GUI.
 
@@ -36,7 +37,9 @@ The Tauri shell has four tabs (each disabled until a repository is open):
 
 ## What works today
 
-The Phase 1 MVP ships a **Rust MCP server** (`projectmind-mcp`) that Claude Code can connect to. It implements:
+The Phase 1 MVP ships a **Rust MCP server** (`projectmind-mcp`) that any
+MCP-aware client — Claude Code, ChatGPT, Gemini CLI, Cursor, or your own
+custom agent — can connect to. It implements:
 
 | Tool | What it does |
 |---|---|
@@ -68,7 +71,8 @@ Smoke-tested against real codebases: a 21-module Spring Boot Maven monorepo pars
 
 ## Build the MCP server (Ubuntu / Debian)
 
-This is the path you want for **using `projectmind` from Claude Code on Ubuntu** — no GUI required.
+This is the path you want for **using `projectmind` from any MCP-aware
+agent (Claude Code, ChatGPT, Gemini CLI, …) on Ubuntu** — no GUI required.
 
 The repo ships an installer for the impatient:
 
@@ -146,9 +150,13 @@ Run the app in dev mode (live-reload):
 cd app && pnpm tauri dev
 ```
 
-## Use with Claude Code
+## Use with an MCP-aware agent
 
-Add to your project's `.mcp.json` (or your global Claude Code config):
+ProjectMind speaks the **Model Context Protocol (MCP)**, so any frontier
+LLM client that supports MCP can drive it: Claude Code, ChatGPT desktop,
+Gemini CLI, Cursor, Continue, or your own scripted agent. Add the server
+to whichever config the client uses (e.g. `.mcp.json` for Claude Code,
+`mcp_settings.json` for Cursor):
 
 ```json
 {
@@ -164,7 +172,7 @@ Add to your project's `.mcp.json` (or your global Claude Code config):
 }
 ```
 
-Restart Claude Code. From a session, you can then ask things like:
+Restart the client. From a session, you can then ask things like:
 
 - *"Open the repo at `/home/me/projects/my-spring-app` and tell me how many services and controllers there are per module."*
 - *"Find any class containing `Auszahl` and outline the most relevant one."*

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,20 +2,31 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+ProjectMind is in active early development. We support the latest minor
+release line with security patches; older lines are not backported.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+| 0.2.x   | :white_check_mark: |
+| < 0.2   | :x:                |
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+If you believe you've found a security issue in ProjectMind, please **do
+not open a public issue**. Instead, send an email to
+[info@plaintext.ch](mailto:info@plaintext.ch) with:
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+- A description of the issue
+- Steps to reproduce, ideally with a minimal proof of concept
+- The affected ProjectMind version (or commit SHA)
+- Your assessment of impact
+
+We aim to acknowledge reports within **3 working days** and to ship a
+fix or workaround within **30 days** for confirmed issues. If we accept
+the report, we will credit you in the release notes unless you prefer
+to remain anonymous. If we decline (e.g. out of scope, intended
+behaviour, third-party dependency), we will explain why.
+
+GitHub's
+[private vulnerability reporting](https://github.com/Plaintext-Gmbh/projectmind/security/advisories/new)
+is also enabled if you'd rather use that channel.


### PR DESCRIPTION
Zwei Polish-Fixes vor v0.2.0:

- **SECURITY.md**: ersetzt das Default-GitHub-Template (5.1.x usw.) durch echte Policy — 0.2.x supported, Vulnerability-Reports an info@plaintext.ch, 3-Tage-Ack / 30-Tage-Fix-Target, Hinweis auf GitHub's private vulnerability reporting.
- **README**: Wording von „Claude Code" auf MCP-generisch verallgemeinert. Frontier-Models wie ChatGPT, Gemini CLI, Cursor, Continue können das Tool genauso nutzen, weil sie alle MCP sprechen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)