### PR TITLE
feat(class-viewer): collapsible method/field outline pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Method outline pane in the class viewer** — when a class is selected, a collapsible right-hand panel lists its methods and fields with visibility glyphs (`+`/`#`/`-`/`~`), the first annotation, and the source line. Click jumps the source pane to the matching line and flashes it briefly. New `class_outline` Tauri command + `/api/class_outline` HTTP endpoint reuse the same data shape as the existing MCP `class_outline` tool, so what the user sees and what the LLM sees are exactly aligned. Open/closed state persists in `localStorage`. First step toward the "annotated source" / code-level maps captured in #64.
+
 ## [0.3.1] — 2026-05-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3141,6 +3141,7 @@ dependencies = [
  "projectmind-framework-spring",
  "projectmind-lang-java",
  "projectmind-lang-rust",
+ "projectmind-plugin-api",
  "rand 0.8.6",
  "serde",
  "serde_json",

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -29,10 +29,10 @@ use projectmind_core::walkthrough::{
 };
 use projectmind_core::{diagram, Engine, Repository};
 use projectmind_framework_lombok::LombokPlugin;
-use projectmind_plugin_api::{Class, Visibility};
 use projectmind_framework_spring::SpringPlugin;
 use projectmind_lang_java::JavaPlugin;
 use projectmind_lang_rust::RustPlugin;
+use projectmind_plugin_api::{Class, Visibility};
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, State};
 use tauri_plugin_opener::OpenerExt;

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -29,6 +29,7 @@ use projectmind_core::walkthrough::{
 };
 use projectmind_core::{diagram, Engine, Repository};
 use projectmind_framework_lombok::LombokPlugin;
+use projectmind_plugin_api::{Class, Visibility};
 use projectmind_framework_spring::SpringPlugin;
 use projectmind_lang_java::JavaPlugin;
 use projectmind_lang_rust::RustPlugin;
@@ -107,6 +108,44 @@ pub struct ClassDetails {
     pub line_start: u32,
     pub line_end: u32,
     pub source: String,
+}
+
+/// Structural outline of a class — methods, fields, annotations, no source.
+/// Used by the GUI's `ClassViewer` to render a side-panel with click-to-jump
+/// navigation. The same data is exposed via the `class_outline` MCP tool.
+#[derive(Debug, Serialize)]
+pub struct ClassOutline {
+    pub fqn: String,
+    pub name: String,
+    pub kind: String,
+    pub visibility: String,
+    pub line_start: u32,
+    pub line_end: u32,
+    pub stereotypes: Vec<String>,
+    pub annotations: Vec<String>,
+    pub methods: Vec<MethodOutline>,
+    pub fields: Vec<FieldOutline>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MethodOutline {
+    pub name: String,
+    pub visibility: String,
+    pub is_static: bool,
+    pub line_start: u32,
+    pub line_end: u32,
+    pub annotations: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FieldOutline {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub type_text: String,
+    pub visibility: String,
+    pub is_static: bool,
+    pub line: u32,
+    pub annotations: Vec<String>,
 }
 
 /// Tauri command: open a repository.
@@ -232,6 +271,18 @@ fn show_class(fqn: String, state: State<'_, Arc<AppState>>) -> Result<ClassDetai
         line_end: class.line_end,
         source,
     })
+}
+
+#[tauri::command]
+fn class_outline(fqn: String, state: State<'_, Arc<AppState>>) -> Result<ClassOutline, String> {
+    let guard = state.repo.read();
+    let repo = guard
+        .as_ref()
+        .ok_or_else(|| "no repository open".to_string())?;
+    let (_module, class) = repo
+        .find_class(&fqn)
+        .ok_or_else(|| format!("class not found: {fqn}"))?;
+    Ok(build_class_outline(class))
 }
 
 #[tauri::command]
@@ -486,6 +537,59 @@ fn list_module_files(
     ))
 }
 
