### PR TITLE
feat(welcome): recent-repos list on the welcome screen

### DIFF
--- a/app/src/App.svelte
+++ b/app/src/App.svelte
@@ -55,6 +55,8 @@
   import * as nav from './lib/navigation';
   import { canBack as nav_canBack, canForward as nav_canForward } from './lib/navigation';
   import type { HistoryEntry, DiagramKind, FolderMapLayout } from './lib/navigation';
+  import * as recents from './lib/recentRepos';
+  import { recentRepos } from './lib/recentRepos';
   const lazyDiagramView = () =>
     loadComponent('DiagramView', () => import('./components/DiagramView.svelte'));
   const lazyFileView = () =>
@@ -484,6 +486,7 @@
       fileKindFilter.set(null);
       packageFilter.set(null);
       classSource = '';
+      recents.record(summary.root, summary.classes, summary.modules);
     } catch (err) {
       if (opts.silent) {
         // Re-throw so caller can decide whether to show or swallow.
@@ -910,6 +913,28 @@
         <p class="claim">{$t('welcome.tagline')}</p>
         <p class="by">{$t('welcome.by')}</p>
         <button on:click={pickAndOpen}>{$t('welcome.openButton')}</button>
+        {#if !browserMode && $recentRepos.length > 0}
+          <div class="recents">
+            <h2>{$t('welcome.recent') || 'Recent'}</h2>
+            <ul>
+              {#each $recentRepos as r (r.path)}
+                <li>
+                  <button class="recent-row" on:click={() => load(r.path)} title={r.path}>
+                    <span class="recent-name">{r.name}</span>
+                    <span class="recent-meta">{r.classes} · {r.modules}m</span>
+                    <span class="recent-path">{r.path}</span>
+                  </button>
+                  <button
+                    class="recent-x"
+                    on:click|stopPropagation={() => recents.forget(r.path)}
+                    title={$t('welcome.forget') || 'Remove from list'}
+                    aria-label="Remove {r.name} from recent list"
+                  >×</button>
+                </li>
+              {/each}
+            </ul>
+          </div>
+        {/if}
         <p class="hint">
           {#if browserMode}
             {$t('welcome.hint.browser')}
@@ -1395,6 +1420,90 @@
     margin: 0 0 20px;
     color: var(--fg-2);
     font-size: 12px;
+  }
+
+  .recents {
+    margin: 24px auto 8px;
+    max-width: 540px;
+    text-align: left;
+  }
+  .recents h2 {
+    margin: 0 0 8px;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--fg-2);
+    font-weight: 600;
+  }
+  .recents ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .recents li {
+    display: flex;
+    align-items: stretch;
+    gap: 4px;
+  }
+  .recent-row {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto auto;
+    gap: 2px 8px;
+    flex: 1;
+    text-align: left;
+    background: var(--bg-1);
+    border: 1px solid var(--bg-3);
+    border-left: 3px solid transparent;
+    border-radius: 4px;
+    padding: 8px 12px;
+    color: var(--fg-1);
+    cursor: pointer;
+    font: inherit;
+    transition: background 80ms ease, border-left-color 80ms ease;
+  }
+  .recent-row:hover {
+    background: var(--bg-2);
+    border-left-color: var(--accent-2);
+  }
+  .recent-name {
+    font-family: var(--mono);
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--fg-0);
+  }
+  .recent-meta {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    color: var(--fg-2);
+    align-self: center;
+  }
+  .recent-path {
+    grid-column: 1 / -1;
+    font-family: var(--mono);
+    font-size: 10.5px;
+    color: var(--fg-2);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .recent-x {
+    background: transparent;
+    border: 1px solid var(--bg-3);
+    border-radius: 4px;
+    color: var(--fg-2);
+    cursor: pointer;
+    width: 28px;
+    font-size: 16px;
+    line-height: 1;
+    padding: 0;
+  }
+  .recent-x:hover {
+    color: var(--accent-2);
+    border-color: var(--accent-2);
   }
 
   .welcome button {

--- a/app/src/i18n/de.json
+++ b/app/src/i18n/de.json
@@ -96,5 +96,7 @@
   "keyboard.row.help": "Diese Übersicht anzeigen",
   "keyboard.row.close": "Schliessen",
   "keyboard.row.zoom": "Zoom rein / raus (alle Viewer)",
-  "keyboard.hint": "Hinweis: in Eingabefeldern sind diese Shortcuts deaktiviert."
+  "keyboard.hint": "Hinweis: in Eingabefeldern sind diese Shortcuts deaktiviert.",
+  "welcome.recent": "Zuletzt geöffnet",
+  "welcome.forget": "Aus Liste entfernen"
 }

--- a/app/src/i18n/en.json
+++ b/app/src/i18n/en.json
@@ -96,5 +96,7 @@
   "keyboard.row.help": "Show this cheatsheet",
   "keyboard.row.close": "Close",
   "keyboard.row.zoom": "Zoom in / out (any viewer)",
-  "keyboard.hint": "Tip: typing inside a text field disables these shortcuts."
+  "keyboard.hint": "Tip: typing inside a text field disables these shortcuts.",
+  "welcome.recent": "Recent",
+  "welcome.forget": "Remove from list"
 }

--- a/app/src/i18n/es.json
+++ b/app/src/i18n/es.json
@@ -96,5 +96,7 @@
   "keyboard.row.help": "Mostrar este resumen",
   "keyboard.row.close": "Cerrar",
   "keyboard.row.zoom": "Acercar / alejar (cualquier visor)",
-  "keyboard.hint": "Consejo: estos atajos se desactivan dentro de campos de texto."
+  "keyboard.hint": "Consejo: estos atajos se desactivan dentro de campos de texto.",
+  "welcome.recent": "Recientes",
+  "welcome.forget": "Quitar de la lista"
 }

--- a/app/src/i18n/fr.json
+++ b/app/src/i18n/fr.json
@@ -96,5 +96,7 @@
   "keyboard.row.help": "Afficher cet aide-mémoire",
   "keyboard.row.close": "Fermer",
   "keyboard.row.zoom": "Zoom avant / arrière (tous les visualiseurs)",
-  "keyboard.hint": "Astuce : ces raccourcis sont désactivés dans les champs de saisie."
+  "keyboard.hint": "Astuce : ces raccourcis sont désactivés dans les champs de saisie.",
+  "welcome.recent": "Récemment ouverts",
+  "welcome.forget": "Retirer de la liste"
 }

