### PR TITLE
chore(build): simplify local build helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,30 +211,32 @@ The agent will pick the right tool calls from the list above.
 
 The latest release on the
 [Releases page](https://github.com/Plaintext-Gmbh/projectmind/releases/latest)
-ships `projectmind-mcp` for **Linux x86_64** and **macOS arm64** (each as
-a `.tar.gz` plus a `.sha256`). macOS x86_64 is built when a runner is
-available. New releases are produced by either pushing a `v*.*.*` tag
-or running the **Auto-Release** workflow manually from the Actions tab
-(it bumps the version, opens a PR, merges, tags, and publishes in one
-shot).
+ships `projectmind-mcp` and desktop app bundles where the GitHub runners
+can build them. New releases are produced by the **Auto-Release** workflow
+from the Actions tab; it bumps the version, opens a PR, merges, tags, and
+publishes in one shot.
 
 ## Tests / development
 
-The same commands CI runs are wrapped in `scripts/ci.sh`:
+For day-to-day work, use the small `./build` helper:
 
 ```bash
-./scripts/ci.sh check    # cargo fmt --check + cargo clippy
-./scripts/ci.sh test     # cargo test --workspace --all-targets + --doc
-./scripts/ci.sh all      # check + test
+./build dev      # Tauri app with hot reload
+./build check    # cargo fmt --check + cargo clippy
+./build test     # cargo test --workspace --all-targets + doctests
+./build ci       # check + test
+./build mcp      # release-build and smoke-test projectmind-mcp
+./build app      # desktop app bundle for this machine
+./build dist     # app bundle plus tar.gz + sha256 package
 ```
 
-If you'd rather invoke cargo directly:
+The lower-level CI wrapper is still available when you need exactly the
+workflow commands:
 
 ```bash
-cargo fmt --all -- --check
-cargo clippy --workspace --all-targets -- -D warnings
-cargo test --workspace --all-targets
-cargo test --workspace --doc
+./scripts/ci.sh check
+./scripts/ci.sh test
+./scripts/ci.sh all
 ```
 
 CI runs on **Ubuntu 22.04** and **macOS 14** for every push and pull request, plus a Linux release-build smoke test.

--- a/TODO.md
+++ b/TODO.md
@@ -112,13 +112,13 @@ require touching frontend code.
 ## Distribution (recently shipped)
 
 ### ~~Cross-platform local + GitHub release pipeline~~ ✅ done
-`./build dist` produces a distributable bundle for the host platform (Mac
-universal app + dmg, Linux .deb/.AppImage, Windows .msi/.exe) without
-GitHub Actions. The release workflow has separate `mcp` and `app` jobs
-that build for macOS / Linux / Windows. `scripts/install.{sh,ps1}` are
-one-shot installers that fetch the right asset from GitHub Releases and
-drop binaries in standard locations; the README has a `curl … | sh` and
-PowerShell `iwr | iex` quickstart.
+`./build` is now a small local helper for development, CI checks, MCP
+smoke builds and host app bundles. Version bumps, tags and published
+release artefacts live in GitHub Actions via Auto-Release. The release
+workflow has separate `mcp` and `app` jobs for macOS / Linux / Windows.
+`scripts/install.{sh,ps1}` are one-shot installers that fetch the right
+asset from GitHub Releases and drop binaries in standard locations; the
+README has a `curl … | sh` and PowerShell `iwr | iex` quickstart.
 
 ## Notes
 

--- a/build
+++ b/build
@@ -1,42 +1,25 @@
 #!/usr/bin/env bash
-# Local build & release driver for projectmind.
+# ProjectMind local build helper.
 #
-# This is a Rust + Tauri project (not Java/Maven), so the deploy-to-NAS half of
-# the plaintext-scripts numeric DSL doesn't apply. The numbers we DO support
-# follow the same convention used in the other plaintext-* projects:
+# Usage:
+#   ./build dev          run the Tauri app with hot reload
+#   ./build check        format check + clippy, same as CI
+#   ./build test         run tests + doctests, same as CI
+#   ./build ci           run check + test
+#   ./build mcp          build and smoke-test the release MCP binary
+#   ./build app          build the desktop app bundle for this machine
+#   ./build dist         build and package the desktop app for this machine
+#   ./build help         show this help
 #
-#   ./build 0          dev mode — launches the Tauri shell with hot-reload
-#   ./build 1          full local build (cargo workspace + Tauri bundle)
-#   ./build 2          MAJOR release (X.0.0): bump versions, tag, push
-#   ./build 3          MINOR release (x.X.0): bump versions, tag, push
-#   ./build 4          PATCH release (x.x.X): bump versions, tag, push
-#   ./build 7          run all CI checks locally (fmt + clippy + tests)
-#   ./build dist       build local distributable bundles (Mac universal app +
-#                      packaged tar.gz; Linux/Windows: builds whatever the host
-#                      can produce — cross-compile is best left to CI)
-#   ./build mcp        release-build only the MCP server binary
-#   ./build h | help   show this help
-#
-# Numbers 5/6/56 (deploy DEV / PROD on the NAS) are intentionally absent —
-# projectmind is a desktop app released as binaries via GitHub Actions when
-# you push a tag. Pushing a v* tag automatically triggers .github/workflows/
-# release.yml and uploads Mac+Linux+Windows artefacts. The `./build dist`
-# command produces the SAME artefacts locally (for the host platform) so a
-# release does not strictly require GitHub Actions — useful when you want to
-# hand someone a build before tagging, or you're offline.
+# Releases are intentionally not handled here. Use the GitHub Auto-Release
+# workflow for version bumps, tags and published release artefacts.
 
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$ROOT_DIR"
 
-CARGO_TOML="$ROOT_DIR/Cargo.toml"
-PKG_JSON="$ROOT_DIR/app/package.json"
-TAURI_CONF="$ROOT_DIR/app/src-tauri/tauri.conf.json"
-
 usage() {
-    # Print the leading comment block (everything from line 2 until the first
-    # non-comment line), stripping the leading `# ` prefix.
     awk '
         NR == 1 { next }
         /^#/    { sub(/^#[[:space:]]?/, ""); print; next }
@@ -44,141 +27,43 @@ usage() {
     ' "$0"
 }
 
-# Read workspace.package.version from Cargo.toml.
-current_version() {
-    awk '
-        /^\[workspace\.package\]/ { in_block=1; next }
-        in_block && /^\[/         { in_block=0 }
-        in_block && /^version[[:space:]]*=/ {
-            gsub(/[",]/, "")
-            split($0, a, "=")
-            gsub(/[[:space:]]/, "", a[2])
-            print a[2]
-            exit
-        }
-    ' "$CARGO_TOML"
-}
-
-# Bump $1 (major|minor|patch) of the current version. Echoes the new version.
-bump_version() {
-    local part="$1"
-    local cur
-    cur="$(current_version)"
-    if [[ -z "$cur" ]]; then
-        echo "could not read current version from Cargo.toml" >&2
-        exit 1
-    fi
-    IFS='.' read -r maj min pat <<<"$cur"
-    case "$part" in
-        major) maj=$((maj + 1)); min=0; pat=0 ;;
-        minor) min=$((min + 1)); pat=0 ;;
-        patch) pat=$((pat + 1)) ;;
-        *) echo "bump_version: unknown part '$part'" >&2; exit 1 ;;
-    esac
-    echo "${maj}.${min}.${pat}"
-}
-
-# Replace the FIRST occurrence of `version = "X.Y.Z"` inside the
-# [workspace.package] block of Cargo.toml. Anchored so we don't touch
-# dependency versions in [workspace.dependencies].
-write_cargo_version() {
-    local new="$1"
-    python3 - "$CARGO_TOML" "$new" <<'PY'
-import re, sys, pathlib
-path = pathlib.Path(sys.argv[1])
-new  = sys.argv[2]
-text = path.read_text()
-# Find the [workspace.package] block.
-m = re.search(r'(\[workspace\.package\][^\[]*)', text, re.S)
-if not m:
-    sys.exit("workspace.package block not found")
-block = m.group(1)
-new_block, n = re.subn(r'^version\s*=\s*"[^"]+"',
-                       f'version = "{new}"',
-                       block, count=1, flags=re.M)
-if n != 1:
-    sys.exit("version line not found in [workspace.package]")
-path.write_text(text.replace(block, new_block))
-PY
-}
-
-# Update package.json "version" field — root key, not nested.
-write_pkg_json_version() {
-    local new="$1"
-    python3 - "$PKG_JSON" "$new" <<'PY'
-import json, sys, pathlib
-path = pathlib.Path(sys.argv[1])
-new  = sys.argv[2]
-data = json.loads(path.read_text())
-data['version'] = new
-# Preserve trailing newline + 2-space indent the file already uses.
-path.write_text(json.dumps(data, indent=2) + "\n")
-PY
-}
-
-# Update tauri.conf.json "version" — root key.
-write_tauri_conf_version() {
-    local new="$1"
-    python3 - "$TAURI_CONF" "$new" <<'PY'
-import json, sys, pathlib
-path = pathlib.Path(sys.argv[1])
-new  = sys.argv[2]
-data = json.loads(path.read_text())
-data['version'] = new
-path.write_text(json.dumps(data, indent=2) + "\n")
-PY
-}
-
-assert_clean_tree() {
-    if [[ -n "$(git status --porcelain)" ]]; then
-        echo "✗ working tree has uncommitted changes — commit or stash first" >&2
-        git status -s >&2
-        exit 1
-    fi
-}
-
-assert_on_main() {
-    local branch
-    branch="$(git rev-parse --abbrev-ref HEAD)"
-    if [[ "$branch" != "main" && "$branch" != "master" ]]; then
-        echo "✗ not on main/master (current: $branch) — release from main only" >&2
-        exit 1
+ensure_js_deps() {
+    cd "$ROOT_DIR/app"
+    if [[ ! -d node_modules ]]; then
+        pnpm install --frozen-lockfile
     fi
 }
 
 cmd_dev() {
-    echo "→ launching Tauri dev shell"
-    cd "$ROOT_DIR/app"
-    if [[ ! -d node_modules ]]; then
-        echo "→ installing npm deps (first run)"
-        npm install
-    fi
-    exec npm run tauri dev
+    ensure_js_deps
+    exec pnpm tauri dev
 }
 
-cmd_build() {
-    echo "→ cargo build --workspace"
-    cargo build --workspace
-    echo "→ tauri build (release bundle)"
-    cd "$ROOT_DIR/app"
-    if [[ ! -d node_modules ]]; then
-        npm install
-    fi
-    npm run tauri build
+cmd_check() {
+    "$ROOT_DIR/scripts/ci.sh" check
 }
 
-cmd_mcp_release() {
-    echo "→ release-build MCP server"
-    cargo build --release --bin projectmind-mcp
-    echo "✓ binary at target/release/projectmind-mcp"
+cmd_test() {
+    "$ROOT_DIR/scripts/ci.sh" test
 }
 
-# Detect host OS / arch and emit { target_triple, asset_suffix } so the dist
-# command produces the same artefact names as the GitHub Actions matrix.
+cmd_ci() {
+    "$ROOT_DIR/scripts/ci.sh" all
+}
+
+cmd_mcp() {
+    "$ROOT_DIR/scripts/ci.sh" release-smoke
+}
+
+cmd_app() {
+    "$ROOT_DIR/scripts/ci.sh" app-build
+}
+
 detect_host_target() {
     local kernel arch
     kernel="$(uname -s)"
     arch="$(uname -m)"
+
     case "$kernel" in
         Darwin)
             case "$arch" in
@@ -204,88 +89,31 @@ detect_host_target() {
 }
 
 cmd_dist() {
-    local pair host_target asset_suffix
+    local pair target suffix
     pair="$(detect_host_target)"
-    host_target="${pair% *}"
-    asset_suffix="${pair#* }"
+    target="${pair% *}"
+    suffix="${pair#* }"
 
-    echo "→ host: ${host_target} (asset suffix: ${asset_suffix})"
-
-    # Make sure the toolchain target is installed (rustup is available on
-    # most setups; if not, fall back to default cargo and hope the host
-    # already has it).
     if command -v rustup >/dev/null 2>&1; then
-        rustup target add "$host_target" >/dev/null 2>&1 || true
+        rustup target add "$target" >/dev/null 2>&1 || true
     fi
 
-    # On macOS, prefer a universal binary so a single .dmg works on both
-    # Apple Silicon and Intel. Tauri's `--target universal-apple-darwin`
-    # handles the lipo dance.
-    if [[ "$host_target" == *-apple-darwin ]]; then
-        if rustup target list --installed 2>/dev/null | grep -q "x86_64-apple-darwin"; then
-            host_target="universal-apple-darwin"
-            asset_suffix="macos-universal"
-            echo "→ Apple Silicon + Intel toolchains both present → building universal binary"
-        else
-            echo "→ Intel toolchain not installed (rustup target add x86_64-apple-darwin to enable universal builds)"
-        fi
-    fi
-
-    "$ROOT_DIR/scripts/ci.sh" app-build "$host_target"
-    "$ROOT_DIR/scripts/ci.sh" app-package "$host_target" "$asset_suffix"
-
-    local archive="$ROOT_DIR/projectmind-app-${asset_suffix}.tar.gz"
-    if [[ -f "$archive" ]]; then
-        echo "✓ distributable: $archive"
-        echo "✓ checksum:      ${archive}.sha256"
-    fi
-}
-
-cmd_ci() {
-    "$ROOT_DIR/scripts/ci.sh" all
-}
-
-cmd_release() {
-    local part="$1"
-    assert_clean_tree
-    assert_on_main
-
-    local cur new
-    cur="$(current_version)"
-    new="$(bump_version "$part")"
-    echo "→ ${part} release: ${cur} → ${new}"
-
-    write_cargo_version "$new"
-    write_pkg_json_version "$new"
-    write_tauri_conf_version "$new"
-
-    # Refresh Cargo.lock so the bumped workspace version lands there too.
-    cargo update --workspace --offline >/dev/null 2>&1 || cargo update --workspace
-
-    # Sanity: tree must compile after the bump before we tag.
-    cargo check --workspace
-
-    git add Cargo.toml Cargo.lock "$PKG_JSON" "$TAURI_CONF"
-    git commit -m "chore(release): v${new}"
-    git tag -a "v${new}" -m "v${new}"
-    git push origin HEAD
-    git push origin "v${new}"
-    echo "✓ released v${new} — GitHub Actions will publish binaries shortly"
+    "$ROOT_DIR/scripts/ci.sh" app-build "$target"
+    "$ROOT_DIR/scripts/ci.sh" app-package "$target" "$suffix"
 }
 
 case "${1:-help}" in
-    0)             cmd_dev ;;
-    1)             cmd_build ;;
-    2)             cmd_release major ;;
-    3)             cmd_release minor ;;
-    4)             cmd_release patch ;;
-    7)             cmd_ci ;;
-    dist)          cmd_dist ;;
-    mcp)           cmd_mcp_release ;;
+    dev)             cmd_dev ;;
+    check)           cmd_check ;;
+    test)            cmd_test ;;
+    ci|all)          cmd_ci ;;
+    mcp)             cmd_mcp ;;
+    app)             cmd_app ;;
+    dist)            cmd_dist ;;
     h|help|-h|--help) usage ;;
     *)
         echo "unknown command: $1" >&2
-        usage
+        usage >&2
         exit 2
         ;;
 esac


### PR DESCRIPTION
Makes the local ./build helper pragmatic and project-specific.\n\n- removes numbered legacy commands and NAS/deploy wording\n- removes local release bump/tag/push behavior\n- switches dev/app paths to pnpm\n- documents the simple commands in README/TODO\n\nValidation:\n- ./build help\n- bash -n build\n- bash -n scripts/ci.sh\n- ./build check