### PR TITLE
feat(nav): browser-style ← / → history with keyboard shortcuts

### DIFF
--- a/app/src/App.svelte
+++ b/app/src/App.svelte
@@ -50,6 +50,9 @@
   import { resizable } from './lib/resizable';
   import { t, language, setLanguage, languages } from './lib/i18n';
   import { loadComponent } from './lib/lazyLoad';
+  import * as nav from './lib/navigation';
+  import { canBack as nav_canBack, canForward as nav_canForward } from './lib/navigation';
+  import type { HistoryEntry, DiagramKind, FolderMapLayout } from './lib/navigation';
   const lazyDiagramView = () =>
     loadComponent('DiagramView', () => import('./components/DiagramView.svelte'));
   const lazyFileView = () =>
@@ -124,6 +127,144 @@
 
   let diagramKind: 'bean-graph' | 'package-tree' | 'folder-map' = 'bean-graph';
   let folderMapLayout: 'hierarchy' | 'solar' | 'td' = 'solar';
+
+  // ----- Navigation history -------------------------------------------------
+  // Browser-style ←/→ over every user-visible state change. The reactive
+  // block at the bottom builds a HistoryEntry from the current store + local
+  // values; `nav.push` is a no-op when the new entry equals the current one,
+  // so re-clicking the same class doesn't pollute the back trail.
+  function buildHistoryEntry(): HistoryEntry {
+    const fv = get(fileView);
+    const wt = get(walkthroughCursor);
+    const dv = get(diffViewRef);
+    const cls = get(selectedClass);
+    return {
+      viewMode: get(viewMode),
+      selectedFqn: cls?.fqn ?? null,
+      filePath: fv?.path ?? null,
+      fileAnchor: fv?.anchor ?? null,
+      diagramKind: diagramKind as DiagramKind,
+      folderMapLayout: folderMapLayout as FolderMapLayout,
+      diffRef: dv?.reference ?? null,
+      diffTo: dv?.to ?? null,
+      walkthroughId: wt?.id ?? null,
+      walkthroughStep: wt?.step ?? null,
+      moduleFilter: get(moduleFilter),
+      packageFilter: get(packageFilter),
+      stereotypeFilter: get(stereotypeFilter),
+      fileKindFilter: get(fileKindFilter),
+      label: describeEntry(get(viewMode), cls?.fqn ?? null, fv?.path ?? null, diagramKind),
+      ts: Date.now(),
+    };
+  }
+
+  function describeEntry(
+    mode: string,
+    fqn: string | null,
+    file: string | null,
+    diagram: string,
+  ): string {
+    if (mode === 'classes' && fqn) return `Class · ${fqn.split('.').pop()}`;
+    if (mode === 'classes') return 'Code';
+    if (mode === 'diagram') return `Diagram · ${diagram}`;
+    if (mode === 'md') return 'Markdown';
+    if (mode === 'html') return 'HTML';
+    if (mode === 'file' && file) return `File · ${file.split('/').pop()}`;
+    if (mode === 'pdf' && file) return `PDF · ${file.split('/').pop()}`;
+    if (mode === 'image' && file) return `Image · ${file.split('/').pop()}`;
+    if (mode === 'diff') return 'Diff';
+    if (mode === 'walkthrough') return 'Walkthrough';
+    return mode;
+  }
+
+  function applyHistoryEntry(entry: HistoryEntry) {
+    // Order matters: filters first, then containers, then leaves —
+    // mirrors how the GUI normally settles on a new view.
+    moduleFilter.set(entry.moduleFilter);
+    packageFilter.set(entry.packageFilter);
+    stereotypeFilter.set(entry.stereotypeFilter);
+    fileKindFilter.set(entry.fileKindFilter);
+    if (entry.diagramKind) diagramKind = entry.diagramKind;
+    if (entry.folderMapLayout) folderMapLayout = entry.folderMapLayout;
+    if (entry.selectedFqn) {
+      const match = get(classes).find((c) => c.fqn === entry.selectedFqn);
+      selectedClass.set(match ?? null);
+    } else {
+      selectedClass.set(null);
+    }
+    if (entry.filePath) {
+      fileView.update((cur) => ({
+        path: entry.filePath as string,
+        anchor: entry.fileAnchor ?? null,
+        nonce: (cur?.nonce ?? 0) + 1,
+      }));
+    } else {
+      fileView.set(null);
+    }
+    if (entry.walkthroughId !== null && entry.walkthroughStep !== null) {
+      walkthroughCursor.update((cur) => ({
+        id: entry.walkthroughId as string,
+        step: entry.walkthroughStep as number,
+        nonce: (cur?.nonce ?? 0) + 1,
+      }));
+    } else {
+      walkthroughCursor.set(null);
+    }
+    if (entry.diffRef) {
+      diffViewRef.set({ reference: entry.diffRef, to: entry.diffTo });
+    } else {
+      diffViewRef.set(null);
+    }
+    viewMode.set(entry.viewMode as never);
+  }
+
+  function navBack() {
+    nav.back(applyHistoryEntry);
+  }
+
+  function navForward() {
+    nav.forward(applyHistoryEntry);
+  }
+
+  function onNavKey(ev: KeyboardEvent) {
+    // Don't steal navigation keys while the user is typing in a field.
+    const t = ev.target as HTMLElement | null;
+    if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+    // ⌘[ / ⌘] (macOS) and Alt+← / Alt+→ (everywhere else) match Finder + browser conventions.
+    const cmdOrAlt = ev.metaKey || ev.altKey;
+    if (cmdOrAlt && (ev.key === '[' || ev.key === 'ArrowLeft')) {
+      ev.preventDefault();
+      navBack();
+    } else if (cmdOrAlt && (ev.key === ']' || ev.key === 'ArrowRight')) {
+      ev.preventDefault();
+      navForward();
+    }
+  }
+  // Reactive auto-push: any time a navigation-relevant store / local var
+  // changes, snapshot it and hand it to nav.push. nav.push de-dupes against
+  // the current entry, so re-clicks of the same class don't fill the back
+  // trail with copies of the same state. nav.push is also a no-op while a
+  // back/forward navigation is being applied.
+  $: void _autoPushOnNavChange(
+    $viewMode,
+    $selectedClass,
+    $fileView,
+    diagramKind,
+    folderMapLayout,
+    $diffViewRef,
+    $walkthroughCursor,
+    $moduleFilter,
+    $packageFilter,
+    $stereotypeFilter,
+    $fileKindFilter,
+    $repo,
+  );
+  function _autoPushOnNavChange(..._: unknown[]) {
+    if (!get(repo)) return; // no repo → nothing to remember
+    nav.push(buildHistoryEntry());
+  }
+  // ----- end navigation history ---------------------------------------------
+
   let classSource = '';
   let classMeta: { file: string; line_start: number; line_end: number } | null = null;
   let loading = false;
