### PR TITLE
chore(release): bump version to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,75 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-05-02
+
+The first release that bundles the Phase-1 UI work that had been sitting
+on an unmerged local branch — folder maps, drag-and-drop, walkthrough
+sync, lazy-load perf — plus the Phase-2 draw.io embed and the multi-
+language i18n that went in via Codex.
+
 ### Added
 
+- **LAN browser host** (`crates/browser-host/`) — optional
+  `open_browser_repo` / `browser_status` / `stop_browser` MCP tools spin
+  up a token-protected HTTP server that serves the SPA from any LAN-
+  reachable client. Self-contained crate; not wired into the desktop
+  shell.
+- **Folder-map diagram** — third diagram kind alongside bean-graph and
+  package-tree, with hierarchy / solar / top-down layouts.
+- **PDF + image files in the module sidebar** — module sidebar +
+  class-list aggregate non-source files; click jumps straight to a
+  PDF viewer with shift+wheel zoom + pan, or an image viewer.
+- **Walkthrough sync** — bidirectional MCP↔GUI sync of walkthrough
+  cursor, per-view zoom, and code-link interception inside the tour.
+- **Plugin-contributed diagram registry** — the Diagrams tab now lists
+  whatever the active framework / language plugins contributed.
+- **Drag-and-drop** — drop any file in the Tauri shell to open its
+  parent directory as a repo, with the file already selected.
+- **Files tab** absorbs the Markdown + HTML browsers — no more separate
+  "Classes" wording when a repo has no parsed classes.
 - **draw.io viewer** (`app/src/components/DrawIoView.svelte`) — `.drawio`
   files open in an embedded `diagrams.net` iframe via the viewer's
