### PR TITLE
feat(ui): keyboard cheatsheet overlay (`?`)

### DIFF
--- a/app/src/App.svelte
+++ b/app/src/App.svelte
@@ -43,6 +43,7 @@
   import ImageView from './components/ImageView.svelte';
   import PdfView from './components/PdfView.svelte';
   import DiffView from './components/DiffView.svelte';
+  import KeyboardHelp from './components/KeyboardHelp.svelte';
   // Heavy components — pulled in dynamically the first time the user
   // visits the matching tab. mermaid (~640 KB) and marked (~40 KB) ride
   // along with DiagramView / FileView / WalkthroughView etc., so keeping
@@ -226,6 +227,8 @@
     nav.forward(applyHistoryEntry);
   }
 
+  let kbdHelpOpen = false;
+
   function onNavKey(ev: KeyboardEvent) {
     // Don't steal navigation keys while the user is typing in a field.
     const t = ev.target as HTMLElement | null;
@@ -238,6 +241,12 @@
     } else if (cmdOrAlt && (ev.key === ']' || ev.key === 'ArrowRight')) {
       ev.preventDefault();
       navForward();
+    } else if (ev.key === '?' && !ev.metaKey && !ev.ctrlKey) {
+      // Bare `?` (Shift+/) opens the keyboard cheatsheet — same shortcut as
+      // every modern web app + Slack + GitHub. The carve-out above keeps it
+      // from firing while the user is typing inside an input or textarea.
+      ev.preventDefault();
+      kbdHelpOpen = true;
     }
   }
   // Reactive auto-push: any time a navigation-relevant store / local var
@@ -858,6 +867,12 @@
       >
         {theme === 'dark' ? '☀' : '☾'}
       </button>
+      <button
+        class="kbd-help-toggle"
+        on:click={() => (kbdHelpOpen = true)}
+        title="{$t('keyboard.title')} (?)"
+        aria-label={$t('keyboard.title')}
+      >?</button>
     </nav>
   </header>
 
@@ -1114,6 +1129,8 @@
       </div>
     </div>
   {/if}
+
+  <KeyboardHelp bind:open={kbdHelpOpen} />
 </main>
 
 <style>
@@ -1291,6 +1308,16 @@
     padding: 6px 0;
     text-align: center;
     font-size: 15px;
+    line-height: 1;
+  }
+
+  .kbd-help-toggle {
+    width: 28px;
+    padding: 6px 0;
+    text-align: center;
+    font-family: var(--mono);
+    font-size: 13px;
+    font-weight: 600;
     line-height: 1;
   }
 