@@ -541,6 +682,7 @@
   }
 
   onMount(async () => {
+    window.addEventListener('keydown', onNavKey);
     browserMode = !isTauriRuntime();
     if (browserMode && !browserToken()) {
       browserAuthorized = false;
@@ -606,6 +748,7 @@
   });
 
   onDestroy(() => {
+    window.removeEventListener('keydown', onNavKey);
     unlistenState?.();
     unlistenDragDrop?.();
     if (statePoll) clearInterval(statePoll);
@@ -622,6 +765,22 @@
 <main>
   <header>
     <div class="brand">
+      <div class="nav-history" role="group" aria-label="Navigation history">
+        <button
+          class="nav-arrow"
+          disabled={!$nav_canBack || !$repo}
+          on:click={navBack}
+          title="{$t('nav.back') || 'Back'} (⌘[ / Alt+←)"
+          aria-label={$t('nav.back') || 'Back'}
+        >‹</button>
+        <button
+          class="nav-arrow"
+          disabled={!$nav_canForward || !$repo}
+          on:click={navForward}
+          title="{$t('nav.forward') || 'Forward'} (⌘] / Alt+→)"
+          aria-label={$t('nav.forward') || 'Forward'}
+        >›</button>
+      </div>
       <img class="logo" src="/logo.png" alt="ProjectMind" />
       <span class="title">ProjectMind</span>
       {#if $repo}
@@ -978,6 +1137,38 @@
     display: flex;
     align-items: center;
     gap: 12px;
+  }
+
+  .nav-history {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    margin-right: 4px;
+  }
+  .nav-arrow {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    background: transparent;
+    border: 1px solid var(--bg-3);
+    border-radius: 6px;
+    color: var(--fg-1);
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+    transition: background 80ms ease, color 80ms ease, border-color 80ms ease;
+  }
+  .nav-arrow:hover:not(:disabled) {
+    background: var(--bg-2);
+    border-color: var(--accent-2);
+    color: var(--accent-2);
+  }
+  .nav-arrow:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
   }
 
   .logo {

--- a/app/src/i18n/de.json
+++ b/app/src/i18n/de.json
@@ -12,6 +12,8 @@
   "nav.followingMcp": "folgt MCP",
   "nav.followingMcpTitle": "Die GUI folgt einem MCP-View-Intent. Klicke auf einen Tab, um manuell weiterzumachen.",
   "nav.openRepo": "Repo öffnen",
+  "nav.back": "Zurück",
+  "nav.forward": "Vorwärts",
   "theme.toggle": "Theme umschalten",
   "theme.switchTo": "Zu {mode} wechseln",
   "theme.light": "hell",

--- a/app/src/i18n/en.json
+++ b/app/src/i18n/en.json
@@ -12,6 +12,8 @@
   "nav.followingMcp": "following MCP",
   "nav.followingMcpTitle": "GUI is following an MCP-issued view intent. Click any tab to continue manually.",
   "nav.openRepo": "Open repo",
+  "nav.back": "Back",
+  "nav.forward": "Forward",
   "theme.toggle": "Toggle theme",
   "theme.switchTo": "Switch to {mode} mode",
   "theme.light": "light",

--- a/app/src/i18n/es.json
+++ b/app/src/i18n/es.json
@@ -12,6 +12,8 @@
   "nav.followingMcp": "siguiendo MCP",
   "nav.followingMcpTitle": "La GUI sigue una intencion MCP. Haz clic en una pestana para continuar manualmente.",
   "nav.openRepo": "Abrir repo",
+  "nav.back": "Atrás",
+  "nav.forward": "Adelante",
   "theme.toggle": "Cambiar tema",
   "theme.switchTo": "Cambiar a modo {mode}",
   "theme.light": "claro",

--- a/app/src/i18n/fr.json
+++ b/app/src/i18n/fr.json
@@ -12,6 +12,8 @@
   "nav.followingMcp": "suit MCP",
   "nav.followingMcpTitle": "L'interface suit une intention MCP. Cliquez sur un onglet pour continuer manuellement.",
   "nav.openRepo": "Ouvrir un depot",
+  "nav.back": "Retour",
+  "nav.forward": "Suivant",
   "theme.toggle": "Basculer le theme",
   "theme.switchTo": "Passer au mode {mode}",
   "theme.light": "clair",

--- a/app/src/i18n/it.json
+++ b/app/src/i18n/it.json
@@ -12,6 +12,8 @@
   "nav.followingMcp": "segue MCP",
   "nav.followingMcpTitle": "La GUI segue un'intenzione MCP. Fai clic su una scheda per continuare manualmente.",
   "nav.openRepo": "Apri repo",
+  "nav.back": "Indietro",
+  "nav.forward": "Avanti",
   "theme.toggle": "Cambia tema",
   "theme.switchTo": "Passa alla modalita {mode}",
   "theme.light": "chiara",

--- a/app/src/lib/navigation.ts
+++ b/app/src/lib/navigation.ts
@@ -1,0 +1,178 @@
+/// Browser-style back/forward navigation history.
+///
+/// Snapshots the user-visible navigation state (viewMode, selected
+/// class, open file, diagram kind, filters) and stacks them up so
+/// ←/→ buttons + keyboard shortcuts can step the user through their
+/// own footprints exactly the way a browser does.
+///
+/// Deliberately tiny on its own: the wiring lives in App.svelte where
+/// the relevant stores are already imported. This module only owns
+/// the data structure, the de-dup rule, the persistence, and the
+/// forward-truncation semantics.
+
+import { derived, get, writable, type Writable } from 'svelte/store';
+
+export type DiagramKind = 'bean-graph' | 'package-tree' | 'folder-map';
+export type FolderMapLayout = 'hierarchy' | 'solar' | 'td';
+
+/// Frozen snapshot of every navigation-relevant piece of state.
+/// Plain JSON values only — no live store references — so it can
+/// round-trip through localStorage without surprises.
+export interface HistoryEntry {
+  viewMode: string;
+  selectedFqn: string | null;
+  filePath: string | null;
+  fileAnchor: string | null;
+  diagramKind: DiagramKind | null;
+  folderMapLayout: FolderMapLayout | null;
+  diffRef: string | null;
+  diffTo: string | null;
+  walkthroughId: string | null;
+  walkthroughStep: number | null;
+  moduleFilter: string | null;
+  packageFilter: string | null;
+  stereotypeFilter: string | null;
+  fileKindFilter: string | null;
+  /// Short human-readable hint (e.g. "Class · UserService", "File ·
+  /// docs/SYNC.md") for the back-button title attribute and the
+  /// optional history dropdown.
+  label: string;
+  /// Wall-clock time of the push, for the dropdown's relative-age
+  /// rendering ("2 min ago").
+  ts: number;
+}
+
+interface HistoryState {
+  entries: HistoryEntry[];
+  cursor: number;
+}
+
+const STORAGE_KEY = 'projectmind.history.v1';
+const MAX_ENTRIES = 200;
+
+function loadFromStorage(): HistoryState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { entries: [], cursor: -1 };
+    const parsed = JSON.parse(raw) as Partial<HistoryState>;
+    if (!Array.isArray(parsed.entries) || typeof parsed.cursor !== 'number') {
+      return { entries: [], cursor: -1 };
+    }
+    const cursor = Math.max(-1, Math.min(parsed.entries.length - 1, parsed.cursor));
+    return { entries: parsed.entries as HistoryEntry[], cursor };
+  } catch {
+    return { entries: [], cursor: -1 };
+  }
+}
+
+function saveToStorage(state: HistoryState) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // localStorage unavailable / quota exceeded — silently ignore;
+    // history just won't survive reloads.
+  }
+}
+
+/// True iff two entries describe the same user-visible state. Used
+/// to drop redundant pushes ("user clicked the same class twice").
+function entriesEqual(a: HistoryEntry, b: HistoryEntry): boolean {
+  return (
+    a.viewMode === b.viewMode &&
+    a.selectedFqn === b.selectedFqn &&
+    a.filePath === b.filePath &&
+    a.fileAnchor === b.fileAnchor &&
+    a.diagramKind === b.diagramKind &&
+    a.folderMapLayout === b.folderMapLayout &&
+    a.diffRef === b.diffRef &&
+    a.diffTo === b.diffTo &&
+    a.walkthroughId === b.walkthroughId &&
+    a.walkthroughStep === b.walkthroughStep &&
+    a.moduleFilter === b.moduleFilter &&
+    a.packageFilter === b.packageFilter &&
+    a.stereotypeFilter === b.stereotypeFilter &&
+    a.fileKindFilter === b.fileKindFilter
+  );
+}
+
+const inner: Writable<HistoryState> = writable(loadFromStorage());
+
+/// Read-only view of the history state. Use `canBack` / `canForward`
+/// for button-enable logic and `entries` / `cursor` for the optional
+/// history dropdown.
+export const history = { subscribe: inner.subscribe };
+
+export const canBack = derived(inner, ($h) => $h.cursor > 0);
+export const canForward = derived(inner, ($h) => $h.cursor < $h.entries.length - 1);
+
+/// Set to `true` while we're applying a back/forward navigation, so
+/// the corresponding store-change subscribers in App.svelte know not
+/// to push the resulting state as a new entry. Exposed to the outer
+/// world as a function to keep the implementation detail tight.
+let applying = false;
+export function isApplyingHistory(): boolean {
+  return applying;
+}
+
+/// Push a new entry onto the history stack. De-dupes against the
+/// current entry so re-clicks don't fill the back button with copies
+/// of the same state. Truncates forward history (standard browser
+/// behaviour: navigating after a Back drops the redo trail).
+export function push(entry: HistoryEntry) {
+  if (applying) return;
+  inner.update((h) => {
+    const current = h.cursor >= 0 ? h.entries[h.cursor] : null;
+    if (current && entriesEqual(current, entry)) return h;
+    const head = h.entries.slice(0, h.cursor + 1);
+    head.push(entry);
+    // Cap the trail so localStorage doesn't grow without bound.
+    const trimmed = head.length > MAX_ENTRIES ? head.slice(-MAX_ENTRIES) : head;
+    const next: HistoryState = { entries: trimmed, cursor: trimmed.length - 1 };
+    saveToStorage(next);
+    return next;
+  });
+}
+
+/// Step one entry backwards and call `apply` with the entry that
+/// becomes current. The caller is responsible for translating an
+/// entry back into store writes.
+export function back(apply: (entry: HistoryEntry) => void): boolean {
+  const h = get(inner);
+  if (h.cursor <= 0) return false;
+  const cursor = h.cursor - 1;
+  applying = true;
+  try {
+    apply(h.entries[cursor]);
+  } finally {
+    applying = false;
+  }
+  const next = { ...h, cursor };
+  inner.set(next);
+  saveToStorage(next);
+  return true;
+}
+
+/// Step one entry forwards. Counterpart to `back`.
+export function forward(apply: (entry: HistoryEntry) => void): boolean {
+  const h = get(inner);
+  if (h.cursor >= h.entries.length - 1) return false;
+  const cursor = h.cursor + 1;
+  applying = true;
+  try {
+    apply(h.entries[cursor]);
+  } finally {
+    applying = false;
+  }
+  const next = { ...h, cursor };
+  inner.set(next);
+  saveToStorage(next);
+  return true;
+}
+
+/// Wipe the history. Wired to the future "Clear history" menu entry;
+/// also useful from the dev console.
+export function clear() {
+  const next: HistoryState = { entries: [], cursor: -1 };
+  inner.set(next);
+  saveToStorage(next);
+}


