### PR TITLE
feat(ci): add Auto-Release workflow with manual dispatch

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,183 @@
+name: Auto-Release
+
+# Manually-triggered, end-to-end release pipeline.
+#
+# What it does:
+# 1. Reads the current workspace version from Cargo.toml
+# 2. Bumps it (minor by default, major on demand)
+# 3. Updates every version reference across the repo (workspace,
+#    internal-dep specs, app/package.json, tauri.conf.json)
+# 4. Opens a "release/vX.Y.Z" PR with that bump
+# 5. Waits until the PR's required CI check is green, then squash-merges it
+# 6. Tags the merged commit as vX.Y.Z and pushes the tag
+# 7. Dispatches the existing release.yml at that tag ref so the binaries
+#    actually get built + published
+#
+# Trigger from the Actions tab → "Auto-Release" → Run workflow → pick
+# `bump: minor` (default) or `bump: major`. Patch bumps are handled by
+# normal commits to master, not by this workflow.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump'
+        required: true
+        default: 'minor'
+        type: choice
+        options:
+          - minor
+          - major
+
+# Default least-privilege; the bump job re-elevates to what it needs.
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Bump → PR → tag → dispatch
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          # Required so the rebase + push + tag-push at the end of the job
+          # use the same authenticated remote as gh CLI.
+          persist-credentials: true
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Compute new version
+        id: ver
+        run: |
+          set -euo pipefail
+          current=$(grep -m1 -E '^version = "' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          if [[ ! "$current" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Cannot parse current version: '$current'" >&2; exit 1
+          fi
+          IFS=. read -r maj min pat <<< "$current"
+          if [ "${{ inputs.bump }}" = "major" ]; then
+            new="$((maj+1)).0.0"
+          else
+            new="${maj}.$((min+1)).0"
+          fi
+          tag="v$new"
+          echo "current=$current"     >> "$GITHUB_OUTPUT"
+          echo "new=$new"             >> "$GITHUB_OUTPUT"
+          echo "tag=$tag"             >> "$GITHUB_OUTPUT"
+          echo "branch=release/$tag"  >> "$GITHUB_OUTPUT"
+          echo "::notice::Bumping ${current} → ${new} (tag ${tag})"
+
+      - name: Update version files
+        env:
+          CURRENT: ${{ steps.ver.outputs.current }}
+          NEW: ${{ steps.ver.outputs.new }}
+        run: |
+          set -euxo pipefail
+          # All `version = "X.Y.Z"` (TOML) and `"version": "X.Y.Z"` (JSON)
+          # references that exactly match the old version. We only touch
+          # files we know about — better to fail visibly than silently
+          # rewrite something unrelated.
+          sed -i "s/^version = \"$CURRENT\"$/version = \"$NEW\"/"            Cargo.toml
+          sed -i "s|version = \"$CURRENT\"|version = \"$NEW\"|g"             Cargo.toml
+          sed -i "s|version = \"$CURRENT\"|version = \"$NEW\"|g"             app/src-tauri/Cargo.toml
+          sed -i "s|version = \"$CURRENT\"|version = \"$NEW\"|g"             crates/mcp-server/Cargo.toml
+          sed -i "s|\"version\": \"$CURRENT\"|\"version\": \"$NEW\"|"        app/package.json
+          sed -i "s|\"version\": \"$CURRENT\"|\"version\": \"$NEW\"|"        app/src-tauri/tauri.conf.json
+          # Sanity check — leave a paper trail so a botched sed shows up.
+          remaining=$(grep -rn "$CURRENT" Cargo.toml app/package.json app/src-tauri/Cargo.toml app/src-tauri/tauri.conf.json crates/mcp-server/Cargo.toml || true)
+          if [ -n "$remaining" ]; then
+            echo "WARNING: still found old version after bump:"
+            echo "$remaining"
+          fi
+
+      - name: Open release PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW: ${{ steps.ver.outputs.new }}
+          TAG: ${{ steps.ver.outputs.tag }}
+          BRANCH: ${{ steps.ver.outputs.branch }}
+        run: |
+          set -euo pipefail
+          git checkout -b "$BRANCH"
+          git add -A
+          git commit -m "chore(release): bump version to ${NEW}"
+          git push -u origin "$BRANCH"
+          body=$(printf '%s\n\n%s\n\n%s\n' \
+            "Automated release bump to **${NEW}**." \
+            "This PR was opened by the *Auto-Release* workflow. As soon as the required CI check (\`Rust ubuntu-22.04\`) is green it will be squash-merged, the merge commit gets tagged as \`${TAG}\`, and \`release.yml\` is dispatched against that tag to build + publish the binaries." \
+            "If something goes wrong, close this PR and re-run the workflow.")
+          pr_url=$(gh pr create \
+            --title "chore(release): ${TAG}" \
+            --body  "$body" \
+            --base master --head "$BRANCH")
+          echo "pr_url=$pr_url"
+          pr_num=$(printf '%s' "$pr_url" | sed -E 's|.*/([0-9]+)$|\1|')
+          echo "pr=$pr_num" >> "$GITHUB_OUTPUT"
+          echo "::notice::Opened release PR #${pr_num} → ${pr_url}"
+
+      - name: Wait for PR CI to be green
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ steps.pr.outputs.pr }}
+        run: |
+          set -euo pipefail
+          deadline=$((SECONDS + 1800))   # 30 min budget
+          while [ $SECONDS -lt $deadline ]; do
+            sleep 30
+            check=$(gh pr view "$PR" --json statusCheckRollup --jq \
+              '[.statusCheckRollup[] | select(.name=="Rust ubuntu-22.04")] | first // {}')
+            status=$(printf '%s' "$check" | jq -r '.status // "MISSING"')
+            concl=$( printf '%s' "$check" | jq -r '.conclusion // "-"')
+            echo "[$(date -u +%H:%M:%S)] required-check status=$status conclusion=$concl"
+            if [ "$status" = "COMPLETED" ]; then
+              if [ "$concl" = "SUCCESS" ]; then
+                echo "::notice::CI green — proceeding to merge"
+                exit 0
+              fi
+              echo "::error::Required check failed: $concl"
+              exit 1
+            fi
+          done
+          echo "::error::Timed out waiting for CI"
+          exit 1
+
+      - name: Merge release PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ steps.pr.outputs.pr }}
+        run: |
+          gh pr merge "$PR" --squash --delete-branch
+
+      - name: Tag merged commit + push
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.ver.outputs.tag }}
+          NEW: ${{ steps.ver.outputs.new }}
+        run: |
+          set -euo pipefail
+          git fetch origin master
+          git checkout master
+          git pull --ff-only origin master
+          git tag -a "$TAG" -m "ProjectMind ${TAG}"
+          git push origin "$TAG"
+          echo "::notice::Tagged ${TAG} on $(git rev-parse --short HEAD)"
+
+      - name: Dispatch release.yml at the new tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.ver.outputs.tag }}
+        run: |
+          # GITHUB_TOKEN-pushed tags don't trigger downstream workflows by
+          # design. Dispatch release.yml ourselves at the tag ref so the
+          # binary build + GitHub Release publish actually run.
+          gh workflow run release.yml --ref "$TAG"
+          echo "::notice::Dispatched release.yml at ${TAG}; binaries will appear on the release within a few minutes."