--- a/app/src/components/KeyboardHelp.svelte
+++ b/app/src/components/KeyboardHelp.svelte
@@ -1,0 +1,217 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { t } from '../lib/i18n';
+
+  export let open = false;
+
+  // Detect macOS so we render ⌘ on Mac and Ctrl/Alt elsewhere. Tauri's
+  // navigator.platform is reliable here.
+  const IS_MAC =
+    typeof navigator !== 'undefined' && /Mac|iPad|iPhone|iPod/.test(navigator.platform);
+
+  type Section = { title: string; rows: { keys: string[]; desc: string }[] };
+
+  $: sections = [
+    {
+      title: $t('keyboard.section.navigation'),
+      rows: [
+        {
+          keys: IS_MAC ? ['⌘', '['] : ['Alt', '←'],
+          desc: $t('keyboard.row.back'),
+        },
+        {
+          keys: IS_MAC ? ['⌘', ']'] : ['Alt', '→'],
+          desc: $t('keyboard.row.forward'),
+        },
+        {
+          keys: ['?'],
+          desc: $t('keyboard.row.help'),
+        },
+        {
+          keys: ['Esc'],
+          desc: $t('keyboard.row.close'),
+        },
+      ],
+    },
+    {
+      title: $t('keyboard.section.zoom'),
+      rows: [
+        {
+          keys: ['Shift', '⇕'],
+          desc: $t('keyboard.row.zoom'),
+        },
+      ],
+    },
+  ] as Section[];
+
+  function close() {
+    open = false;
+  }
+
+  function onKey(ev: KeyboardEvent) {
+    if (!open) return;
+    if (ev.key === 'Escape') {
+      ev.preventDefault();
+      close();
+    }
+  }
+
+  onMount(() => window.addEventListener('keydown', onKey));
+  onDestroy(() => window.removeEventListener('keydown', onKey));
+</script>
+
+{#if open}
+  <div
+    class="backdrop"
+    role="presentation"
+    on:click={close}
+    on:keydown={(e) => e.key === 'Escape' && close()}
+  >
+    <div
+      class="dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="kbd-help-title"
+      tabindex="-1"
+      on:click|stopPropagation
+      on:keydown|stopPropagation
+    >
+      <header>
+        <h2 id="kbd-help-title">{$t('keyboard.title')}</h2>
+        <button class="close" on:click={close} aria-label={$t('keyboard.row.close')}>×</button>
+      </header>
+      <div class="body">
+        {#each sections as section (section.title)}
+          <section>
+            <h3>{section.title}</h3>
+            <dl>
+              {#each section.rows as row, i (i)}
+                <dt>
+                  {#each row.keys as key, j (j)}
+                    {#if j > 0}<span class="plus">+</span>{/if}
+                    <kbd>{key}</kbd>
+                  {/each}
+                </dt>
+                <dd>{row.desc}</dd>
+              {/each}
+            </dl>
+          </section>
+        {/each}
+      </div>
+      <footer>
+        <span class="hint">{$t('keyboard.hint')}</span>
+      </footer>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    backdrop-filter: blur(2px);
+  }
+  .dialog {
+    background: var(--bg-0);
+    color: var(--fg-0);
+    border: 1px solid var(--bg-3);
+    border-radius: 10px;
+    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5);
+    width: min(560px, 92vw);
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--bg-3);
+    background: var(--bg-1);
+  }
+  header h2 {
+    margin: 0;
+    font-size: 15px;
+    font-weight: 600;
+  }
+  .close {
+    background: transparent;
+    border: 0;
+    color: var(--fg-2);
+    font-size: 22px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 4px;
+  }
+  .close:hover {
+    color: var(--fg-0);
+  }
+  .body {
+    padding: 16px 20px 8px;
+    overflow-y: auto;
+  }
+  section {
+    margin-bottom: 16px;
+  }
+  section h3 {
+    margin: 0 0 8px;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--fg-2);
+    font-weight: 600;
+  }
+  dl {
+    display: grid;
+    grid-template-columns: minmax(120px, max-content) 1fr;
+    column-gap: 24px;
+    row-gap: 8px;
+    margin: 0;
+  }
+  dt {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+  dd {
+    margin: 0;
+    color: var(--fg-1);
+    font-size: 13px;
+    align-self: center;
+  }
+  kbd {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 22px;
+    height: 22px;
+    padding: 0 6px;
+    background: var(--bg-2);
+    border: 1px solid var(--bg-3);
+    border-radius: 4px;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--fg-0);
+    box-shadow: 0 1px 0 var(--bg-3);
+  }
+  .plus {
+    color: var(--fg-2);
+    font-size: 11px;
+  }
+  footer {
+    border-top: 1px solid var(--bg-3);
+    padding: 10px 18px;
+    background: var(--bg-1);
+  }
+  .hint {
+    font-size: 11px;
+    color: var(--fg-2);
+  }
+</style>

--- a/app/src/i18n/de.json
+++ b/app/src/i18n/de.json
@@ -87,5 +87,14 @@
   "diff.kind": "diff",
   "diff.workingTree": "Arbeitsbaum",
   "diff.computing": "Diff wird berechnet...",
-  "diff.noChanges": "Keine Änderungen."
+  "diff.noChanges": "Keine Änderungen.",
+  "keyboard.title": "Tastaturkürzel",
+  "keyboard.section.navigation": "Navigation",
+  "keyboard.section.zoom": "Zoom",
+  "keyboard.row.back": "Zurück",
+  "keyboard.row.forward": "Vorwärts",
+  "keyboard.row.help": "Diese Übersicht anzeigen",
+  "keyboard.row.close": "Schliessen",
+  "keyboard.row.zoom": "Zoom rein / raus (alle Viewer)",
+  "keyboard.hint": "Hinweis: in Eingabefeldern sind diese Shortcuts deaktiviert."
 }

