### PR TITLE
fix(install): tolerate missing desktop-app archive (404 → graceful skip)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -62,6 +62,19 @@ try {
         Invoke-WebRequest -UseBasicParsing -Uri "$DownloadBase/$asset" -OutFile (Join-Path $Tmp $asset)
     }
 
+    # Soft variant: returns $true on success, $false on 404/transport error
+    # without raising. Used for the desktop app archive, which is allowed to
+    # be missing on releases that ship MCP-only.
+    function Download-Optional($asset) {
+        Info "downloading $asset"
+        try {
+            Invoke-WebRequest -UseBasicParsing -Uri "$DownloadBase/$asset" -OutFile (Join-Path $Tmp $asset) -ErrorAction Stop
+            return $true
+        } catch {
+            return $false
+        }
+    }
+
     # ---- MCP server ------------------------------------------------------
     if ($env:PM_NO_MCP -ne '1') {
         $McpArchive = "projectmind-mcp-$McpSuffix.tar.gz"
@@ -86,7 +99,16 @@ try {
     # ---- Desktop app -----------------------------------------------------
     if ($env:PM_NO_APP -ne '1') {
         $AppArchive = "projectmind-app-$AppSuffix.tar.gz"
-        Download $AppArchive
+        if (-not (Download-Optional $AppArchive)) {
+            Warn "no desktop app bundle in this release ($Tag) — skipping."
+            Warn "  the MCP server above is fully functional on its own; re-run"
+            Warn "  this script once a release that ships $AppArchive is out, or"
+            Warn "  set `$env:PM_NO_APP='1' to silence this warning."
+            $env:PM_NO_APP = '1'
+        }
+    }
+
+    if ($env:PM_NO_APP -ne '1') {
         $AppExtract = Join-Path $Tmp 'app'
         New-Item -ItemType Directory -Force -Path $AppExtract | Out-Null
         tar -xzf (Join-Path $Tmp $AppArchive) -C $AppExtract

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -106,6 +106,18 @@ download() {
     esac
 }
 
+# Soft variant: returns non-zero on 404 / fetch error instead of bringing the
+# whole script down (set -e). Used for the desktop-app archive, which is
+# allowed to be missing on releases that ship MCP-only.
+download_optional() {
+    asset="$1"
+    info "downloading $asset"
+    case "$DL" in
+        curl*) curl -fsSL --fail "${DOWNLOAD_BASE}/${asset}" -o "${TMP}/${asset}" 2>/dev/null ;;
+        wget*) wget -q "${DOWNLOAD_BASE}/${asset}" -O "${TMP}/${asset}" 2>/dev/null ;;
+    esac
+}
+
 # ---- MCP server ------------------------------------------------------------
 if [ "${PM_NO_MCP:-0}" != "1" ]; then
     MCP_ARCHIVE="projectmind-mcp-${MCP_SUFFIX}.tar.gz"
@@ -123,7 +135,17 @@ fi
 # ---- Desktop app -----------------------------------------------------------
 if [ "${PM_NO_APP:-0}" != "1" ]; then
     APP_ARCHIVE="projectmind-app-${APP_SUFFIX}.tar.gz"
-    download "$APP_ARCHIVE"
+    if ! download_optional "$APP_ARCHIVE"; then
+        warn "no desktop app bundle in this release ($TAG) — skipping."
+        warn "  • the MCP server above is fully functional on its own."
+        warn "  • re-run this script once a release that ships ${APP_ARCHIVE} is out,"
+        warn "    or pass PM_NO_APP=1 to silence this warning, or build the Tauri shell"
+        warn "    from source (see https://github.com/${REPO}#build-the-tauri-shell-optional-gui)."
+        PM_NO_APP=1
+    fi
+fi
+
+if [ "${PM_NO_APP:-0}" != "1" ]; then
     mkdir -p "${TMP}/app"
     tar xzf "${TMP}/${APP_ARCHIVE}" -C "${TMP}/app"
     case "$OS" in


### PR DESCRIPTION
Repro auf macOS:

```
curl -fsSL https://raw.githubusercontent.com/Plaintext-Gmbh/projectmind/master/scripts/install.sh | sh
:: resolving latest release tag
:: version: v0.2.0
:: downloading projectmind-mcp-macos-arm64.tar.gz
:: installed: /Users/mad/.local/bin/projectmind-mcp
:: downloading projectmind-app-macos-universal.tar.gz
curl: (56) The requested URL returned error: 404
```

v0.2.0 hat keine Desktop-App-Bundles (kommt erst mit v0.3.0). Der `set -eu` lässt die ganze Pipe failen — der MCP-Install darüber sah erfolgreich aus, aber das ganze Skript exit'et mit Fehler.

Fix: `download_optional` (sh) / `Download-Optional` (ps1) liefern bei 404 false statt den Skript-Tod. Konkrete Fehlermeldung erklärt was zu tun ist (MCP läuft, App später re-installen oder aus Source bauen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)