### PR TITLE
chore(security): turn on a Tauri CSP with diagrams.net whitelist

### DIFF
--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": null,
+      "csp": "default-src 'self' tauri: 'unsafe-inline' 'unsafe-eval' data: blob: ; img-src 'self' data: blob: tauri: asset: https: ; connect-src 'self' tauri: ipc: ws: wss: http://localhost:* http://127.0.0.1:* https://embed.diagrams.net ; frame-src https://embed.diagrams.net https://*.diagrams.net ; worker-src 'self' blob: ; object-src 'none' ; base-uri 'self'",
       "assetProtocol": {
         "enable": true,
         "scope": ["**"]


### PR DESCRIPTION
Improvement #7: Tauri CSP von `null` weg, mit drawio-iframe-Whitelist.

**Wins:**
- `frame-src https://embed.diagrams.net https://*.diagrams.net` — nur drawio darf reingeladen werden
- `object-src 'none'` — keine Flash/PDF-Embeds
- `base-uri 'self'` — keine `<base href>`-Hijacks
- `connect-src` whitelisted

Bewusst permissiv für `script-src` / `style-src` (Tauri+Svelte+Mermaid brauchen `'unsafe-inline'` + `'unsafe-eval'`). Strict-CSP-Tightening ist Follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)