### PR DESCRIPTION
Lets you cut a release with one click from the **Actions → Auto-Release → Run workflow** menu.

## What it does

Single workflow_dispatch entry point with a `bump` input (`minor` default, `major` opt-in):

1. Reads current version from `Cargo.toml`
2. Computes the new version (minor or major bump)
3. Updates every version reference in workspace + JS/Tauri manifests
4. Opens a `release/vX.Y.Z` PR
5. Waits up to 30 min for `Rust ubuntu-22.04` to go green
6. Squash-merges the PR
7. Tags the merge commit `vX.Y.Z` and pushes the tag
8. Dispatches `release.yml` at that tag ref so binaries get built + published

## Why the explicit dispatch at the end

GitHub-Actions `GITHUB_TOKEN`-pushed tags don't trigger downstream workflows by design. The final `gh workflow run release.yml --ref TAG` step is what actually fires the existing release-build matrix.

## Why no `patch` choice

Patch bumps come from normal feature/fix merges to master, not from this button. Keeping the input small avoids accidental patch-only releases.

## Test plan

- [x] CI on this PR is green
- [ ] After merge: trigger Auto-Release with `bump: minor` → confirm a release/v0.3.0 PR opens, gets merged, v0.3.0 tag appears, release.yml runs, GitHub Release shows up with the binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)