### PR TITLE
feat(drawio): render .drawio files via embedded diagrams.net iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **draw.io viewer** (`app/src/components/DrawIoView.svelte`) — `.drawio`
+  files open in an embedded `diagrams.net` iframe via the viewer's
+  `proto=json` channel. The Svelte component reads the file content via
+  `read_file_text`, the iframe announces `init` over `postMessage`, and
+  the host responds with `{action: "load", xml}`. Wired into App.svelte
+  next to the existing PDF / image / Markdown viewers, lazy-loaded so
+  non-drawio sessions don't pay for the iframe scaffolding. The same
+  shift+wheel zoom helper as the other viewers makes the diagram easy
+  to read on Hi-DPI displays.
+
 ## [0.2.0] — 2026-05-01
 
 First release after the rebrand from `plaintext-ide` to **ProjectMind**

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ See [`docs/plan/`](docs/plan/) for the full design notes:
 ## Roadmap
 
 - **Phase 1 (done):** MCP server with Java + Spring + Lombok plugins, Rust plugin, package tree, bean graph, folder map, diff view, Markdown + HTML browsers, walkthrough mode, core MCP tools, Tauri shell with bidirectional MCP sync.
-- **Phase 2 (in progress):** Annotation round-trip, draw.io embed, Confluence MCP bridge, dynamic plugin loading from `./plugins/`.
+- **Phase 2 (in progress):** Annotation round-trip, ~~draw.io embed~~ (`.drawio` files render via the embedded diagrams.net viewer), Confluence MCP bridge, dynamic plugin loading from `./plugins/`.
 - **Phase 3:** Plugin marketplace, more languages, JSF / PrimeFaces preview, C4 diagram generator.
 
 ## Contributing

--- a/app/src/App.svelte
+++ b/app/src/App.svelte
@@ -54,6 +54,8 @@
     loadComponent('DiagramView', () => import('./components/DiagramView.svelte'));
   const lazyFileView = () =>
     loadComponent('FileView', () => import('./components/FileView.svelte'));
+  const lazyDrawIoView = () =>
+    loadComponent('DrawIoView', () => import('./components/DrawIoView.svelte'));
   const lazyHtmlIndex = () =>
     loadComponent('HtmlIndex', () => import('./components/HtmlIndex.svelte'));
   const lazyMarkdownIndex = () =>
@@ -883,6 +885,10 @@
             <PdfView path={$fileView.path} />
           {:else if $viewMode === 'image' && $fileView}
             <ImageView path={$fileView.path} />
+          {:else if $viewMode === 'file' && $fileView && /\.drawio$/i.test($fileView.path ?? '')}
+            {#await lazyDrawIoView() then mod}
+              <svelte:component this={mod.default} path={$fileView.path} />
+            {/await}
           {:else if $viewMode === 'file' && $fileView}
             {#await lazyFileView() then mod}
               <svelte:component

--- a/app/src/components/DrawIoView.svelte
+++ b/app/src/components/DrawIoView.svelte
@@ -1,0 +1,157 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { readFileText } from '../lib/api';
+  import { createShiftWheelZoom } from '../lib/shiftWheelZoom';
+
+  export let path: string;
+
+  // diagrams.net embed protocol — `proto=json` lets us postMessage the XML
+  // payload after the iframe loads, so we don't have to encode it into the
+  // URL (which has a hard size limit on every browser).
+  const EMBED_URL =
+    'https://embed.diagrams.net/?embed=1&ui=atlas&proto=json&splash=0&toolbar=0&libraries=0&dark=auto';
+
+  let frame: HTMLIFrameElement;
+  let xml = '';
+  let loading = false;
+  let error: string | null = null;
+  let initialised = false;
+
+  const { zoom, action: zoomAction } = createShiftWheelZoom(
+    'projectmind.drawio.zoom',
+  );
+
+  $: void load(path);
+
+  async function load(p: string) {
+    if (!p) return;
+    loading = true;
+    error = null;
+    initialised = false;
+    try {
+      xml = await readFileText(p);
+    } catch (e) {
+      error = String(e);
+      xml = '';
+    } finally {
+      loading = false;
+    }
+  }
+
+  function onMessage(ev: MessageEvent) {
+    if (ev.source !== frame?.contentWindow) return;
+    let data: { event?: string };
+    try {
+      data = typeof ev.data === 'string' ? JSON.parse(ev.data) : ev.data;
+    } catch {
+      return;
+    }
+    if (data?.event === 'init' && !initialised && xml) {
+      initialised = true;
+      frame.contentWindow?.postMessage(
+        JSON.stringify({ action: 'load', xml, autosave: 0 }),
+        '*',
+      );
+    }
+  }
+
+  // Once xml lands AND the iframe is ready, we dispatch the load action.
+  // The iframe announces "init" via postMessage; we react to that above.
+  $: if (xml && frame && !initialised) {
+    // Trigger a no-op postMessage so the iframe's `init` re-fires if it's
+    // already past that point. Cheap and safe.
+    try {
+      frame.contentWindow?.postMessage(
+        JSON.stringify({ action: 'status' }),
+        '*',
+      );
+    } catch {
+      // ignore
+    }
+  }
+
+  onMount(() => window.addEventListener('message', onMessage));
+  onDestroy(() => window.removeEventListener('message', onMessage));
+</script>
+
+<section class="root" use:zoomAction style="font-size: {$zoom}em;">
+  <header class="bar">
+    <span class="kind">drawio</span>
+    <span class="path">{path}</span>
+  </header>
+  <div class="body">
+    {#if loading}
+      <div class="empty">Loading…</div>
+    {:else if error}
+      <div class="error">⚠ {error}</div>
+    {:else}
+      <iframe
+        bind:this={frame}
+        class="frame"
+        title="draw.io diagram"
+        src={EMBED_URL}
+        allow="clipboard-read; clipboard-write"
+      ></iframe>
+    {/if}
+  </div>
+</section>
+
+<style>
+  .root {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+  }
+  .bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 16px;
+    background: var(--bg-1);
+    border-bottom: 1px solid var(--bg-3);
+    flex-shrink: 0;
+  }
+  .kind {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 2px 6px;
+    background: var(--bg-2);
+    border-radius: 3px;
+    color: var(--fg-2);
+  }
+  .path {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--fg-1);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .body {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    overflow: hidden;
+  }
+  .frame {
+    flex: 1;
+    width: 100%;
+    height: 100%;
+    border: 0;
+    background: var(--bg-0);
+  }
+  .empty,
+  .error {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--fg-2);
+    font-size: 13px;
+  }
+  .error {
+    color: var(--error);
+  }
+</style>


### PR DESCRIPTION
Closes part of the Phase-2 roadmap (\`draw.io embed\`).

## What's new
- New \`DrawIoView.svelte\` component that talks the diagrams.net \`embed=1&proto=json\` protocol — reads the \`.drawio\` file content, hands it to the iframe via \`postMessage\`.
- App.svelte routes \`.drawio\` paths to the new viewer instead of the plain-text fallback in FileView.
- Lazy-loaded; reuses \`createShiftWheelZoom\` for zoom parity with other viewers.

## Test plan
- [x] \`svelte-check\` clean
- [x] \`pnpm build\` succeeds
- [ ] CI green on this PR
- [ ] After merge: open any \`.drawio\` file via Claude Code (\`view_file\` tool) and confirm the diagram renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)