### PR TITLE
feat(release): build + publish Tauri desktop app bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,14 +6,19 @@ on:
       - 'v*.*.*'
   workflow_dispatch:
 
-# Default to read-only. The release-publish job re-elevates to
-# `contents: write` to upload assets — see below.
+# Default to read-only. The publish job re-elevates to `contents: write`
+# to upload assets — see below.
 permissions:
   contents: read
 
+# Two parallel matrices that publish into the same GitHub Release at the end:
+#  * `mcp` — the standalone MCP server binary, useful for any LLM CLI that
+#    just wants stdio JSON-RPC. Multiple OS/arch slices.
+#  * `app` — the Tauri desktop bundle (.dmg/.app on macOS, .deb/.AppImage on
+#    Linux, .msi/.exe on Windows). One slice per host platform.
 jobs:
-  build:
-    name: Build ${{ matrix.target }}
+  mcp:
+    name: MCP server / ${{ matrix.asset_suffix }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -23,15 +28,12 @@ jobs:
         include:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-            artifact_name: projectmind-mcp
             asset_suffix: linux-x86_64
           - os: macos-14
             target: aarch64-apple-darwin
-            artifact_name: projectmind-mcp
             asset_suffix: macos-arm64
           - os: macos-13
             target: x86_64-apple-darwin
-            artifact_name: projectmind-mcp
             asset_suffix: macos-x86_64
 
     steps:
@@ -46,23 +48,100 @@ jobs:
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Build release MCP binary
+        shell: bash
         run: ./scripts/ci.sh release-build ${{ matrix.target }}
 
       - name: Package
+        shell: bash
         run: ./scripts/ci.sh release-package ${{ matrix.target }} ${{ matrix.asset_suffix }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ${{ matrix.artifact_name }}-${{ matrix.asset_suffix }}
+          name: projectmind-mcp-${{ matrix.asset_suffix }}
           path: |
-            ${{ matrix.artifact_name }}-${{ matrix.asset_suffix }}.tar.gz
-            ${{ matrix.artifact_name }}-${{ matrix.asset_suffix }}.tar.gz.sha256
+            projectmind-mcp-${{ matrix.asset_suffix }}.tar.gz
+            projectmind-mcp-${{ matrix.asset_suffix }}.tar.gz.sha256
+          retention-days: 30
+
+  app:
+    name: Desktop app / ${{ matrix.asset_suffix }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # macOS universal binary covers both Apple Silicon and Intel in
+          # one bundle so we only need one Mac runner. The `extra_targets`
+          # hack tells rust-toolchain to add the second arch.
+          - os: macos-14
+            target: universal-apple-darwin
+            extra_targets: x86_64-apple-darwin
+            asset_suffix: macos-universal
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            asset_suffix: linux-x86_64
+          - os: windows-2022
+            target: x86_64-pc-windows-msvc
+            asset_suffix: windows-x86_64
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}${{ matrix.extra_targets && format(',{0}', matrix.extra_targets) || '' }}
+
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        with:
+          key: app-${{ matrix.asset_suffix }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+          cache: pnpm
+          cache-dependency-path: app/pnpm-lock.yaml
+
+      - name: Install Linux Tauri build deps
+        if: runner.os == 'Linux'
+        shell: bash
+        run: ./scripts/ci.sh install-deps
+
+      - name: Install JS deps
+        shell: bash
+        working-directory: app
+        run: pnpm install --frozen-lockfile
+
+      - name: Build app bundle
+        shell: bash
+        run: ./scripts/ci.sh app-build ${{ matrix.target }}
+
+      - name: Package
+        shell: bash
+        run: ./scripts/ci.sh app-package ${{ matrix.target }} ${{ matrix.asset_suffix }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: projectmind-app-${{ matrix.asset_suffix }}
+          path: |
+            projectmind-app-${{ matrix.asset_suffix }}.tar.gz
+            projectmind-app-${{ matrix.asset_suffix }}.tar.gz.sha256
           retention-days: 30
 
   release:
     name: Publish GitHub release
-    needs: build
+    needs: [mcp, app]
     runs-on: ubuntu-22.04
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -31,9 +31,29 @@ Commands:
   release-build [<target>]    cargo build --release --bin projectmind-mcp [--target <target>]
   release-smoke               release-build + stdio JSON-RPC ping against the binary
   release-package <target> <suffix>
-                              tar.gz + sha256 packaging for the release workflow
+                              tar.gz + sha256 packaging for the MCP server binary
+  app-build [<target>]        Build the Tauri desktop app bundle for the host
+                              platform (.app/.dmg on macOS, .deb/.AppImage on
+                              Linux, .msi/.exe on Windows). Optional Rust
+                              target triple for cross-arch builds (e.g.
+                              universal-apple-darwin).
+  app-package <target> <suffix>
+                              Collect every Tauri bundle artefact under
+                              target/<target>/release/bundle into
+                              projectmind-app-<suffix>.tar.gz + .sha256.
   all                         check + test
 EOF
+}
+
+# Cross-platform sha256 helper. macOS has shasum, Linux has sha256sum,
+# Windows runners under Git Bash have either depending on the runner image.
+sha256() {
+    local file="$1"
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$file"
+    else
+        shasum -a 256 "$file"
+    fi
 }
 
 cmd_check() {
@@ -115,8 +135,68 @@ cmd_release_package() {
     tar czf "$archive" \
         -C "$(dirname "$bin_path")" "$(basename "$bin_path")" \
         -C "$ROOT_DIR" LICENSE README.md
-    shasum -a 256 "$archive" > "$archive.sha256"
+    sha256 "$archive" > "$archive.sha256"
     echo "release-package: $archive ($(wc -c <"$archive") bytes)"
+}
+
+cmd_app_build() {
+    local target="${1:-}"
+    cd "$ROOT_DIR/app"
+    if [[ ! -d node_modules ]]; then
+        echo "app-build: installing js deps (first run)"
+        pnpm install --frozen-lockfile
+    fi
+    if [[ -n "$target" ]]; then
+        echo "app-build: tauri build --target $target"
+        pnpm tauri build --target "$target"
+    else
+        echo "app-build: tauri build (host target)"
+        pnpm tauri build
+    fi
+    cd "$ROOT_DIR"
+}
+
+cmd_app_package() {
+    local target="${1:?target triple required, e.g. aarch64-apple-darwin}"
+    local suffix="${2:?asset suffix required, e.g. macos-arm64}"
+    local archive="projectmind-app-${suffix}.tar.gz"
+    local bundle_dir="target/${target}/release/bundle"
+
+    if [[ ! -d "$bundle_dir" ]]; then
+        echo "app-package: missing $bundle_dir — run app-build first" >&2
+        exit 1
+    fi
+
+    # Tauri scatters bundle artefacts across format-specific subdirs
+    # (bundle/dmg/, bundle/macos/, bundle/deb/, bundle/appimage/, bundle/msi/,
+    # bundle/nsis/). Pick whatever distributable formats actually got produced
+    # and pack them plus LICENSE + README into one archive — keeps the workflow
+    # simple: ONE artefact per target, asset_suffix telling Mac/Linux/Win apart.
+    local bundles=()
+    while IFS= read -r f; do
+        bundles+=("$f")
+    done < <(find "$bundle_dir" -type f \
+        \( -name "*.dmg" -o -name "*.app.tar.gz" -o -name "*.deb" \
+           -o -name "*.AppImage" -o -name "*.msi" -o -name "*.exe" \) \
+        2>/dev/null | sort)
+
+    if [[ ${#bundles[@]} -eq 0 ]]; then
+        echo "app-package: no bundle artefacts found under $bundle_dir" >&2
+        find "$bundle_dir" -maxdepth 3 -type f >&2 || true
+        exit 1
+    fi
+
+    # `tar -C <dir> file` requires file as a relative path inside <dir>.
+    # Build a flat archive: every bundle artefact at the archive root.
+    local args=()
+    for f in "${bundles[@]}"; do
+        args+=( -C "$(dirname "$f")" "$(basename "$f")" )
+    done
+    tar czf "$archive" "${args[@]}" -C "$ROOT_DIR" LICENSE README.md
+    sha256 "$archive" > "$archive.sha256"
+    local size_h
+    size_h="$(du -h "$archive" | cut -f1)"
+    echo "app-package: $archive ($size_h, ${#bundles[@]} bundle file(s))"
 }
 
 case "${1:-}" in
@@ -126,6 +206,8 @@ case "${1:-}" in
     release-build)   shift; cmd_release_build "$@" ;;
     release-smoke)   shift; cmd_release_smoke "$@" ;;
     release-package) shift; cmd_release_package "$@" ;;
+    app-build)       shift; cmd_app_build "$@" ;;
+    app-package)     shift; cmd_app_package "$@" ;;
     all)             cmd_check; cmd_test ;;
     -h|--help|help|"") usage ;;
     *) echo "unknown command: $1" >&2; usage; exit 2 ;;


