### PR TITLE
fix(release): restore pnpm-based release.yml after #48 cherry-pick

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,14 +6,22 @@ on:
       - 'v*.*.*'
   workflow_dispatch:
 
-# Two parallel build matrices: the standalone MCP server binary (small, useful
-# in isolation for LLM CLIs that just want stdio JSON-RPC) and the Tauri
-# desktop app (a full bundle: .dmg / .deb+.AppImage / .msi). Both publish
-# their artefacts to the same GitHub Release at the end.
+# Default to read-only. The publish job re-elevates to `contents: write`
+# to upload assets — see below.
+permissions:
+  contents: read
+
+# Two parallel matrices that publish into the same GitHub Release at the end:
+#  * `mcp` — the standalone MCP server binary, useful for any LLM CLI that
+#    just wants stdio JSON-RPC. Multiple OS/arch slices.
+#  * `app` — the Tauri desktop bundle (.dmg/.app on macOS, .deb/.AppImage on
+#    Linux, .msi/.exe on Windows). One slice per host platform.
 jobs:
   mcp:
     name: MCP server / ${{ matrix.asset_suffix }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -32,14 +40,15 @@ jobs:
             asset_suffix: windows-x86_64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Build release MCP binary
         shell: bash
@@ -50,7 +59,7 @@ jobs:
         run: ./scripts/ci.sh release-package ${{ matrix.target }} ${{ matrix.asset_suffix }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: projectmind-mcp-${{ matrix.asset_suffix }}
           path: |
@@ -61,12 +70,15 @@ jobs:
   app:
     name: Desktop app / ${{ matrix.asset_suffix }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
         include:
           # macOS universal binary covers both Apple Silicon and Intel in
-          # one bundle so we only need one Mac runner.
+          # one bundle so we only need one Mac runner. The `extra_targets`
+          # hack tells rust-toolchain to add the second arch.
           - os: macos-14
             target: universal-apple-darwin
             extra_targets: x86_64-apple-darwin
@@ -79,33 +91,39 @@ jobs:
             asset_suffix: windows-x86_64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}${{ matrix.extra_targets && format(',{0}', matrix.extra_targets) || '' }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           key: app-${{ matrix.asset_suffix }}
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        with:
+          version: 9
+
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
-          cache: npm
-          cache-dependency-path: app/package-lock.json
+          cache: pnpm
+          cache-dependency-path: app/pnpm-lock.yaml
 
       - name: Install Linux Tauri build deps
         if: runner.os == 'Linux'
         shell: bash
         run: ./scripts/ci.sh install-deps
 
-      - name: Install npm deps
+      - name: Install JS deps
         shell: bash
         working-directory: app
-        run: npm ci || npm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build app bundle
         shell: bash
@@ -116,7 +134,7 @@ jobs:
         run: ./scripts/ci.sh app-package ${{ matrix.target }} ${{ matrix.asset_suffix }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: projectmind-app-${{ matrix.asset_suffix }}
           path: |
@@ -132,11 +150,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           files: |
             artifacts/**/*.tar.gz


### PR DESCRIPTION
Schnellfix: #48 hat `release.yml` mit der alten npm-Version überschrieben. v0.3.0-Release-Run scheitert deshalb auf allen 3 Desktop-App-Jobs.

Vor dem v0.4.0-Release oder einem Re-Tag von v0.3.0 muss das durch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)