--- a/app/src/i18n/en.json
+++ b/app/src/i18n/en.json
@@ -87,5 +87,14 @@
   "diff.kind": "diff",
   "diff.workingTree": "working tree",
   "diff.computing": "Computing diff...",
-  "diff.noChanges": "No changes."
+  "diff.noChanges": "No changes.",
+  "keyboard.title": "Keyboard shortcuts",
+  "keyboard.section.navigation": "Navigation",
+  "keyboard.section.zoom": "Zoom",
+  "keyboard.row.back": "Back",
+  "keyboard.row.forward": "Forward",
+  "keyboard.row.help": "Show this cheatsheet",
+  "keyboard.row.close": "Close",
+  "keyboard.row.zoom": "Zoom in / out (any viewer)",
+  "keyboard.hint": "Tip: typing inside a text field disables these shortcuts."
 }

--- a/app/src/i18n/es.json
+++ b/app/src/i18n/es.json
@@ -87,5 +87,14 @@
   "diff.kind": "diff",
   "diff.workingTree": "arbol de trabajo",
   "diff.computing": "Calculando diff...",
-  "diff.noChanges": "Sin cambios."
+  "diff.noChanges": "Sin cambios.",
+  "keyboard.title": "Atajos de teclado",
+  "keyboard.section.navigation": "Navegación",
+  "keyboard.section.zoom": "Zoom",
+  "keyboard.row.back": "Atrás",
+  "keyboard.row.forward": "Adelante",
+  "keyboard.row.help": "Mostrar este resumen",
+  "keyboard.row.close": "Cerrar",
+  "keyboard.row.zoom": "Acercar / alejar (cualquier visor)",
+  "keyboard.hint": "Consejo: estos atajos se desactivan dentro de campos de texto."
 }

--- a/app/src/i18n/fr.json
+++ b/app/src/i18n/fr.json
@@ -87,5 +87,14 @@
   "diff.kind": "diff",
   "diff.workingTree": "arbre de travail",
   "diff.computing": "Calcul du diff...",
-  "diff.noChanges": "Aucun changement."
+  "diff.noChanges": "Aucun changement.",
+  "keyboard.title": "Raccourcis clavier",
+  "keyboard.section.navigation": "Navigation",
+  "keyboard.section.zoom": "Zoom",
+  "keyboard.row.back": "Retour",
+  "keyboard.row.forward": "Suivant",
+  "keyboard.row.help": "Afficher cet aide-mémoire",
+  "keyboard.row.close": "Fermer",
+  "keyboard.row.zoom": "Zoom avant / arrière (tous les visualiseurs)",
+  "keyboard.hint": "Astuce : ces raccourcis sont désactivés dans les champs de saisie."
 }

--- a/app/src/i18n/it.json
+++ b/app/src/i18n/it.json
@@ -87,5 +87,14 @@
   "diff.kind": "diff",
   "diff.workingTree": "working tree",
   "diff.computing": "Calcolo diff...",
-  "diff.noChanges": "Nessuna modifica."
+  "diff.noChanges": "Nessuna modifica.",
+  "keyboard.title": "Scorciatoie da tastiera",
+  "keyboard.section.navigation": "Navigazione",
+  "keyboard.section.zoom": "Zoom",
+  "keyboard.row.back": "Indietro",
+  "keyboard.row.forward": "Avanti",
+  "keyboard.row.help": "Mostra questo riepilogo",
+  "keyboard.row.close": "Chiudi",
+  "keyboard.row.zoom": "Zoom avanti / indietro (qualsiasi viewer)",
+  "keyboard.hint": "Suggerimento: queste scorciatoie sono disabilitate nei campi di testo."
 }


### PR DESCRIPTION
Discoverability für die ←/→-Shortcuts aus #75. `?` öffnet ein Modal mit allen Tastatur-Befehlen, gruppiert nach Zweck. Macht aus den unsichtbaren Shortcuts entdeckbare Funktionen.

* `KeyboardHelp.svelte` neu — Modal-Overlay, ⌘-Icons auf macOS, Alt+Arrow sonst
* `App.svelte` lauscht auf bare `?` (Shift+/) — gleiche Input-Carve-out wie die Nav-Keys
* Header bekommt einen `?`-Button neben Theme/Lang als sichtbares Affordance
* i18n in allen 5 Sprachen

🤖 Generated with [Claude Code](https://claude.com/claude-code)