### PR TITLE
Scope file viewing to opened repository

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -19,6 +19,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
+use projectmind_core::file_access;
 use projectmind_core::files::{self, MarkdownFile, MarkdownHit};
 use projectmind_core::git::{self, ChangedFile};
 use projectmind_core::heartbeat;
@@ -253,23 +254,20 @@ fn show_diagram(kind: String, state: State<'_, Arc<AppState>>) -> Result<String,
     }
 }
 
-/// Read an arbitrary file as UTF-8 text. Used by the file viewer for `view_file`
+const FILE_VIEW_LIMIT_BYTES: u64 = 10_000_000;
+
+/// Read a repo-scoped UTF-8 text file. Used by the file viewer for `view_file`
 /// intents (markdown, plain source, etc.). Capped at 10 MB to keep the view
-/// responsive — large binaries are not the target.
+/// responsive; paths outside the opened repository are rejected.
 #[tauri::command]
-fn read_file_text(path: String) -> Result<String, String> {
+fn read_file_text(path: String, state: State<'_, Arc<AppState>>) -> Result<String, String> {
+    let guard = state.repo.read();
+    let repo = guard
+        .as_ref()
+        .ok_or_else(|| "no repository open".to_string())?;
     let p = std::path::Path::new(&path);
-    if !p.is_absolute() {
-        return Err(format!("path must be absolute: {path}"));
-    }
-    let bytes = std::fs::read(p).map_err(|e| format!("read {path}: {e}"))?;
-    if bytes.len() > 10_000_000 {
-        return Err(format!(
-            "file too large ({} bytes; limit 10 MB)",
-            bytes.len()
-        ));
-    }
-    String::from_utf8(bytes).map_err(|e| format!("invalid UTF-8 in {path}: {e}"))
+    file_access::read_text_file_in_repo(&repo.root, p, FILE_VIEW_LIMIT_BYTES)
+        .map_err(|e| e.to_string())
 }
 
 /// Return the unified diff between two refs (or `ref` vs working tree). Used

--- a/crates/core/src/file_access.rs
+++ b/crates/core/src/file_access.rs
@@ -1,0 +1,206 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Repo-scoped file access helpers.
+
+use std::path::{Path, PathBuf};
+
+/// Errors returned when a file access request violates the repo boundary or
+/// cannot be served.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum FileAccessError {
+    /// The caller supplied a non-absolute path.
+    #[error("path must be absolute: {0}")]
+    PathNotAbsolute(PathBuf),
+
+    /// The repository root could not be canonicalized.
+    #[error("invalid repository root {path}: {source}")]
+    InvalidRepoRoot {
+        /// Repository root path.
+        path: PathBuf,
+        /// Underlying IO error.
+        source: std::io::Error,
+    },
+
+    /// The requested path could not be canonicalized.
+    #[error("invalid file path {path}: {source}")]
+    InvalidPath {
+        /// Requested file path.
+        path: PathBuf,
+        /// Underlying IO error.
+        source: std::io::Error,
+    },
+
+    /// The requested path resolves outside the opened repository.
+    #[error("access denied: {path} is outside repository {repo_root}")]
+    OutsideRepo {
+        /// Canonical requested path.
+        path: PathBuf,
+        /// Canonical repository root.
+        repo_root: PathBuf,
+    },
+
+    /// The path does not resolve to a regular file.
+    #[error("path is not a file: {0}")]
+    NotAFile(PathBuf),
+
+    /// IO failure while reading the file.
+    #[error("read {path}: {source}")]
+    Read {
+        /// Canonical requested path.
+        path: PathBuf,
+        /// Underlying IO error.
+        source: std::io::Error,
+    },
+
+    /// File exceeds the configured byte limit.
+    #[error("file too large ({actual} bytes; limit {limit} bytes)")]
+    FileTooLarge {
+        /// Actual file size in bytes.
+        actual: u64,
+        /// Configured byte limit.
+        limit: u64,
+    },
+
+    /// File bytes were not valid UTF-8.
+    #[error("invalid UTF-8 in {path}: {source}")]
+    InvalidUtf8 {
+        /// Canonical requested path.
+        path: PathBuf,
+        /// Underlying UTF-8 error.
+        source: std::string::FromUtf8Error,
+    },
+}
+
+/// Canonicalize `path` and verify that it points to a regular file within
+/// `repo_root`.
+pub fn canonical_file_in_repo(repo_root: &Path, path: &Path) -> Result<PathBuf, FileAccessError> {
+    if !path.is_absolute() {
+        return Err(FileAccessError::PathNotAbsolute(path.to_path_buf()));
+    }
+
+    let repo_root =
+        std::fs::canonicalize(repo_root).map_err(|source| FileAccessError::InvalidRepoRoot {
+            path: repo_root.to_path_buf(),
+            source,
+        })?;
+    let path = std::fs::canonicalize(path).map_err(|source| FileAccessError::InvalidPath {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    if !path.starts_with(&repo_root) {
+        return Err(FileAccessError::OutsideRepo { path, repo_root });
+    }
+    if !path.is_file() {
+        return Err(FileAccessError::NotAFile(path));
+    }
+    Ok(path)
+}
+
+/// Read a UTF-8 file within `repo_root`, rejecting files above `limit_bytes`.
+pub fn read_text_file_in_repo(
+    repo_root: &Path,
+    path: &Path,
+    limit_bytes: u64,
+) -> Result<String, FileAccessError> {
+    let path = canonical_file_in_repo(repo_root, path)?;
+    let metadata = std::fs::metadata(&path).map_err(|source| FileAccessError::Read {
+        path: path.clone(),
+        source,
+    })?;
+    if metadata.len() > limit_bytes {
+        return Err(FileAccessError::FileTooLarge {
+            actual: metadata.len(),
+            limit: limit_bytes,
+        });
+    }
+    let bytes = std::fs::read(&path).map_err(|source| FileAccessError::Read {
+        path: path.clone(),
+        source,
+    })?;
+    String::from_utf8(bytes).map_err(|source| FileAccessError::InvalidUtf8 { path, source })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tempdir(name: &str) -> TempDir {
+        TempDir::new(name)
+    }
+
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new(name: &str) -> Self {
+            let mut p = std::env::temp_dir();
+            p.push(format!(
+                "projectmind-file-access-{}-{}-{}",
+                std::process::id(),
+                name,
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+            ));
+            std::fs::create_dir_all(&p).unwrap();
+            Self(p)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn reads_text_file_inside_repo() {
+        let repo = tempdir("inside");
+        let file = repo.path().join("README.md");
+        std::fs::write(&file, "hello").unwrap();
+
+        let text = read_text_file_in_repo(repo.path(), &file, 100).unwrap();
+
+        assert_eq!(text, "hello");
+    }
+
+    #[test]
+    fn rejects_file_outside_repo() {
+        let repo = tempdir("repo");
+        let outside = tempdir("outside");
+        let file = outside.path().join("secret.txt");
+        std::fs::write(&file, "secret").unwrap();
+
+        let err = canonical_file_in_repo(repo.path(), &file).unwrap_err();
+
+        assert!(matches!(err, FileAccessError::OutsideRepo { .. }));
+    }
+
+    #[test]
+    fn rejects_non_absolute_path() {
+        let repo = tempdir("relative");
+
+        let err = canonical_file_in_repo(repo.path(), Path::new("README.md")).unwrap_err();
+
+        assert!(matches!(err, FileAccessError::PathNotAbsolute(_)));
+    }
+
+    #[test]
+    fn rejects_oversized_file() {
+        let repo = tempdir("large");
+        let file = repo.path().join("large.txt");
+        std::fs::write(&file, "hello").unwrap();
+
+        let err = read_text_file_in_repo(repo.path(), &file, 4).unwrap_err();
+
+        assert!(matches!(err, FileAccessError::FileTooLarge { .. }));
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -15,6 +15,7 @@
 pub mod cargo;
 pub mod diagram;
 pub mod engine;
+pub mod file_access;
 pub mod files;
 pub mod git;
 pub mod heartbeat;

--- a/crates/mcp-server/src/tools.rs
+++ b/crates/mcp-server/src/tools.rs
@@ -6,6 +6,7 @@
 
 use std::path::PathBuf;
 
+use projectmind_core::file_access;
 use projectmind_core::state::{self, UiState, ViewIntent};
 use projectmind_core::walkthrough::{self as wt, Walkthrough, WalkthroughStep};
 use projectmind_core::{diagram, git, html};
@@ -347,7 +348,7 @@ pub(crate) async fn call(state: &Mutex<ServerState>, params: Value) -> DispatchR
         "list_html_snippets" => list_html_snippets(state).await,
         "view_class" => view_class(state, parsed.arguments).await,
         "view_diff" => view_diff(parsed.arguments),
-        "view_file" => view_file(parsed.arguments),
+        "view_file" => view_file(state, parsed.arguments).await,
         "view_diagram" => view_diagram(parsed.arguments),
         "walkthrough_start" => walkthrough_start(parsed.arguments),
         "walkthrough_append" => walkthrough_append(parsed.arguments),
@@ -779,7 +780,7 @@ struct ViewFileArgs {
     anchor: Option<String>,
 }
 
-fn view_file(args: Value) -> DispatchResult {
+async fn view_file(server_state: &Mutex<ServerState>, args: Value) -> DispatchResult {
     let args: ViewFileArgs = serde_json::from_value(args)
         .map_err(|e| DispatchError::invalid_params(format!("view_file: {e}")))?;
     let path = PathBuf::from(&args.path);
@@ -790,9 +791,20 @@ fn view_file(args: Value) -> DispatchResult {
         )));
     }
     let prev = state::read().ok().flatten().unwrap_or_default();
+    let repo_root = {
+        let server_state = server_state.lock().await;
+        server_state
+            .repo
+            .as_ref()
+            .map(|repo| repo.root.clone())
+            .or_else(|| prev.repo_root.clone())
+            .ok_or_else(|| DispatchError::invalid_params("view_file: no repository open"))?
+    };
+    let path = file_access::canonical_file_in_repo(&repo_root, &path)
+        .map_err(|e| DispatchError::invalid_params(format!("view_file: {e}")))?;
     let anchor = args.anchor.clone();
     publish_state(UiState {
-        repo_root: prev.repo_root,
+        repo_root: Some(repo_root),
         view: ViewIntent::File {
             path: path.clone(),
             anchor: anchor.clone(),

--- a/crates/mcp-server/tests/protocol.rs
+++ b/crates/mcp-server/tests/protocol.rs
@@ -221,6 +221,35 @@ fn show_diagram_bean_graph_returns_mermaid() {
     assert!(mermaid.starts_with("flowchart LR\n"));
 }
 
+#[test]
+fn view_file_rejects_paths_outside_open_repo() {
+    let tmp = TempRepo::create_with_java_class();
+    let outside = TempRepo::create_with_text_file("secret.txt", "secret");
+    let mut s = Server::spawn();
+    let repo_path = tmp.root.to_string_lossy().into_owned();
+    s.call(&format!(
+        r#"{{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{{"name":"open_repo","arguments":{{"path":"{repo_path}"}}}}}}"#
+    ));
+
+    let outside_path = outside
+        .root
+        .join("secret.txt")
+        .to_string_lossy()
+        .into_owned();
+    let resp = s.call(&format!(
+        r#"{{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{{"name":"view_file","arguments":{{"path":"{outside_path}"}}}}}}"#
+    ));
+
+    assert_eq!(resp["error"]["code"], -32602);
+    assert!(
+        resp["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("outside repository"),
+        "unexpected response: {resp}"
+    );
+}
+
 // ----- helpers -----
 
 struct TempRepo {
@@ -266,6 +295,14 @@ impl TempRepo {
             "package demo;\npublic class Sample {\n    private int counter;\n    public void doIt() {}\n}\n",
         )
         .unwrap();
+        Self { root }
+    }
+
+    fn create_with_text_file(name: &str, contents: &str) -> Self {
+        let root =
+            std::env::temp_dir().join(format!("projectmind-it-{}-{}", std::process::id(), uniq()));
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join(name), contents).unwrap();
         Self { root }
     }
 }

--- a/docs/reviews/architecture-review-2026-05-02.md
+++ b/docs/reviews/architecture-review-2026-05-02.md
@@ -1,0 +1,343 @@
+# Architecture Review: ProjectMind
+
+Date: 2026-05-02  
+Branch: `feature/architecture-review`
+
+## Executive Summary
+
+ProjectMind already has a sound high-level split:
+
+- `crates/plugin-api` defines the public extension surface.
+- `crates/core` owns repository discovery, parsing, diagrams, git helpers, files, HTML scanning, state and walkthrough primitives.
+- `crates/mcp-server` exposes the product to MCP clients over JSON-RPC.
+- `app/src-tauri` exposes the same product to the Svelte desktop UI.
+- `plugins/*` contain statically linked language/framework implementations.
+- `app/src` is a focused Svelte UI layer.
+
+The current architecture is workable for the Phase 1 MVP, but it is starting to show pressure at the application boundary. MCP and Tauri both know too much about plugin wiring, DTO shaping, command semantics and some security decisions. If Phase 2 adds dynamic plugins, annotation round-trips and more UI/MCP workflows without a shared application layer, the project will likely accumulate duplicated behavior and inconsistent contracts.
+
+## Current Shape
+
+```text
+Svelte UI
+  -> Tauri commands in app/src-tauri
+      -> projectmind-core
+          -> plugin-api traits
+          -> statically linked plugins
+
+MCP client
+  -> projectmind-mcp JSON-RPC tools
+      -> projectmind-core
+          -> plugin-api traits
+          -> statically linked plugins
+
+MCP <-> GUI coordination
+  -> cache/state JSON file
+  -> walkthrough body/feedback files
+  -> heartbeat file
+```
+
+This is a reasonable MVP architecture because the expensive logic is in Rust and the UI remains comparatively thin. The concern is that the two product entrypoints are not actually thin in the same way: they independently assemble plugin sets and independently translate core state into user-facing responses.
+
+## Strengths
+
+1. Clear workspace-level ownership.
+   The crates and plugins are easy to discover from `Cargo.toml`, and the repository layout matches the README architecture table.
+
+2. The plugin API is small and understandable.
+   `LanguagePlugin`, `FrameworkPlugin` and `VisualizerPlugin` are cohesive traits. The static metadata type also gives a clean base for diagnostics and future loading.
+
+3. The core engine is intentionally read-only.
+   Repository loading uses `canonicalize`, ignore-aware walking and in-memory `Repository` output. That matches the product promise.
+
+4. The MCP/GUI sync mechanism is pragmatic.
+   A small JSON state file plus sequence number is much simpler than prematurely introducing a local daemon or database.
+
+5. Tests exist at multiple useful layers.
+   There are parser tests, core tests and MCP protocol tests. That is a good foundation for refactoring without losing behavior.
+
+## Findings And Risks
+
+### 1. Plugin registration is duplicated across product entrypoints
+
+Evidence:
+
+- `crates/mcp-server/src/handler.rs` registers Java, Rust, Spring and Lombok in `ServerState::new`.
+- `app/src-tauri/src/lib.rs` repeats the same registration in `AppState::new`.
+
+Risk:
+
+Adding or reordering a plugin requires edits in multiple crates. This becomes fragile when dynamic loading arrives because MCP and GUI may end up with different plugin sets.
+
+Recommendation:
+
+Move Phase 1 plugin assembly behind one shared constructor, for example:
+
+```rust
+// crates/core/src/default_engine.rs or a new app/service crate
+pub fn default_engine() -> Engine {
+    let mut engine = Engine::new();
+    engine.register_language(Box::new(JavaPlugin::new()));
+    engine.register_language(Box::new(RustPlugin::new()));
+    engine.register_framework(Box::new(SpringPlugin::new()));
+    engine.register_framework(Box::new(LombokPlugin::new()));
+    engine
+}
+```
+
+Because `core` currently should not depend on `plugins/*`, the cleaner variant is a new crate such as `crates/runtime` or `crates/app-core` that depends on `core` and the bundled plugins. MCP and Tauri would depend on that crate.
+
+Priority: High.
+
+### 2. MCP and Tauri duplicate application use-cases and DTO shaping
+
+Evidence:
+
+- `list_classes`, `show_class`, `module_summary`, `show_diagram`, `list_changes_since` and `show_diff` exist independently in MCP tools and Tauri commands.
+- MCP responses are mostly `serde_json::Value` converted to text, while Tauri responses are typed structs.
+
+Risk:
+
+The same product operation can diverge across clients. For example, the UI `ClassEntry` includes `module`; MCP `list_classes` currently omits it. The UI supports module filtering; MCP only supports stereotype filtering. These differences may be deliberate, but there is no shared boundary that makes them explicit.
+
+Recommendation:
+
+Introduce an application service layer with typed request/response models:
+
+```text
+crates/app-core
+  - ProjectMindService
+  - OpenRepoRequest / RepoSummary
+  - ClassQuery / ClassEntry / ClassDetails
+  - ModuleSummary
+  - DiagramKind / DiagramOutput
+  - DiffRequest
+  - FileReadPolicy
+```
+
+Then:
+
+- Tauri commands call service methods and return typed DTOs.
+- MCP tools call the same service methods and only adapt output into MCP `content`.
+- Shared DTOs get serialization tests.
+
+Priority: High.
+
+### 3. `Engine::open_repo` combines discovery, walking, parsing and enrichment
+
+Evidence:
+
+- `Engine::open_repo` chooses Maven vs Cargo vs root mode.
+- `parse_root`, `parse_cargo_crates` and `parse_maven_modules` each build language indexes, walk files, attribute modules, parse files and enrich modules.
+
+Risk:
+
+The engine is still understandable, but it has three parallel parsing paths with repeated mechanics. Future layouts such as Gradle, npm workspaces, mixed repositories or user-configured roots will push more branching into one type.
+
+Recommendation:
+
+Split repository opening into a small pipeline:
+
+```text
+RepoDiscovery
+  -> Vec<DiscoveredModule>
+SourceIndex
+  -> Vec<SourceFile { path, module_id, language_id }>
+ParserPipeline
+  -> Repository
+FrameworkPipeline
+  -> Repository
+```
+
+Keep `Engine` as the orchestrator, but move layout-specific discovery and source indexing into focused components. This also makes it easier to test "mixed repo" behavior without invoking all parsers.
+
+Priority: Medium-high.
+
+### 4. Module detection is exclusive, but the roadmap points toward polyglot repos
+
+Evidence:
+
+The engine currently gives Maven priority over Cargo and treats the two as mutually exclusive. The comment says mixed Maven/Cargo monorepos are rare and Phase 1 stays simple.
+
+Risk:
+
+ProjectMind's target users are likely to point it at real monorepos. A Java backend plus Rust tooling, JS frontend or generated code is not unusual. Exclusive discovery means some files are invisible to the architecture model once a higher-priority layout is detected.
+
+Recommendation:
+
+Move toward "deepest containing manifest wins" across all known module detectors:
+
+- Run all module detectors.
+- Normalize discovered modules into a shared `DiscoveredModule`.
+- Attribute files to the deepest module whose root contains the file.
+- Fall back to a synthetic root module only for unattributed files.
+
+Priority: Medium.
+
+### 5. The file-read boundary is too broad for a read-only architecture browser
+
+Evidence:
+
+`read_file_text` accepts any absolute path and reads up to 10 MB. The MCP `view_file` command also accepts any absolute path and publishes it to the GUI state.
+
+Risk:
+
+The product is read-only, but not necessarily repo-scoped. A compromised or confused MCP client can ask the GUI to display arbitrary UTF-8 files outside the opened repository. Even if this is local-only, it weakens the stated security posture.
+
+Recommendation:
+
+Centralize file access in a repo-scoped service:
+
+- Resolve and canonicalize paths before reading.
+- Require `path.starts_with(repo.root)` unless an explicit future capability allows external docs.
+- Return a typed `AccessDenied` error.
+- Apply the same rule for Tauri `read_file_text`, MCP `view_file`, markdown browsing and HTML browsing.
+
+Priority: High.
+
+### 6. Shared state file is pragmatic but needs ownership semantics before multi-client use
+
+Evidence:
+
+The shared state file stores `repo_root`, `view` and `seq`. Both MCP and GUI write to it. The `seq` value is process-local with initialization from the existing file.
+
+Risk:
+
+Two clients can overwrite each other's intent, and there is no writer identity, timestamp or compare-and-swap style conflict check. This is acceptable for a single MCP client plus one GUI, but weak for multiple agents, multiple windows or long-running guided tours.
+
+Recommendation:
+
+Extend the schema while it is still version 1-compatible or before version 2:
+
+- `writer`: `mcp`, `gui`, or a process/session id.
+- `updated_at_ms`.
+- `repo_epoch` or `session_id` so stale view intents cannot apply to a newly opened repository.
+- Optional `intent_id` for walkthrough/view commands.
+
+Priority: Medium.
+
+### 7. Framework relations are computed ad hoc instead of owned by the parsed repository
+
+Evidence:
+
+Spring relations are recomputed by constructing a `SpringPlugin` in diagram, MCP and Tauri paths. The `Repository` itself stores modules/classes but not the graph edges produced by framework plugins.
+
+Risk:
+
+As more frameworks arrive, relation computation may scatter across diagrams, tools and UI commands. Cross-module graph behavior will also be harder to keep consistent.
+
+Recommendation:
+
+Promote relations to a first-class output of parsing/enrichment:
+
+```rust
+pub struct Repository {
+    pub root: PathBuf,
+    pub modules: BTreeMap<String, Module>,
+    pub relations: Vec<Relation>,
+}
+```
+
+Framework plugins can still compute module-local relations, but the engine should aggregate them once after enrichment. Diagrams and MCP tools should read the same graph.
+
+Priority: Medium.
+
+### 8. Documentation has drifted from the current implementation
+
+Evidence:
+
+`docs/plan/03-architecture.md` still describes `app/frontend`, Cytoscape/Monaco, a smaller plugin list and an initial MCP tool set. README is much closer to reality.
+
+Risk:
+
+Architecture docs will mislead contributors during Phase 2, especially around plugin loading and UI responsibilities.
+
+Recommendation:
+
+Keep `docs/plan/*` as historical design notes, but add a current architecture document:
+
+```text
+docs/architecture/current.md
+docs/architecture/runtime-boundaries.md
+docs/architecture/plugin-loading.md
+```
+
+The current document should explicitly mark planned vs implemented architecture.
+
+Priority: Medium.
+
+## Proposed Target Architecture
+
+```text
+app/src
+  Svelte UI only
+  calls typed Tauri commands
+
+app/src-tauri
+  thin command adapter
+  owns desktop-only concerns: dialogs, events, watcher, heartbeat
+  calls app-core service
+
+crates/mcp-server
+  thin MCP adapter
+  owns JSON-RPC and MCP content wrapping
+  calls app-core service
+
+crates/app-core or crates/runtime
+  default engine/plugin assembly
+  typed use-cases
+  DTOs shared by MCP and Tauri
+  repo-scoped file access policy
+  view intent validation
+
+crates/core
+  repository model
+  discovery/indexing/parsing/enrichment pipeline
+  git/files/html/state/walkthrough primitives if kept as infrastructure
+
+crates/plugin-api
+  stable extension contracts
+
+plugins/*
+  plugin implementations only
+```
+
+This keeps `core` free of bundled plugin dependencies while removing duplication from the product entrypoints.
+
+## Suggested Refactoring Sequence
+
+1. Add `crates/app-core` with no behavior changes.
+   Move shared DTOs and `default_engine()` there. Update MCP and Tauri to use it.
+
+2. Move duplicated read/query operations into `ProjectMindService`.
+   Start with `repo_info`, `list_classes`, `show_class`, `module_summary`, `show_diagram`, `show_diff`.
+
+3. Add repo-scoped file access.
+   Replace direct `std::fs::read_to_string` / `std::fs::read` calls in adapters with service calls.
+
+4. Aggregate relations into `Repository`.
+   Keep existing diagram output stable, but change its data source to `repo.relations`.
+
+5. Split discovery/indexing from `Engine::open_repo`.
+   Introduce `DiscoveredModule` and a source attribution pass.
+
+6. Update architecture docs.
+   Mark the old plan as historical and make the implemented runtime boundary explicit.
+
+## Branch Scope Recommendation
+
+For the current branch, keep this as a review/documentation branch. The next implementation branch should be narrow:
+
+```text
+feature/app-core-service
+```
+
+First milestone:
+
+- create `crates/app-core`
+- move default plugin registration there
+- move shared class/module DTOs there
+- update MCP and Tauri without changing behavior
+- add tests that MCP and Tauri-visible summaries are derived from the same service DTOs
+
+That reduces risk before deeper pipeline changes.


### PR DESCRIPTION
## Summary

- add a repo-scoped file access helper in projectmind-core
- enforce the opened repository boundary for Tauri read_file_text
- validate MCP view_file paths before publishing GUI state
- add architecture review notes and regression coverage for outside-repo view_file

## Tests

- cargo fmt --all -- --check
- cargo test -p projectmind-core file_access
- cargo test -p projectmind-mcp view_file_rejects_paths_outside_open_repo
- cargo check -p projectmind-mcp -p projectmind-app
- cargo test --workspace --all-targets