### PR TITLE
chore(release): v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] — 2026-05-02
+
 ### Added
 
 - **Tab registry as a plugin contract** — `TabContribution` + `provided_tabs()` on `LanguagePlugin` / `FrameworkPlugin`; `Engine::available_tabs(repo)` aggregates core tabs (`files`, `diagrams`) with plugin contributions; `App.svelte` renders nav buttons dynamically from `RepoSummary.tabs`. Future plugins (e.g. a `framework-junit` "Tests" tab) can drop in a top-level entry without touching frontend code — the prerequisite for Phase 2's dynamic plugin loading.
@@ -14,6 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Roadmap and backlog moved from `docs/plan/` and `TODO.md` to GitHub Issues / Discussions.** `docs/plan/03-architecture.md` is now `docs/architecture.md` (living reference). Vision, persistence, visualisation catalogue, and walkthrough follow-ups are tracked as Issues; vision discussion lives on GitHub Discussions. README and CONTRIBUTING updated to point at the new locations.
+
+### Fixed
+
+- Release workflow now installs concrete Rust targets for the macOS
+  universal desktop build while keeping Tauri's
+  `universal-apple-darwin` build target.
+- Linux desktop archives package `.deb`, `.rpm`, and `.AppImage`
+  outputs reliably.
+- Windows desktop builds reference the checked-in `.ico` icon.
+- MCP release artifacts no longer include unsupported macOS x86_64
+  builds.
 
 ## [0.3.0] — 2026-05-02
 
@@ -205,6 +218,8 @@ was sitting in unpublished branches.
 - Issue and pull request templates
 - Dependabot configuration
 
-[Unreleased]: https://github.com/Plaintext-Gmbh/projectmind/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/Plaintext-Gmbh/projectmind/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/Plaintext-Gmbh/projectmind/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/Plaintext-Gmbh/projectmind/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Plaintext-Gmbh/projectmind/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Plaintext-Gmbh/projectmind/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-app"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "notify",
  "parking_lot",
@@ -3132,7 +3132,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-browser-host"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "open",
@@ -3149,7 +3149,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3168,7 +3168,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-framework-lombok"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "projectmind-plugin-api",
  "serde_json",
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-framework-spring"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "projectmind-plugin-api",
  "tracing",
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-lang-java"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "projectmind-plugin-api",
  "tracing",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-lang-rust"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "projectmind-plugin-api",
  "tracing",
@@ -3204,7 +3204,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-mcp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-plugin-api"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/Plaintext-Gmbh/projectmind"
@@ -49,8 +49,8 @@ struct_field_names = "allow"
 ignored_unit_patterns = "allow"
 
 [workspace.dependencies]
-projectmind-plugin-api = { path = "crates/plugin-api", version = "0.3.0" }
-projectmind-core       = { path = "crates/core",       version = "0.3.0" }
+projectmind-plugin-api = { path = "crates/plugin-api", version = "0.3.1" }
+projectmind-core       = { path = "crates/core",       version = "0.3.1" }
 
 # General
 anyhow      = "1.0"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "projectmind-app",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -21,10 +21,10 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 projectmind-plugin-api = { workspace = true }
 projectmind-core       = { workspace = true }
-projectmind-lang-java  = { path = "../../plugins/lang-java", version = "0.3.0" }
-projectmind-lang-rust  = { path = "../../plugins/lang-rust", version = "0.3.0" }
-projectmind-framework-spring = { path = "../../plugins/framework-spring", version = "0.3.0" }
-projectmind-framework-lombok = { path = "../../plugins/framework-lombok", version = "0.3.0" }
+projectmind-lang-java  = { path = "../../plugins/lang-java", version = "0.3.1" }
+projectmind-lang-rust  = { path = "../../plugins/lang-rust", version = "0.3.1" }
+projectmind-framework-spring = { path = "../../plugins/framework-spring", version = "0.3.1" }
+projectmind-framework-lombok = { path = "../../plugins/framework-lombok", version = "0.3.1" }
 
 tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-dialog = "2"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "ProjectMind",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "ch.plaintext.projectmind",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/crates/browser-host/Cargo.toml
+++ b/crates/browser-host/Cargo.toml
@@ -13,10 +13,10 @@ workspace = true
 
 [dependencies]
 projectmind-core = { workspace = true }
-projectmind-lang-java = { path = "../../plugins/lang-java", version = "0.3.0" }
-projectmind-lang-rust = { path = "../../plugins/lang-rust", version = "0.3.0" }
-projectmind-framework-spring = { path = "../../plugins/framework-spring", version = "0.3.0" }
-projectmind-framework-lombok = { path = "../../plugins/framework-lombok", version = "0.3.0" }
+projectmind-lang-java = { path = "../../plugins/lang-java", version = "0.3.1" }
+projectmind-lang-rust = { path = "../../plugins/lang-rust", version = "0.3.1" }
+projectmind-framework-spring = { path = "../../plugins/framework-spring", version = "0.3.1" }
+projectmind-framework-lombok = { path = "../../plugins/framework-lombok", version = "0.3.1" }
 
 anyhow = { workspace = true }
 rand = "0.8"

--- a/crates/mcp-server/Cargo.toml
+++ b/crates/mcp-server/Cargo.toml
@@ -18,13 +18,13 @@ workspace = true
 [dependencies]
 projectmind-plugin-api = { workspace = true }
 projectmind-core       = { workspace = true }
-projectmind-browser-host = { path = "../browser-host", version = "0.3.0" }
+projectmind-browser-host = { path = "../browser-host", version = "0.3.1" }
 
 # Local plugins linked statically for Phase 1
-projectmind-lang-java         = { path = "../../plugins/lang-java", version = "0.3.0" }
-projectmind-lang-rust         = { path = "../../plugins/lang-rust", version = "0.3.0" }
-projectmind-framework-spring  = { path = "../../plugins/framework-spring", version = "0.3.0" }
-projectmind-framework-lombok  = { path = "../../plugins/framework-lombok", version = "0.3.0" }
+projectmind-lang-java         = { path = "../../plugins/lang-java", version = "0.3.1" }
+projectmind-lang-rust         = { path = "../../plugins/lang-rust", version = "0.3.1" }
+projectmind-framework-spring  = { path = "../../plugins/framework-spring", version = "0.3.1" }
+projectmind-framework-lombok  = { path = "../../plugins/framework-lombok", version = "0.3.1" }
 
 anyhow      = { workspace = true }
 clap        = { workspace = true }


### PR DESCRIPTION
## Summary
- bump ProjectMind manifests and lockfile to 0.3.1
- add v0.3.1 changelog entry for release workflow and desktop packaging fixes

## Verification
- ./scripts/ci.sh check
- python3 -m json.tool app/package.json >/dev/null
- python3 -m json.tool app/src-tauri/tauri.conf.json >/dev/null

After merge, tag and push `v0.3.1` from the merged master commit.