### PR DESCRIPTION
Mittel. Erweitert die Release-Pipeline um Tauri-App-Bundles (.dmg / .deb / .AppImage / .msi / .app), so dass der README-Claim „Install the desktop app + MCP server" tatsächlich Substanz hat.

## Was neu ist

- `release.yml` bekommt einen parallelen **`app`-Job** neben dem bestehenden `mcp`-Job.
- Pro Tag-Push / `workflow_dispatch` werden jetzt **6 Assets** publishet:
  - `projectmind-mcp-{linux-x86_64,macos-arm64,macos-x86_64}.tar.gz`
  - `projectmind-app-{linux-x86_64,macos-universal,windows-x86_64}.tar.gz`
- Jeder App-Bundle-Tarball enthält die jeweiligen Tauri-Distributables für die Plattform (auf macOS .dmg + .app.tar.gz, Linux .deb + .AppImage, Windows .msi + .exe) plus LICENSE + README.
- `scripts/ci.sh` lernt `app-build` und `app-package`, plus eine plattform-portable `sha256`-Helfer (`sha256sum` bevorzugt, sonst `shasum -a 256`).

## Test plan

- [ ] CI grün auf diesem PR
- [ ] Nach Merge + Tag (oder via Auto-Release): GitHub-Release zeigt 6 Assets statt 3
- [ ] Folge-PR: `scripts/install.sh` aus den 21 lokalen Commits portieren — die Asset-Namen passen schon

🤖 Generated with [Claude Code](https://claude.com/claude-code)