+/// Render a [`Visibility`] enum as the lowercase string the frontend expects
+/// (`"public"`, `"protected"`, `"package"`, `"private"`). Matches the rendering
+/// the MCP `class_outline` tool uses, so MCP and GUI stay in sync.
+fn visibility_str(v: Visibility) -> String {
+    match v {
+        Visibility::Public => "public",
+        Visibility::Protected => "protected",
+        Visibility::PackagePrivate => "package",
+        Visibility::Private => "private",
+    }
+    .to_string()
+}
+
+/// Build a [`ClassOutline`] from a parsed [`Class`]. Pure data shaping — no
+/// I/O, no source reading. Reused by the Tauri command and (in `browser-host`)
+/// by the HTTP endpoint serving the same payload.
+fn build_class_outline(class: &Class) -> ClassOutline {
+    ClassOutline {
+        fqn: class.fqn.clone(),
+        name: class.name.clone(),
+        kind: format!("{:?}", class.kind).to_lowercase(),
+        visibility: visibility_str(class.visibility),
+        line_start: class.line_start,
+        line_end: class.line_end,
+        stereotypes: class.stereotypes.clone(),
+        annotations: class.annotations.iter().map(|a| a.name.clone()).collect(),
+        methods: class
+            .methods
+            .iter()
+            .map(|m| MethodOutline {
+                name: m.name.clone(),
+                visibility: visibility_str(m.visibility),
+                is_static: m.is_static,
+                line_start: m.line_start,
+                line_end: m.line_end,
+                annotations: m.annotations.iter().map(|a| a.name.clone()).collect(),
+            })
+            .collect(),
+        fields: class
+            .fields
+            .iter()
+            .map(|f| FieldOutline {
+                name: f.name.clone(),
+                type_text: f.type_text.clone(),
+                visibility: visibility_str(f.visibility),
+                is_static: f.is_static,
+                line: f.line,
+                annotations: f.annotations.iter().map(|a| a.name.clone()).collect(),
+            })
+            .collect(),
+    }
+}
+
 /// Best-effort publish: GUI tells the MCP/cooperating processes about its state.
 fn publish_state(payload: UiState) {
     if let Err(err) = state::write(payload) {
@@ -578,6 +682,7 @@ pub fn run() {
             list_classes,
             list_modules,
             show_class,
+            class_outline,
             list_changes_since,
             show_diagram,
             show_diff,

--- a/app/src/components/ClassViewer.svelte
+++ b/app/src/components/ClassViewer.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
-  import type { ClassEntry } from '../lib/api';
+  import { onMount } from 'svelte';
+  import type { ClassEntry, ClassOutline, MethodOutline, FieldOutline } from '../lib/api';
+  import { classOutline as fetchOutline } from '../lib/api';
   import { createShiftWheelZoom } from '../lib/shiftWheelZoom';
+  import { t } from '../lib/i18n';
 
   export let klass: ClassEntry;
   export let source: string;
@@ -20,6 +23,97 @@
 
   // Shift + wheel zoom, persisted under the per-component key.
   const { zoom, action: zoomAction } = createShiftWheelZoom('projectmind.classviewer.zoom');
+
+  // ----- Outline panel -----------------------------------------------------
+
+  // The outline ships methods + fields without source so it's cheap to fetch
+  // every time the selected class changes. Backend uses the same data path
+  // as the `class_outline` MCP tool, so what the GUI shows here is exactly
+  // what the LLM sees.
+  let outline: ClassOutline | null = null;
+  let outlineFqn: string | null = null;
+  // Persist the panel's open/closed state across class switches and reloads.
+  const OUTLINE_KEY = 'projectmind.classviewer.outlineOpen';
+  let outlineOpen = readOutlineOpen();
+  let sourceEl: HTMLPreElement | null = null;
+  let lastFlash: number | null = null;
+
+  function readOutlineOpen(): boolean {
+    try {
+      const v = localStorage.getItem(OUTLINE_KEY);
+      // Default to *open* — the panel exists to be discovered.
+      return v === null ? true : v === '1';
+    } catch {
+      return true;
+    }
+  }
+
+  function writeOutlineOpen(v: boolean) {
+    try {
+      localStorage.setItem(OUTLINE_KEY, v ? '1' : '0');
+    } catch {
+      // ignore
+    }
+  }
+
+  function toggleOutline() {
+    outlineOpen = !outlineOpen;
+    writeOutlineOpen(outlineOpen);
+  }
+
+  // Whenever the selected class changes, refetch its outline. We dedupe by
+  // fqn so re-renders that don't actually change the class don't re-fire.
+  $: if (klass && klass.fqn !== outlineFqn) {
+    outlineFqn = klass.fqn;
+    outline = null;
+    void loadOutline(klass.fqn);
+  }
+
+  async function loadOutline(fqn: string) {
+    try {
+      const o = await fetchOutline(fqn);
+      // Race guard: discard if the user clicked another class meanwhile.
+      if (outlineFqn === fqn) outline = o;
+    } catch (err) {
+      // Non-fatal — the class viewer is still useful without the outline.
+      console.warn('class_outline failed:', err);
+      if (outlineFqn === fqn) outline = null;
+    }
+  }
+
+  function jumpToLine(line: number) {
+    if (!sourceEl) return;
+    const target = sourceEl.querySelector<HTMLElement>(`[data-line-no="${line}"]`);
+    if (!target) return;
+    target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    // Brief flash so the eye finds the row even when the surrounding code
+    // looks similar. Reuses the .flash style already in this component.
+    if (lastFlash !== null) clearTimeout(lastFlash);
+    target.classList.add('flash');
+    lastFlash = window.setTimeout(() => {
+      target.classList.remove('flash');
+      lastFlash = null;
+    }, 1200);
+  }
+
+  function visibilityGlyph(v: MethodOutline['visibility'] | FieldOutline['visibility']): string {
+    switch (v) {
+      case 'public':
+        return '+';
+      case 'protected':
+        return '#';
+      case 'private':
+        return '-';
+      default:
+        return '~';
+    }
+  }
+
+  onMount(() => {
+    return () => {
+      if (lastFlash !== null) clearTimeout(lastFlash);
+    };
+  });
 </script>
 
 <div class="root" use:zoomAction style="font-size: {$zoom}em;">
@@ -35,18 +129,90 @@
       {#if meta}
         <span class="file">{meta.file}:{meta.line_start}–{meta.line_end}</span>
       {/if}
+      <button
+        type="button"
+        class="outline-toggle"
+        class:active={outlineOpen}
+        on:click={toggleOutline}
+        title={outlineOpen ? $t('outline.hide') : $t('outline.show')}
+        aria-label={outlineOpen ? $t('outline.hide') : $t('outline.show')}
+        aria-pressed={outlineOpen}
+      >
+        ☰
+      </button>
     </div>
   </div>
 
-  <pre class="source"><code>{#each lines as line, i (i)}{@const lineNo = i + 1}<span
-        class="line"
-        data-line-no={lineNo}
-        class:highlight={highlightRanges.length === 0 &&
-          lineNo >= defaultFrom &&
-          lineNo <= defaultTo}
-        class:wt-highlight={highlightRanges.length > 0 && inWalkthroughRange(lineNo)}
-      ><span class="lineno">{lineNo}</span><span class="content">{line}</span>
+  <div class="body" class:has-outline={outlineOpen}>
+    <pre class="source" bind:this={sourceEl}><code>{#each lines as line, i (i)}{@const lineNo = i + 1}<span
+          class="line"
+          data-line-no={lineNo}
+          class:highlight={highlightRanges.length === 0 &&
+            lineNo >= defaultFrom &&
+            lineNo <= defaultTo}
+          class:wt-highlight={highlightRanges.length > 0 && inWalkthroughRange(lineNo)}
+        ><span class="lineno">{lineNo}</span><span class="content">{line}</span>
 </span>{/each}</code></pre>
+
+    {#if outlineOpen}
+      <aside class="outline" aria-label={$t('outline.title')}>
+        {#if outline === null}
+          <div class="outline-placeholder">…</div>
+        {:else if outline.methods.length === 0 && outline.fields.length === 0}
+          <div class="outline-placeholder">{$t('outline.empty')}</div>
+        {:else}
+          {#if outline.methods.length > 0}
+            <div class="outline-section">
+              <h3>{$t('outline.methods')} <span class="count">{outline.methods.length}</span></h3>
+              <ul>
+                {#each outline.methods as m (m.name + ':' + m.line_start)}
+                  <li>
+                    <button
+                      type="button"
+                      class="outline-row"
+                      on:click={() => jumpToLine(m.line_start)}
+                      title={`${m.visibility}${m.is_static ? ' static' : ''} ${m.name} · L${m.line_start}-${m.line_end}`}
+                    >
+                      <span class="vis">{visibilityGlyph(m.visibility)}</span>
+                      <span class="name">{m.name}{m.is_static ? '·s' : ''}</span>
+                      {#if m.annotations.length > 0}
+                        <span class="anno">@{m.annotations[0]}{m.annotations.length > 1 ? `+${m.annotations.length - 1}` : ''}</span>
+                      {/if}
+                      <span class="line-no">{m.line_start}</span>
+                    </button>
+                  </li>
+                {/each}
+              </ul>
+            </div>
+          {/if}
+          {#if outline.fields.length > 0}
+            <div class="outline-section">
+              <h3>{$t('outline.fields')} <span class="count">{outline.fields.length}</span></h3>
+              <ul>
+                {#each outline.fields as f (f.name + ':' + f.line)}
+                  <li>
+                    <button
+                      type="button"
+                      class="outline-row"
+                      on:click={() => jumpToLine(f.line)}
+                      title={`${f.visibility}${f.is_static ? ' static' : ''} ${f.name}: ${f.type} · L${f.line}`}
+                    >
+                      <span class="vis">{visibilityGlyph(f.visibility)}</span>
+                      <span class="name">{f.name}</span>
+                      {#if f.type}
+                        <span class="ftype">{f.type}</span>
+                      {/if}
+                      <span class="line-no">{f.line}</span>
+                    </button>
+                  </li>
+                {/each}
+              </ul>
+            </div>
+          {/if}
+        {/if}
+      </aside>
+    {/if}
+  </div>
 </div>
 
 <style>
@@ -94,6 +260,39 @@
     color: var(--fg-2);
   }
 
+  .outline-toggle {
+    margin-left: 4px;
+    padding: 3px 8px;
+    background: var(--bg-2);
+    border: 1px solid var(--bg-3);
+    border-radius: 4px;
+    color: var(--fg-1);
+    font-size: 12px;
+    line-height: 1;
+    cursor: pointer;
+  }
+  .outline-toggle:hover {
+    background: var(--bg-3);
+  }
+  .outline-toggle.active {
+    border-color: var(--accent-2);
+    color: var(--accent-2);
+  }
+
+  /* Source pane spans the full body until the outline is opened, at which
+     point a fixed-width column is reserved on the right. */
+  .body {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 12px;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+  }
+  .body.has-outline {
+    grid-template-columns: minmax(0, 1fr) 240px;
+  }
+
   .source {
     background: var(--bg-1);
     border: 1px solid var(--bg-3);
@@ -106,7 +305,6 @@
     line-height: 1.55;
     margin: 0;
     overflow: auto;
-    flex: 1;
     min-height: 0;
   }
 
@@ -144,5 +342,108 @@
 
   .content {
     white-space: pre;
+  }
+
+  /* ----- Outline pane -------------------------------------------------- */
+
+  .outline {
+    background: var(--bg-1);
+    border: 1px solid var(--bg-3);
+    border-radius: var(--radius-md);
+    overflow: auto;
+    padding: 8px 6px;
+    font-size: 0.78em;
+    min-height: 0;
+  }
+
+  .outline-section + .outline-section {
+    margin-top: 12px;
+    padding-top: 10px;
+    border-top: 1px solid var(--bg-3);
+  }
+
+  .outline h3 {
+    margin: 0 6px 6px;
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--fg-2);
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+  .outline h3 .count {
+    font-family: var(--mono);
+    font-weight: 400;
+    color: var(--fg-2);
+  }
+
+  .outline ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .outline-row {
+    width: 100%;
+    display: grid;
+    grid-template-columns: 14px minmax(0, 1fr) auto auto;
+    align-items: baseline;
+    gap: 6px;
+    padding: 4px 6px;
+    background: transparent;
+    border: 0;
+    border-radius: 3px;
+    color: inherit;
+    text-align: left;
+    font: inherit;
+    font-family: var(--mono);
+    cursor: pointer;
+  }
+  .outline-row:hover {
+    background: var(--bg-2);
+  }
+  .outline-row:focus-visible {
+    outline: 2px solid var(--accent-2);
+    outline-offset: -2px;
+  }
+
+  .outline-row .vis {
+    color: var(--fg-2);
+    text-align: center;
+  }
+  .outline-row .name {
+    color: var(--fg-0);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .outline-row .anno {
+    font-size: 10px;
+    color: var(--accent-2);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 80px;
+  }
+  .outline-row .ftype {
+    font-size: 10px;
+    color: var(--fg-2);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 80px;
+  }
+  .outline-row .line-no {
+    color: var(--fg-2);
+    font-size: 10px;
+  }
+
+  .outline-placeholder {
+    padding: 12px;
+    color: var(--fg-2);
+    font-style: italic;
+    text-align: center;
   }
 </style>

--- a/app/src/i18n/de.json
+++ b/app/src/i18n/de.json
@@ -102,5 +102,11 @@
   "mcp.toast.file": "MCP hat Datei geöffnet",
   "mcp.toast.class": "MCP hat Klasse geöffnet",
   "mcp.toast.view": "MCP hat Ansicht gewechselt",
-  "mcp.toast.stop": "MCP-Sync stoppen"
+  "mcp.toast.stop": "MCP-Sync stoppen",
+  "outline.title": "Übersicht",
+  "outline.methods": "Methoden",
+  "outline.fields": "Felder",
+  "outline.empty": "Keine Methoden oder Felder",
+  "outline.show": "Übersicht einblenden",
+  "outline.hide": "Übersicht ausblenden"
 }

--- a/app/src/i18n/en.json
+++ b/app/src/i18n/en.json
@@ -102,5 +102,11 @@
   "mcp.toast.file": "MCP opened file",
   "mcp.toast.class": "MCP opened class",
   "mcp.toast.view": "MCP switched view",
-  "mcp.toast.stop": "Stop following MCP"
+  "mcp.toast.stop": "Stop following MCP",
+  "outline.title": "Outline",
+  "outline.methods": "Methods",
+  "outline.fields": "Fields",
+  "outline.empty": "No methods or fields",
+  "outline.show": "Show outline",
+  "outline.hide": "Hide outline"
 }

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -135,6 +135,42 @@ export async function showClass(
   return invoke('show_class', { fqn });
 }
 
+export interface MethodOutline {
+  name: string;
+  visibility: 'public' | 'protected' | 'package' | 'private';
+  is_static: boolean;
+  line_start: number;
+  line_end: number;
+  annotations: string[];
+}
+
+export interface FieldOutline {
+  name: string;
+  type: string;
+  visibility: 'public' | 'protected' | 'package' | 'private';
+  is_static: boolean;
+  line: number;
+  annotations: string[];
+}
+
+export interface ClassOutline {
+  fqn: string;
+  name: string;
+  kind: string;
+  visibility: 'public' | 'protected' | 'package' | 'private';
+  line_start: number;
+  line_end: number;
+  stereotypes: string[];
+  annotations: string[];
+  methods: MethodOutline[];
+  fields: FieldOutline[];
+}
+
+export async function classOutline(fqn: string): Promise<ClassOutline> {
+  if (!isTauriRuntime()) return api<ClassOutline>(`/api/class_outline${query({ fqn })}`);
+  return invoke<ClassOutline>('class_outline', { fqn });
+}
+
 export async function listChangesSince(reference: string, to?: string): Promise<ChangedFile[]> {
   if (!isTauriRuntime()) {
     return api<ChangedFile[]>(`/api/list_changes_since${query({ reference, to })}`);

--- a/crates/browser-host/Cargo.toml
+++ b/crates/browser-host/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 projectmind-core = { workspace = true }
+projectmind-plugin-api = { workspace = true }
 projectmind-lang-java = { path = "../../plugins/lang-java", version = "0.3.1" }
 projectmind-lang-rust = { path = "../../plugins/lang-rust", version = "0.3.1" }
 projectmind-framework-spring = { path = "../../plugins/framework-spring", version = "0.3.1" }

--- a/crates/browser-host/src/lib.rs
+++ b/crates/browser-host/src/lib.rs
@@ -400,6 +400,10 @@ fn route_api(
             let fqn = required(query, "fqn")?;
             Ok(serde_json::to_value(show_class_locked(&guard, fqn)?)?)
         }
+        ("GET", "/api/class_outline") => {
+            let fqn = required(query, "fqn")?;
+            Ok(serde_json::to_value(class_outline_locked(&guard, fqn)?)?)
+        }
         ("GET", "/api/list_changes_since") => {
             let reference = required(query, "reference")?;
             let to = query.get("to").map(String::as_str);
@@ -626,6 +630,68 @@ pub struct ClassDetails {
     pub source: String,
 }
 
+/// Structural outline of a class — methods, fields, annotations, no source.
+/// Mirror of the Tauri-side `ClassOutline`. Used by the GUI's `ClassViewer`
+/// to render a side-panel with click-to-jump navigation.
+#[derive(Debug, Serialize)]
+pub struct ClassOutline {
+    /// Fully-qualified class name.
+    pub fqn: String,
+    /// Simple class name.
+    pub name: String,
+    /// Lowercase class kind (`class`, `interface`, `enum`, `record`, `annotation`).
+    pub kind: String,
+    /// Visibility (`public`, `protected`, `package`, `private`).
+    pub visibility: String,
+    /// First line of the class definition (1-based).
+    pub line_start: u32,
+    /// Last line of the class definition.
+    pub line_end: u32,
+    /// Stereotypes attached by framework plugins.
+    pub stereotypes: Vec<String>,
+    /// Class-level annotation names (without `@`).
+    pub annotations: Vec<String>,
+    /// Methods, in source order.
+    pub methods: Vec<MethodOutline>,
+    /// Fields, in source order.
+    pub fields: Vec<FieldOutline>,
+}
+
+/// One method entry in the class outline.
+#[derive(Debug, Serialize)]
+pub struct MethodOutline {
+    /// Method name.
+    pub name: String,
+    /// Visibility.
+    pub visibility: String,
+    /// Whether the method is static.
+    pub is_static: bool,
+    /// 1-based start line of the method definition.
+    pub line_start: u32,
+    /// 1-based end line of the method definition.
+    pub line_end: u32,
+    /// Annotation names.
+    pub annotations: Vec<String>,
+}
+
+/// One field entry in the class outline.
+#[derive(Debug, Serialize)]
+pub struct FieldOutline {
+    /// Field name.
+    pub name: String,
+    /// Field type as written in source.
+    #[serde(rename = "type")]
+    pub type_text: String,
+    /// Visibility.
+    pub visibility: String,
+    /// Whether the field is static.
+    pub is_static: bool,
+    /// 1-based line where the field is declared.
+    pub line: u32,
+    /// Annotation names.
+    pub annotations: Vec<String>,
+}
+
 fn open_repo_locked(state: &mut HostState, path: &Path) -> anyhow::Result<RepoSummary> {
     if !path.is_absolute() {
         anyhow::bail!("repo path must be absolute: {}", path.display());
@@ -728,6 +794,62 @@ fn show_class_locked(state: &HostState, fqn: &str) -> anyhow::Result<ClassDetail
         line_end: class.line_end,
         source,
     })
+}
+
+fn class_outline_locked(state: &HostState, fqn: &str) -> anyhow::Result<ClassOutline> {
+    let repo = repo(state)?;
+    let (_module, class) = repo
+        .find_class(fqn)
+        .ok_or_else(|| anyhow::anyhow!("class not found: {fqn}"))?;
+    Ok(build_class_outline(class))
+}
+
+fn visibility_str(v: projectmind_plugin_api::Visibility) -> String {
+    use projectmind_plugin_api::Visibility;
+    match v {
+        Visibility::Public => "public",
+        Visibility::Protected => "protected",
+        Visibility::PackagePrivate => "package",
+        Visibility::Private => "private",
+    }
+    .to_string()
+}
+
+fn build_class_outline(class: &projectmind_plugin_api::Class) -> ClassOutline {
+    ClassOutline {
+        fqn: class.fqn.clone(),
+        name: class.name.clone(),
+        kind: format!("{:?}", class.kind).to_lowercase(),
+        visibility: visibility_str(class.visibility),
+        line_start: class.line_start,
+        line_end: class.line_end,
+        stereotypes: class.stereotypes.clone(),
+        annotations: class.annotations.iter().map(|a| a.name.clone()).collect(),
+        methods: class
+            .methods
+            .iter()
+            .map(|m| MethodOutline {
+                name: m.name.clone(),
+                visibility: visibility_str(m.visibility),
+                is_static: m.is_static,
+                line_start: m.line_start,
+                line_end: m.line_end,
+                annotations: m.annotations.iter().map(|a| a.name.clone()).collect(),
+            })
+            .collect(),
+        fields: class
+            .fields
+            .iter()
+            .map(|f| FieldOutline {
+                name: f.name.clone(),
+                type_text: f.type_text.clone(),
+                visibility: visibility_str(f.visibility),
+                is_static: f.is_static,
+                line: f.line,
+                annotations: f.annotations.iter().map(|a| a.name.clone()).collect(),
+            })
+            .collect(),
+    }
 }
 
 fn read_file_text_locked(state: &HostState, path: &Path) -> anyhow::Result<String> {


### PR DESCRIPTION
## Summary

First sighting from the visualization catalogue ([#61](https://github.com/Plaintext-Gmbh/projectmind/issues/61), [#64](https://github.com/Plaintext-Gmbh/projectmind/issues/64)): a small "annotated source" affordance that lights up immediately for any parsed class. The data already powers the \`class_outline\` MCP tool; this PR exposes it to the GUI so the LLM and the user see the **same shape**.

## What you see

When you click a class in the Files tab, a new collapsible right-hand panel lists its methods and fields:

\`\`\`
┌─────────────────────────────────────────────┬──────────────────────┐
│   1  package com.example;                   │  METHODS         12  │
│   2                                         │  + create        L42 │
│   3  @Service                               │  + findAll       L51 │
│  …                                          │  + findById      L60 │
│                                             │  - validate      L74 │
│                                             │  FIELDS           3  │
│                                             │  - repo: Repo    L18 │
│                                             │  - log: Logger   L19 │
└─────────────────────────────────────────────┴──────────────────────┘
\`\`\`

- **Visibility glyphs** — \`+\` public · \`#\` protected · \`-\` private · \`~\` package
- **First annotation** rendered as a chip (\`@Transactional\`, \`@Override\`, …) with a "+N" hint when there's more
- **Click** any row → smooth-scroll the source pane to the matching line + brief flash so the eye finds it
- **Toggle button** in the class header (\`☰\`); state persists per browser via \`localStorage\`
- Static methods/fields get a \`·s\` suffix
- Field type rendered next to the name when known

## Why this is a good first step

Issue #64 lists *Annotated source*, *Call graph (per method)*, *Inheritance tree*, *DTO map* as code-level visualisations. The outline pane is the smallest of those that immediately:
- works for **every parsed language** (Java + Rust today)
- shows the user something **new and useful** without needing new data extraction
- aligns the GUI with what \`class_outline\` already returns over MCP — no divergence between LLM- and user-facing data

## Architecture

- \`crates/browser-host\`: new \`ClassOutline\` / \`MethodOutline\` / \`FieldOutline\` structs, \`/api/class_outline?fqn=…\` route, shared \`build_class_outline\` helper. Visibility enum serialised the same way the MCP tool does (\`public\` / \`protected\` / \`package\` / \`private\`).
- \`app/src-tauri\`: matching \`class_outline\` Tauri command, registered in \`generate_handler!\`. Same struct shape so Tauri and HTTP callers receive identical JSON.
- \`app/src/lib/api.ts\`: \`classOutline(fqn)\` wrapper plus the matching TypeScript types.
- \`ClassViewer.svelte\`: outline pane with race-guarded fetch (cancel on class switch), \`scrollIntoView\` jump, flash animation reusing the existing \`.flash\` style.
- i18n: \`outline.title\`, \`outline.methods\`, \`outline.fields\`, \`outline.empty\`, \`outline.show\`, \`outline.hide\` in EN + DE. Other languages fall through to EN via the existing dictionary fallback.

## Test plan

- [x] \`cargo build --workspace\`
- [x] \`cargo test --workspace\` — all green
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`pnpm check\` — 0 errors, only the pre-existing unused-CSS warning
- [x] \`pnpm build\` — frontend builds
- [ ] **Manual smoke test recommended**: open a Java repo, click a class with methods, verify the outline appears, click a method → source jumps + flashes; toggle button hides/shows; state persists across class switches.

Refs #61, #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)