### PR DESCRIPTION
Plant + implementiert das vom User angefragte Navigations-Konzept: jede sichtbare State-Änderung (viewMode, selektierte Klasse, geöffnete Datei, Diagram-Typ, Filter, Walkthrough, Diff-Refs) wird als History-Eintrag aufgezeichnet. Browser-typisch ←/→ zwischen den Einträgen blättern.

## Konzept

- **Auto-push** auf jede navigations-relevante Änderung
- **De-dup**: identische konsekutive Einträge werden zusammengefasst (re-click auf dieselbe Klasse füllt den Back-Trail nicht mit Kopien)
- **Truncate-forward**: nach Back + neue Navigation wird der Forward-Trail verworfen (Standard-Browser-Verhalten)
- **Persistierung** in `localStorage` unter `projectmind.history.v1` (max 200 Einträge)
- **Tolerant** gegenüber fehlendem localStorage (Safari Private Mode etc.) — fällt still in In-Memory-Modus

## UI

- Zwei Pfeil-Buttons \`‹\` \`›\` direkt neben dem Logo, kompakt (28×28 px)
- Disabled state mit 35% Opacity wenn nichts zum Zurück/Vorwärts da ist
- Tooltips zeigen Shortcut + i18n-Label
- Shortcuts: **⌘[ / ⌘]** (macOS) und **Alt+← / Alt+→** (alle Plattformen)
- Inputs + Textareas absorbieren die Keys nicht (carve-out)

## Test plan

- [x] svelte-check clean, cargo check clean, pnpm build clean
- [ ] CI grün
- [ ] Manuell: Klasse öffnen → Diagram → Markdown → ← / ← / ← landet wieder bei Klasse; → spielt vorwärts
- [ ] Reload: History bleibt erhalten
- [ ] Filter-Klicks (Modul / Stereotype / Kind) sind ebenfalls ←/→-fähig

🤖 Generated with [Claude Code](https://claude.com/claude-code)