### PR TITLE
fix(classviewer): shift+wheel actually scales the source code

### DIFF
--- a/app/src/components/ClassViewer.svelte
+++ b/app/src/components/ClassViewer.svelte
@@ -141,7 +141,9 @@
     border-radius: var(--radius-md);
     padding: 12px 0;
     font-family: var(--mono);
-    font-size: 12.5px;
+    /* `em`, not `px`, so the .root `font-size: {zoom}em` actually scales
+       the source code on shift+wheel. 0.78em ≈ 12.5px at the 16px base. */
+    font-size: 0.78em;
     line-height: 1.55;
     margin: 0;
     overflow: auto;


### PR DESCRIPTION
ClassViewer hatte zwar Shift+Wheel-Hook, aber `.source` mit `font-size: 12.5px` (fix px) überschrieb das em-Scaling von `.root`. Source-Code blieb beim Zoom statisch.

→ `.source` auf `0.78em` umgestellt, damit das em-Scaling von .root durchschlägt. 0.78em × 16px = 12.5px (default) → kein visueller Default-Unterschied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)