--- a/app/src/i18n/it.json
+++ b/app/src/i18n/it.json
@@ -96,5 +96,7 @@
   "keyboard.row.help": "Mostra questo riepilogo",
   "keyboard.row.close": "Chiudi",
   "keyboard.row.zoom": "Zoom avanti / indietro (qualsiasi viewer)",
-  "keyboard.hint": "Suggerimento: queste scorciatoie sono disabilitate nei campi di testo."
+  "keyboard.hint": "Suggerimento: queste scorciatoie sono disabilitate nei campi di testo.",
+  "welcome.recent": "Aperti di recente",
+  "welcome.forget": "Rimuovi dalla lista"
 }

--- a/app/src/lib/recentRepos.ts
+++ b/app/src/lib/recentRepos.ts
@@ -1,0 +1,89 @@
+/// "Recent repositories" list shown on the welcome screen.
+///
+/// Persists the last N repos the user opened so re-opening one is a click
+/// instead of a directory-picker round-trip. Pure localStorage, no
+/// backend, no MCP — by design we forget across machines.
+
+import { writable, type Writable } from 'svelte/store';
+
+export interface RecentRepo {
+  /// Absolute path to the repo root.
+  path: string;
+  /// Display name — usually `basename(path)`, but stored so we don't have
+  /// to re-derive it.
+  name: string;
+  /// Cached counters from `RepoSummary` so the welcome cards show
+  /// "12 modules · 87 classes" without reopening every entry.
+  classes: number;
+  modules: number;
+  /// Wall-clock millis of the most recent open.
+  openedAt: number;
+}
+
+const STORAGE_KEY = 'projectmind.recent_repos.v1';
+const MAX = 10;
+
+function load(): RecentRepo[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (e): e is RecentRepo =>
+        e &&
+        typeof e.path === 'string' &&
+        typeof e.name === 'string' &&
+        typeof e.openedAt === 'number',
+    );
+  } catch {
+    return [];
+  }
+}
+
+function save(list: RecentRepo[]) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+  } catch {
+    // ignore — storage unavailable / quota exceeded
+  }
+}
+
+const inner: Writable<RecentRepo[]> = writable(load());
+
+/// Subscribable store for the welcome screen.
+export const recentRepos = { subscribe: inner.subscribe };
+
+function basename(p: string): string {
+  const idx = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'));
+  return idx === -1 ? p : p.slice(idx + 1);
+}
+
+/// Record a successful repo open. Move-to-front if the path is already in
+/// the list, otherwise prepend; trim to `MAX`.
+export function record(path: string, classes: number, modules: number) {
+  inner.update((list) => {
+    const filtered = list.filter((e) => e.path !== path);
+    const next: RecentRepo[] = [
+      { path, name: basename(path), classes, modules, openedAt: Date.now() },
+      ...filtered,
+    ].slice(0, MAX);
+    save(next);
+    return next;
+  });
+}
+
+/// Remove a single entry. Used by the welcome card's `×` affordance.
+export function forget(path: string) {
+  inner.update((list) => {
+    const next = list.filter((e) => e.path !== path);
+    save(next);
+    return next;
+  });
+}
+
+/// Clear all entries. Wired to a future "Clear recent" menu item.
+export function clear() {
+  inner.set([]);
+  save([]);
+}


### PR DESCRIPTION
Improvement #3: Welcome-Screen kennt die letzten 10 Repos. Re-Open ist ein Klick statt Browse-Dialog.

- `recentRepos.ts` persistiert in localStorage
- Card-Liste mit Name, Count, Path und × pro Eintrag
- Wird beim erfolgreichen `open_repo` automatisch aktualisiert
- Browser-Mode bekommt die Liste nicht (Pfade sind dort eh nicht stabil)
- i18n in allen 5 Sprachen

🤖 Generated with [Claude Code](https://claude.com/claude-code)