### PR TITLE
feat(plugins): per-plugin tab contributions via Contributions trait

### DIFF
--- a/app/src/App.svelte
+++ b/app/src/App.svelte
@@ -36,7 +36,7 @@
     isTauriRuntime,
     setBrowserToken,
   } from './lib/api';
-  import type { ClassEntry, ModuleEntry, ModuleFile, UiState } from './lib/api';
+  import type { ClassEntry, ModuleEntry, ModuleFile, TabDescriptor, UiState } from './lib/api';
   // Eagerly imported — small, almost-always rendered:
   import ClassViewer from './components/ClassViewer.svelte';
   import ModuleSidebar from './components/ModuleSidebar.svelte';
@@ -97,6 +97,22 @@
   // chip refactor) markdown / HTML alike. "Modules" stays as the synonym
   // for folders.
   $: codeTabLabel = $t('nav.files');
+
+  // The "files" tab hosts several render modes (classes / pdf / image /
+  // markdown / html / single-file viewer) that are all reachable from
+  // chips inside the same surface. Other tabs are 1:1 with their
+  // viewMode so the default below covers them.
+  const FILES_VIEW_MODES = new Set(['classes', 'pdf', 'image', 'md', 'html', 'file']);
+
+  function isTabActive(tab: TabDescriptor, mode: string): boolean {
+    if (tab.id === 'files') return FILES_VIEW_MODES.has(mode);
+    return tab.view_mode === mode;
+  }
+
+  function activateTab(tab: TabDescriptor) {
+    followingMcp.set(false);
+    viewMode.set(tab.view_mode as Parameters<typeof viewMode.set>[0]);
+  }
 
   function toggleLang() {
     // Cycle through the configured languages (codex's i18n module ships
@@ -630,31 +646,19 @@
       {/if}
     </div>
     <nav>
-      <button
-        class:active={$viewMode === 'classes' ||
-          $viewMode === 'pdf' ||
-          $viewMode === 'image' ||
-          $viewMode === 'md' ||
-          $viewMode === 'html' ||
-          $viewMode === 'file'}
-        disabled={!$repo}
-        on:click={() => {
-          followingMcp.set(false);
-          viewMode.set('classes');
-        }}
-      >
-        {codeTabLabel}
-      </button>
-      <button
-        class:active={$viewMode === 'diagram'}
-        disabled={!$repo}
-        on:click={() => {
-          followingMcp.set(false);
-          viewMode.set('diagram');
-        }}
-      >
-        {$t('nav.diagrams')}
-      </button>
+      {#if $repo}
+        {#each $repo.tabs as tab (tab.id)}
+          <button
+            class:active={isTabActive(tab, $viewMode)}
+            on:click={() => activateTab(tab)}
+          >
+            {$t(tab.label_key)}
+          </button>
+        {/each}
+      {:else}
+        <button disabled>{codeTabLabel}</button>
+        <button disabled>{$t('nav.diagrams')}</button>
+      {/if}
       {#if $walkthroughCursor}
         <button
           class:active={$viewMode === 'walkthrough'}

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -79,6 +79,15 @@ export interface ModuleEntry {
   stereotypes: Record<string, number>;
 }
 
+export interface TabDescriptor {
+  /// Stable id, used as Svelte each-key (e.g. "files", "diagrams", "tests").
+  id: string;
+  /// i18n key for the visible label.
+  label_key: string;
+  /// Frontend viewMode the tab activates.
+  view_mode: string;
+}
+
 export interface RepoSummary {
   root: string;
   modules: number;
@@ -91,6 +100,10 @@ export interface RepoSummary {
   /// "package-tree", "folder-map"). Returned by the backend so the UI can
   /// render the Diagram-tab buttons dynamically.
   available_diagrams: string[];
+  /// Top-level UI tabs the active plugin set contributes. Core ships
+  /// "files" + "diagrams"; plugins can append more (e.g. a future
+  /// "framework-junit" "Tests" tab). Rendered in declaration order.
+  tabs: TabDescriptor[];
 }
 
 export interface ChangedFile {

--- a/crates/browser-host/src/lib.rs
+++ b/crates/browser-host/src/lib.rs
@@ -572,6 +572,11 @@ pub struct RepoSummary {
     /// Diagram kinds available for this repo + plugin set. The browser UI
     /// uses this to render Diagram-tab buttons dynamically.
     pub available_diagrams: Vec<String>,
+    /// Top-level UI tabs the active plugin set contributes for this repo.
+    /// Core ships `files` + `diagrams`; plugins can append more (a future
+    /// `framework-junit` "Tests" tab, for example). The frontend renders
+    /// one nav button per entry.
+    pub tabs: Vec<projectmind_core::TabDescriptor>,
 }
 
 /// One class entry exposed to the browser UI.
@@ -630,6 +635,7 @@ fn open_repo_locked(state: &mut HostState, path: &Path) -> anyhow::Result<RepoSu
     let html_count =
         html::list_html_files(&repo.root).len() + html::find_html_snippets(&repo.root).len();
     let available_diagrams = state.engine.available_diagrams(&repo);
+    let tabs = state.engine.available_tabs(&repo);
     let summary = RepoSummary {
         root: repo.root.clone(),
         modules: repo.modules.len(),
@@ -639,6 +645,7 @@ fn open_repo_locked(state: &mut HostState, path: &Path) -> anyhow::Result<RepoSu
         markdown_count,
         html_count,
         available_diagrams,
+        tabs,
     };
     state.repo_root = Some(repo.root.clone());
     state::write(UiState {

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -8,10 +8,54 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use ignore::WalkBuilder;
-use projectmind_plugin_api::{FrameworkPlugin, LanguagePlugin, Module};
+use projectmind_plugin_api::{FrameworkPlugin, LanguagePlugin, Module, TabContribution};
+use serde::Serialize;
 use tracing::{debug, info, warn};
 
 use crate::repository::{Repository, RepositoryError};
+
+/// Serializable view of a [`TabContribution`] for the public API.
+///
+/// `TabContribution` is a `Copy` static-string struct that's convenient for
+/// plugins to declare; the host turns it into this owned, serializable form
+/// before exposing it to the GUI.
+#[derive(Debug, Clone, Serialize)]
+pub struct TabDescriptor {
+    /// Stable identifier (e.g. `files`, `diagrams`, `tests`).
+    pub id: String,
+    /// i18n key for the visible label.
+    pub label_key: String,
+    /// Frontend view-mode value the tab activates.
+    pub view_mode: String,
+}
+
+impl From<TabContribution> for TabDescriptor {
+    fn from(c: TabContribution) -> Self {
+        Self {
+            id: c.id.to_string(),
+            label_key: c.label_key.to_string(),
+            view_mode: c.view_mode.to_string(),
+        }
+    }
+}
+
+/// Built-in tab contributions the core ships unconditionally.
+///
+/// Kept here (not on a plugin) because they describe core capabilities — a
+/// repo always has files, and `folder-map` is always renderable so the
+/// Diagrams tab is always meaningful.
+const CORE_TABS: &[TabContribution] = &[
+    TabContribution {
+        id: "files",
+        label_key: "nav.files",
+        view_mode: "classes",
+    },
+    TabContribution {
+        id: "diagrams",
+        label_key: "nav.diagrams",
+        view_mode: "diagram",
+    },
+];
 
 /// The engine wires plugins to repositories.
 pub struct Engine {
@@ -78,6 +122,51 @@ impl Engine {
     /// Get registered framework plugin ids (for diagnostics).
     pub fn framework_ids(&self) -> Vec<&'static str> {
         self.frameworks.iter().map(|p| p.info().id).collect()
+    }
+
+    /// Diagram kinds that the active plugin set can render against `repo`.
+    /// "folder-map" is always present (it's a core capability); language and
+    /// framework plugins contribute the rest. Languages only contribute when
+    /// the repo has parsed classes — a docs-only repo with no Java/Rust code
+    /// shouldn't advertise "package-tree" since it has no packages to draw.
+    /// Frameworks only contribute when at least one of their supported
+    /// languages produced a class (i.e. the framework has something to enrich).
+    /// The result is sorted + deduplicated for stable UI ordering.
+    /// Top-level UI tabs the active plugin set contributes for `repo`.
+    /// Core ships `files` + `diagrams` unconditionally; languages and
+    /// frameworks can append plugin-specific tabs (a future
+    /// `framework-junit` "Tests" tab, for example). Duplicate ids across
+    /// plugins are dropped — the first occurrence wins so core tabs always
+    /// appear in the order declared in [`CORE_TABS`].
+    ///
+    /// `repo` is currently unused but accepted so the signature mirrors
+    /// [`Engine::available_diagrams`] and so future plugins can scope tab
+    /// visibility to repo content (e.g. only show "Tests" when the repo
+    /// actually has tests).
+    pub fn available_tabs(&self, _repo: &Repository) -> Vec<TabDescriptor> {
+        let mut out: Vec<TabDescriptor> = Vec::new();
+        let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        let push = |c: TabContribution,
+                    out: &mut Vec<TabDescriptor>,
+                    seen: &mut std::collections::BTreeSet<String>| {
+            if seen.insert(c.id.to_string()) {
+                out.push(c.into());
+            }
+        };
+        for c in CORE_TABS {
+            push(*c, &mut out, &mut seen);
+        }
+        for lang in &self.languages {
+            for c in lang.provided_tabs() {
+                push(*c, &mut out, &mut seen);
+            }
+        }
+        for fw in &self.frameworks {
+            for c in fw.provided_tabs() {
+                push(*c, &mut out, &mut seen);
+            }
+        }
+        out
     }
 
     /// Diagram kinds that the active plugin set can render against `repo`.
@@ -403,6 +492,89 @@ mod tests {
         assert_eq!(repo.class_count(), 1);
     }
 
+    struct TabPlugin;
+    impl LanguagePlugin for TabPlugin {
+        fn info(&self) -> PluginInfo {
+            PluginInfo {
+                id: "tab-lang",
+                name: "Tab",
+                version: "0.0.1",
+            }
+        }
+        fn file_extensions(&self) -> &[&'static str] {
+            &[]
+        }
+        fn parse_file(
+            &self,
+            _file: &Path,
+            _source: &str,
+            _module: &mut Module,
+        ) -> projectmind_plugin_api::Result<()> {
+            Ok(())
+        }
+        fn provided_tabs(&self) -> &[TabContribution] {
+            &[TabContribution {
+                id: "tests",
+                label_key: "nav.tests",
+                view_mode: "tests",
+            }]
+        }
+    }
+
+    #[test]
+    fn available_tabs_includes_core_and_plugin_contributions() {
+        let dir = tempdir();
+        let mut engine = Engine::new();
+        engine.register_language(Box::new(TabPlugin));
+        let repo = engine.open_repo(dir.path()).unwrap();
+        let tabs = engine.available_tabs(&repo);
+        let ids: Vec<_> = tabs.iter().map(|t| t.id.as_str()).collect();
+        // Core tabs come first in declaration order, then plugin tabs.
+        assert_eq!(ids, vec!["files", "diagrams", "tests"]);
+    }
+
+    #[test]
+    fn available_tabs_dedupes_by_id() {
+        // A plugin re-declaring a core id (e.g. `files`) shouldn't double the
+        // entry — first occurrence wins so core ordering stays stable.
+        struct ShadowPlugin;
+        impl LanguagePlugin for ShadowPlugin {
+            fn info(&self) -> PluginInfo {
+                PluginInfo {
+                    id: "shadow",
+                    name: "Shadow",
+                    version: "0.0.1",
+                }
+            }
+            fn file_extensions(&self) -> &[&'static str] {
+                &[]
+            }
+            fn parse_file(
+                &self,
+                _f: &Path,
+                _s: &str,
+                _m: &mut Module,
+            ) -> projectmind_plugin_api::Result<()> {
+                Ok(())
+            }
+            fn provided_tabs(&self) -> &[TabContribution] {
+                &[TabContribution {
+                    id: "files",
+                    label_key: "nav.files.shadowed",
+                    view_mode: "classes",
+                }]
+            }
+        }
+        let dir = tempdir();
+        let mut engine = Engine::new();
+        engine.register_language(Box::new(ShadowPlugin));
+        let repo = engine.open_repo(dir.path()).unwrap();
+        let tabs = engine.available_tabs(&repo);
+        let files: Vec<_> = tabs.iter().filter(|t| t.id == "files").collect();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].label_key, "nav.files");
+    }
+
     fn tempdir() -> TempDir {
         TempDir::new()
     }
@@ -410,8 +582,14 @@ mod tests {
     struct TempDir(PathBuf);
     impl TempDir {
         fn new() -> Self {
+            // Per-test directory: PID + a process-wide monotonic counter so
+            // tests running in parallel (cargo's default) don't share a path
+            // and stomp each other on Drop.
+            use std::sync::atomic::{AtomicU64, Ordering};
+            static COUNTER: AtomicU64 = AtomicU64::new(0);
+            let n = COUNTER.fetch_add(1, Ordering::Relaxed);
             let mut p = std::env::temp_dir();
-            p.push(format!("projectmind-test-{}", std::process::id()));
+            p.push(format!("projectmind-test-{}-{}", std::process::id(), n));
             std::fs::create_dir_all(&p).unwrap();
             Self(p)
         }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -26,7 +26,7 @@ pub mod state;
 pub mod walkthrough;
 
 pub use cargo::CargoCrate;
-pub use engine::Engine;
+pub use engine::{Engine, TabDescriptor};
 pub use maven::MavenModule;
 pub use repository::{Repository, RepositoryError};
 

--- a/crates/plugin-api/src/lib.rs
+++ b/crates/plugin-api/src/lib.rs
@@ -23,7 +23,7 @@ pub mod relation;
 pub mod storage;
 
 pub use entity::{Annotation, Class, ClassKind, Field, Method, Module, Visibility};
-pub use plugin::{FrameworkPlugin, LanguagePlugin, PluginInfo, VisualizerPlugin};
+pub use plugin::{FrameworkPlugin, LanguagePlugin, PluginInfo, TabContribution, VisualizerPlugin};
 pub use relation::{Relation, RelationKind};
 pub use storage::{AnnotationStore, CodeGraphStore, EdgeKind, GraphNode, GraphQuery, NodeId};
 

--- a/crates/plugin-api/src/plugin.rs
+++ b/crates/plugin-api/src/plugin.rs
@@ -23,6 +23,27 @@ pub struct PluginInfo {
     pub version: &'static str,
 }
 
+/// A top-level UI tab a plugin contributes.
+///
+/// The frontend renders one button per contribution (after deduplication
+/// across plugins). `view_mode` is the value that's set on the frontend's
+/// `viewMode` store when the tab is clicked — keeping it as a plain string
+/// means a future plugin can introduce an entirely new render mode without
+/// the core having to know its name.
+///
+/// Core ships two contributions out of the box: `files` and `diagrams`.
+/// Plugins can add their own (e.g. a future `framework-junit` "Tests" tab).
+#[derive(Debug, Clone, Copy)]
+pub struct TabContribution {
+    /// Stable identifier (e.g. `tests`). Used for de-duplication and as the
+    /// React/Svelte key in the rendered nav.
+    pub id: &'static str,
+    /// i18n key for the visible label (e.g. `nav.tests`).
+    pub label_key: &'static str,
+    /// Frontend view-mode value the tab activates (e.g. `tests`).
+    pub view_mode: &'static str,
+}
+
 /// A plugin that knows how to parse a programming language.
 pub trait LanguagePlugin: Send + Sync {
     /// Plugin metadata.
@@ -45,6 +66,14 @@ pub trait LanguagePlugin: Send + Sync {
     fn provided_diagrams(&self) -> &[&'static str] {
         &[]
     }
+
+    /// Top-level UI tabs this plugin contributes. Default empty —
+    /// plugins that just produce classes fold into the core "files" tab
+    /// and don't need an entry here. Plugins that own a standalone view
+    /// (a future `framework-junit` "Tests" tab) return their tabs here.
+    fn provided_tabs(&self) -> &[TabContribution] {
+        &[]
+    }
 }
 
 /// A plugin that enriches one or more languages with framework-specific information.
@@ -65,6 +94,12 @@ pub trait FrameworkPlugin: Send + Sync {
     /// `&["bean-graph"]`; a future `framework-junit` could return
     /// `&["test-coverage"]`. Default empty.
     fn provided_diagrams(&self) -> &[&'static str] {
+        &[]
+    }
+
+    /// Top-level UI tabs this framework contributes. Default empty.
+    /// See [`LanguagePlugin::provided_tabs`] for guidance on when to add one.
+    fn provided_tabs(&self) -> &[TabContribution] {
         &[]
     }
 }


### PR DESCRIPTION
Closes #60.

## Summary

Closes the last open item from `TODO.md` — the **Tab registry**. The `Code` / `Diagrams` tab pair was hard-coded in `App.svelte`; this PR moves the registry to plugins so the visible set adapts to what the active language/framework set declares. Mirrors the existing `provided_diagrams()` path that landed earlier.

A future `framework-junit` plugin can drop in a "Tests" tab with **zero core changes** — which is the prerequisite for Phase 2's dynamic plugin loading.

## What changed

- `plugin-api`: new `TabContribution { id, label_key, view_mode }` struct + default-empty `provided_tabs()` hook on `LanguagePlugin` and `FrameworkPlugin`.
- `core`: serializable `TabDescriptor` and `Engine::available_tabs(repo)` that aggregates two core tabs (`files`, `diagrams`) with plugin contributions. Dedup by `id` (first occurrence wins, so core ordering stays stable).
- `browser-host`: `RepoSummary.tabs` ships the aggregate to the GUI.
- `app/src/App.svelte`: nav buttons render dynamically from `$repo.tabs`. The `files` tab still spans multiple view modes (`classes` / `pdf` / `image` / `md` / `html` / `file`) via a small `isTabActive` helper; all other tabs are 1:1 with their `view_mode`.

## Tests

- New unit tests in `crates/core/src/engine.rs`:
  - `available_tabs_includes_core_and_plugin_contributions`
  - `available_tabs_dedupes_by_id`
- Bonus fix: per-test temp directory now uses an atomic counter so parallel cargo tests don't clobber each other (the existing `engine_walks_and_calls_plugin` started colliding with the new ones).

## Test plan

- [x] `cargo test --workspace` — all green (was 41 passing in core, now 44)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `pnpm check` (svelte-check) — 0 errors
- [x] `pnpm build` — frontend builds
- [ ] Manual GUI smoke test — open a Java repo, verify Files + Diagrams tabs still render and behave identically

## Follow-up (separate PR)

`TODO.md` is now empty. The next PR will:
- delete `TODO.md`
- migrate `docs/plan/*` to GitHub Issues + a Discussion
- set up a Kanban board for tracking
- update README to point at Issues / Project board for the roadmap

🤖 Generated with [Claude Code](https://claude.com/claude-code)