-  `proto=json` channel. The Svelte component reads the file content via
-  `read_file_text`, the iframe announces `init` over `postMessage`, and
-  the host responds with `{action: "load", xml}`. Wired into App.svelte
-  next to the existing PDF / image / Markdown viewers, lazy-loaded so
-  non-drawio sessions don't pay for the iframe scaffolding. The same
-  shift+wheel zoom helper as the other viewers makes the diagram easy
-  to read on Hi-DPI displays.
+  `proto=json` channel. Lazy-loaded next to the PDF / image / Markdown
+  viewers; reuses `createShiftWheelZoom` for zoom parity.
+- **5-language i18n** — DE / EN / FR / IT / ES via Codex's
+  `app/src/lib/i18n.ts`, with a header-level language toggle.
+- **Tauri desktop bundles in the release** — Linux x86_64, macOS
+  universal, and Windows x86_64 `.dmg / .deb / .AppImage / .msi`
+  alongside the MCP server tarballs.
+- **Cross-platform install scripts** — `scripts/install.sh` (POSIX) and
+  `scripts/install.ps1` (Windows) pick the right pre-built bundle.
+
+### Changed
+
+- **Markdown index** gets index zoom, TOC arrow-navigation, macOS
+  shift-wheel axis-swap fix.
+- **Shift+wheel zoom** consolidated into one helper
+  (`app/src/lib/shiftWheelZoom.ts`) and applied to every viewer
+  (FileView / ClassViewer / DiffView / HtmlIndex / MarkdownIndex /
+  WalkthroughView / DrawIoView).
+- **Mermaid + marked** lazy-loaded as their own chunks via Vite
+  `manualChunks` — the welcome screen + Files tab no longer pay the
+  Mermaid tax.
+
+### Fixed
+
+- **PDF view** shift+wheel zoom now actually fires (an invisible
+  wheel-catcher overlay sits above the rendered PDF so wheel events
+  don't reach the canvas first).
+- **Tour** code-links no longer leave the tour pane; PDF pan inside
+  the tour scroller respects the parent zoom.
+- **Module-files store** gets re-fetched when the modules list
+  populates after `open_repo`, and aggregates across every module
+  when the filter is null.
+- **`view_file`** scoped to the currently-open repo
+  (`file_access::canonical_file_in_repo`) — matches the security
+  fix from #22 even after the cherry-picked code reverted it.
+
+### Roadmap
+
+- Phase 2 progress: draw.io embed shipped; annotation round-trip,
+  Confluence MCP bridge, and dynamic plugin loading still open.
 
 ## [0.2.0] — 2026-05-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-app"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "notify",
  "parking_lot",
@@ -3132,7 +3132,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-browser-host"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "open",
@@ -3149,7 +3149,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3168,7 +3168,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-framework-lombok"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "projectmind-plugin-api",
  "serde_json",
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-framework-spring"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "projectmind-plugin-api",
  "tracing",
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-lang-java"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "projectmind-plugin-api",
  "tracing",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-lang-rust"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "projectmind-plugin-api",
  "tracing",
@@ -3204,7 +3204,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-mcp"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-plugin-api"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/Plaintext-Gmbh/projectmind"
@@ -49,8 +49,8 @@ struct_field_names = "allow"
 ignored_unit_patterns = "allow"
 
 [workspace.dependencies]
-projectmind-plugin-api = { path = "crates/plugin-api", version = "0.2.0" }
-projectmind-core       = { path = "crates/core",       version = "0.2.0" }
+projectmind-plugin-api = { path = "crates/plugin-api", version = "0.3.0" }
+projectmind-core       = { path = "crates/core",       version = "0.3.0" }
 
 # General
 anyhow      = "1.0"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "projectmind-app",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -21,10 +21,10 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 projectmind-plugin-api = { workspace = true }
 projectmind-core       = { workspace = true }
-projectmind-lang-java  = { path = "../../plugins/lang-java", version = "0.2.0" }
-projectmind-lang-rust  = { path = "../../plugins/lang-rust", version = "0.2.0" }
-projectmind-framework-spring = { path = "../../plugins/framework-spring", version = "0.2.0" }
-projectmind-framework-lombok = { path = "../../plugins/framework-lombok", version = "0.2.0" }
+projectmind-lang-java  = { path = "../../plugins/lang-java", version = "0.3.0" }
+projectmind-lang-rust  = { path = "../../plugins/lang-rust", version = "0.3.0" }
+projectmind-framework-spring = { path = "../../plugins/framework-spring", version = "0.3.0" }
+projectmind-framework-lombok = { path = "../../plugins/framework-lombok", version = "0.3.0" }
 
 tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-dialog = "2"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "ProjectMind",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "identifier": "ch.plaintext.projectmind",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/crates/browser-host/Cargo.toml
+++ b/crates/browser-host/Cargo.toml
@@ -13,10 +13,10 @@ workspace = true
 
 [dependencies]
 projectmind-core = { workspace = true }
-projectmind-lang-java = { path = "../../plugins/lang-java", version = "0.2.0" }
-projectmind-lang-rust = { path = "../../plugins/lang-rust", version = "0.2.0" }
-projectmind-framework-spring = { path = "../../plugins/framework-spring", version = "0.2.0" }
-projectmind-framework-lombok = { path = "../../plugins/framework-lombok", version = "0.2.0" }
+projectmind-lang-java = { path = "../../plugins/lang-java", version = "0.3.0" }
+projectmind-lang-rust = { path = "../../plugins/lang-rust", version = "0.3.0" }
+projectmind-framework-spring = { path = "../../plugins/framework-spring", version = "0.3.0" }
+projectmind-framework-lombok = { path = "../../plugins/framework-lombok", version = "0.3.0" }
 
 anyhow = { workspace = true }
 rand = "0.8"

--- a/crates/mcp-server/Cargo.toml
+++ b/crates/mcp-server/Cargo.toml
@@ -18,13 +18,13 @@ workspace = true
 [dependencies]
 projectmind-plugin-api = { workspace = true }
 projectmind-core       = { workspace = true }
-projectmind-browser-host = { path = "../browser-host", version = "0.2.0" }
+projectmind-browser-host = { path = "../browser-host", version = "0.3.0" }
 
 # Local plugins linked statically for Phase 1
-projectmind-lang-java         = { path = "../../plugins/lang-java", version = "0.2.0" }
-projectmind-lang-rust         = { path = "../../plugins/lang-rust", version = "0.2.0" }
-projectmind-framework-spring  = { path = "../../plugins/framework-spring", version = "0.2.0" }
-projectmind-framework-lombok  = { path = "../../plugins/framework-lombok", version = "0.2.0" }
+projectmind-lang-java         = { path = "../../plugins/lang-java", version = "0.3.0" }
+projectmind-lang-rust         = { path = "../../plugins/lang-rust", version = "0.3.0" }
+projectmind-framework-spring  = { path = "../../plugins/framework-spring", version = "0.3.0" }
+projectmind-framework-lombok  = { path = "../../plugins/framework-lombok", version = "0.3.0" }
 
 anyhow      = { workspace = true }
 clap        = { workspace = true }


### PR DESCRIPTION
Manuelle Bump-PR weil das Auto-Release-Workflow am Org-Setting "Allow GitHub Actions to create and approve pull requests" hängt (kann ich ohne admin:org-Scope nicht setzen). Sobald das Org-Setting an ist, läuft das Auto-Release-Workflow künftig durch.

CHANGELOG kriegt einen vollen 0.3.0-Eintrag — Phase-1-Sweep aus #48, draw.io-Embed aus #49, Codex' i18n, Tauri-Bundles, plus Fixes.