### PR TITLE
chore(security): pin postMessage origin + harden browser-host response headers

### DIFF
--- a/app/src/components/DrawIoView.svelte
+++ b/app/src/components/DrawIoView.svelte
@@ -8,8 +8,13 @@
   // diagrams.net embed protocol — `proto=json` lets us postMessage the XML
   // payload after the iframe loads, so we don't have to encode it into the
   // URL (which has a hard size limit on every browser).
-  const EMBED_URL =
-    'https://embed.diagrams.net/?embed=1&ui=atlas&proto=json&splash=0&toolbar=0&libraries=0&dark=auto';
+  //
+  // Privacy note: the .drawio XML is sent into an iframe pointed at
+  // embed.diagrams.net (a third-party service). For repos with sensitive
+  // diagrams, build the Tauri shell with a self-hosted draw.io viewer or
+  // run the .drawio file through a local converter first.
+  const EMBED_ORIGIN = 'https://embed.diagrams.net';
+  const EMBED_URL = `${EMBED_ORIGIN}/?embed=1&ui=atlas&proto=json&splash=0&toolbar=0&libraries=0&dark=auto`;
 
   let frame: HTMLIFrameElement;
   let xml = '';
@@ -39,7 +44,12 @@
   }
 
   function onMessage(ev: MessageEvent) {
+    // Defence-in-depth: only react to messages from the iframe we mounted
+    // AND from the diagrams.net origin we expect. Either check on its own
+    // is enough for the happy path; combining them rules out a redirected
+    // iframe smuggling messages back at us.
     if (ev.source !== frame?.contentWindow) return;
+    if (ev.origin !== EMBED_ORIGIN) return;
     let data: { event?: string };
     try {
       data = typeof ev.data === 'string' ? JSON.parse(ev.data) : ev.data;
@@ -48,9 +58,11 @@
     }
     if (data?.event === 'init' && !initialised && xml) {
       initialised = true;
+      // Pin the postMessage target origin to embed.diagrams.net so a
+      // navigated-away iframe doesn't end up receiving the diagram XML.
       frame.contentWindow?.postMessage(
         JSON.stringify({ action: 'load', xml, autosave: 0 }),
-        '*',
+        EMBED_ORIGIN,
       );
     }
   }
@@ -63,7 +75,7 @@
     try {
       frame.contentWindow?.postMessage(
         JSON.stringify({ action: 'status' }),
-        '*',
+        EMBED_ORIGIN,
       );
     } catch {
       // ignore

--- a/crates/browser-host/src/lib.rs
+++ b/crates/browser-host/src/lib.rs
@@ -747,7 +747,15 @@ fn read_file_bytes_response(
     let ctype = content_type(path);
     write!(
         stream,
-        "HTTP/1.1 200 OK\r\nContent-Type: {ctype}\r\nContent-Length: {}\r\nAccess-Control-Allow-Origin: *\r\nCache-Control: no-store\r\n\r\n",
+        "HTTP/1.1 200 OK\r\n\
+         Content-Type: {ctype}\r\n\
+         Content-Length: {}\r\n\
+         Access-Control-Allow-Origin: *\r\n\
+         Cache-Control: no-store\r\n\
+         X-Content-Type-Options: nosniff\r\n\
+         X-Frame-Options: SAMEORIGIN\r\n\
+         Referrer-Policy: no-referrer\r\n\
+         \r\n",
         bytes.len()
     )?;
     stream.write_all(&bytes)?;
@@ -797,7 +805,14 @@ fn serve_asset(stream: &mut TcpStream, asset_dir: &Path, path: &str) -> anyhow::
     let ctype = content_type(&file);
     write!(
         stream,
-        "HTTP/1.1 200 OK\r\nContent-Type: {ctype}\r\nContent-Length: {}\r\nCache-Control: no-store\r\n\r\n",
+        "HTTP/1.1 200 OK\r\n\
+         Content-Type: {ctype}\r\n\
+         Content-Length: {}\r\n\
+         Cache-Control: no-store\r\n\
+         X-Content-Type-Options: nosniff\r\n\
+         X-Frame-Options: SAMEORIGIN\r\n\
+         Referrer-Policy: no-referrer\r\n\
+         \r\n",
         bytes.len()
     )?;
     stream.write_all(&bytes)?;
@@ -815,7 +830,15 @@ fn json_response(stream: &mut TcpStream, status: u16, value: Value) -> anyhow::R
     };
     write!(
         stream,
-        "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nAccess-Control-Allow-Origin: *\r\nCache-Control: no-store\r\n\r\n",
+        "HTTP/1.1 {status} {reason}\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         Access-Control-Allow-Origin: *\r\n\
+         Cache-Control: no-store\r\n\
+         X-Content-Type-Options: nosniff\r\n\
+         X-Frame-Options: SAMEORIGIN\r\n\
+         Referrer-Policy: no-referrer\r\n\
+         \r\n",
         body.len()
     )?;
     stream.write_all(&body)?;


### PR DESCRIPTION
Defence-in-depth über die in #48/#49 frisch gemergten Files.

## DrawIoView
- `postMessage(..., '*')` → `postMessage(..., 'https://embed.diagrams.net')`
- Empfangsseite prüft jetzt `ev.origin` zusätzlich zu `ev.source`
- Privacy-Hinweis im Code: .drawio XML geht an embed.diagrams.net (third-party service)

## browser-host
Drei Standard-Response-Header auf jeder HTTP-Antwort:
- `X-Content-Type-Options: nosniff` — gegen MIME-Sniffing
- `X-Frame-Options: SAMEORIGIN` — gegen Clickjacking durch andere Origins
- `Referrer-Policy: no-referrer` — verhindert Leaks der LAN-URL inkl. Token-Fragment

Bestehende Schutzschichten (Bearer-Token-Auth, Pfad-Kanonisierung, Header/Body-Byte-Limits) bleiben unverändert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)