### PR TITLE
fix(release): repair desktop app packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,9 +139,6 @@ jobs:
           - os: macos-14
             target: aarch64-apple-darwin
             asset_suffix: macos-arm64
-          - os: macos-13
-            target: x86_64-apple-darwin
-            asset_suffix: macos-x86_64
           - os: windows-2022
             target: x86_64-pc-windows-msvc
             asset_suffix: windows-x86_64

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -32,7 +32,9 @@
     "active": true,
     "targets": "all",
     "icon": [
-      "icons/icon.png"
+      "icons/icon.png",
+      "icons/icon.ico",
+      "icons/icon.icns"
     ],
     "category": "DeveloperTool",
     "shortDescription": "Read-only architecture browser",

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -176,8 +176,8 @@ cmd_app_package() {
     fi
 
     # Tauri scatters bundle artefacts across format-specific subdirs
-    # (bundle/dmg/, bundle/macos/, bundle/deb/, bundle/appimage/, bundle/msi/,
-    # bundle/nsis/). Pick whatever distributable formats actually got produced
+    # (bundle/dmg/, bundle/macos/, bundle/deb/, bundle/rpm/, bundle/appimage/,
+    # bundle/msi/, bundle/nsis/). Pick whatever distributable formats actually got produced
     # and pack them plus LICENSE + README into one archive. This keeps the
     # workflow simple: ONE artefact per target, asset_suffix telling Mac/Linux/Win
     # apart.
@@ -186,7 +186,8 @@ cmd_app_package() {
         bundles+=("$f")
     done < <(find "$bundle_dir" -type f \
         \( -name "*.dmg" -o -name "*.app.tar.gz" -o -name "*.deb" \
-           -o -name "*.AppImage" -o -name "*.msi" -o -name "*.exe" \) \
+           -o -name "*.rpm" -o -name "*.AppImage" \
+           -o -name "*.msi" -o -name "*.exe" \) \
         2>/dev/null | sort)
 
     if [[ ${#bundles[@]} -eq 0 ]]; then
@@ -199,7 +200,9 @@ cmd_app_package() {
     # Build a flat archive: every bundle artefact at the archive root.
     local args=()
     for f in "${bundles[@]}"; do
-        args+=( -C "$(dirname "$f")" "$(basename "$f")" )
+        local dir
+        dir="$(cd "$(dirname "$f")" && pwd)"
+        args+=( -C "$dir" "$(basename "$f")" )
     done
     tar czf "$archive" "${args[@]}" -C "$ROOT_DIR" LICENSE README.md
     sha256 "$archive" > "$archive.sha256"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -50,7 +50,7 @@ case "$OS" in
         APP_SUFFIX="macos-universal"
         case "$ARCH" in
             arm64)  MCP_SUFFIX="macos-arm64" ;;
-            x86_64) MCP_SUFFIX="macos-x86_64" ;;
+            x86_64) MCP_SUFFIX="" ;;
             *) fail "unsupported macOS arch: $ARCH" ;;
         esac
         ;;
@@ -120,6 +120,7 @@ download_optional() {
 
 # ---- MCP server ------------------------------------------------------------
 if [ "${PM_NO_MCP:-0}" != "1" ]; then
+    [ -n "${MCP_SUFFIX:-}" ] || fail "macOS Intel MCP builds are no longer published — set PM_NO_MCP=1 to install only the universal desktop app"
     MCP_ARCHIVE="projectmind-mcp-${MCP_SUFFIX}.tar.gz"
     download "$MCP_ARCHIVE"
     mkdir -p "${TMP}/mcp"


### PR DESCRIPTION
## Summary
- remove the unsupported macOS x86_64 MCP release slice
- package Linux desktop bundles with absolute tar paths and include RPM output
- reference the existing Windows .ico and macOS .icns icons in Tauri config
- keep Intel macOS desktop installs possible with PM_NO_MCP=1 while MCP is unsupported

## Verification
- bash -n scripts/ci.sh scripts/install.sh
- python3 -m json.tool app/src-tauri/tauri.conf.json >/dev/null
- ./scripts/ci.sh check
- local fake app-package run with deb/rpm/AppImage/setup.exe outputs