### PR TITLE
feat(ui): MCP activity toast — show what the LLM just did

### DIFF
--- a/app/src/App.svelte
+++ b/app/src/App.svelte
@@ -45,6 +45,7 @@
   import DiffView from './components/DiffView.svelte';
   import KeyboardHelp from './components/KeyboardHelp.svelte';
   import StatusBar from './components/StatusBar.svelte';
+  import McpToast from './components/McpToast.svelte';
   // Heavy components — pulled in dynamically the first time the user
   // visits the matching tab. mermaid (~640 KB) and marked (~40 KB) ride
   // along with DiagramView / FileView / WalkthroughView etc., so keeping
@@ -1157,6 +1158,7 @@
   {/if}
 
   <KeyboardHelp bind:open={kbdHelpOpen} />
+  <McpToast />
   <StatusBar />
 </main>
 

--- a/app/src/components/McpToast.svelte
+++ b/app/src/components/McpToast.svelte
@@ -1,0 +1,203 @@
+<script lang="ts">
+  /// Transparency toast for MCP-driven view changes.
+  ///
+  /// When an MCP-aware client (Claude Code, ChatGPT, …) calls something
+  /// like `view_file` or `view_class`, the GUI quietly switches to that
+  /// view. The user can be left wondering "did Claude just do that?" —
+  /// especially when several actions land in a row. This toast surfaces
+  /// each MCP intent for 4 seconds at the bottom-right corner, with an
+  /// inline "stop following" button that cuts the GUI loose from the MCP
+  /// stream until the user explicitly re-engages.
+  ///
+  /// It's deliberately read-only: it does NOT block the view change.
+  /// Repo-scoping (`file_access::canonical_file_in_repo`) already
+  /// prevents the MCP from reaching files outside the open repo, so a
+  /// hard approval gate would be friction without a security win. A
+  /// dedicated approval workflow lives on the future-work list.
+
+  import { onMount, onDestroy } from 'svelte';
+  import { followingMcp, fileView, viewMode, selectedClass } from '../lib/store';
+  import { t } from '../lib/i18n';
+
+  type Toast = {
+    id: number;
+    label: string;
+    detail: string;
+    expiresAt: number;
+  };
+
+  const SHOW_FOR_MS = 4000;
+
+  let toasts: Toast[] = [];
+  let nextId = 1;
+  let interval: ReturnType<typeof setInterval> | null = null;
+
+  function basename(p: string | null | undefined): string {
+    if (!p) return '';
+    const idx = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'));
+    return idx === -1 ? p : p.slice(idx + 1);
+  }
+
+  function emit(label: string, detail: string) {
+    toasts = [
+      ...toasts.slice(-2), // keep at most 3 visible at a time
+      { id: nextId++, label, detail, expiresAt: Date.now() + SHOW_FOR_MS },
+    ];
+  }
+
+  function dismiss(id: number) {
+    toasts = toasts.filter((t) => t.id !== id);
+  }
+
+  function stopFollowing() {
+    followingMcp.set(false);
+    toasts = [];
+  }
+
+  // Whenever an MCP-driven view change lands, drop a toast. The watchers
+  // only fire while followingMcp is true; the user clicking any tab or
+  // the "stop following" button flips that flag and silences us.
+  let lastFile: string | null = null;
+  let lastClass: string | null = null;
+  let lastView: string | null = null;
+  $: if ($followingMcp && $fileView && $fileView.path !== lastFile) {
+    lastFile = $fileView.path;
+    emit($t('mcp.toast.file') || 'MCP opened file', basename($fileView.path));
+  }
+  $: if ($followingMcp && $selectedClass && $selectedClass.fqn !== lastClass) {
+    lastClass = $selectedClass.fqn;
+    emit($t('mcp.toast.class') || 'MCP opened class', $selectedClass.fqn);
+  }
+  $: if ($followingMcp && $viewMode !== lastView && $viewMode !== 'classes') {
+    lastView = $viewMode;
+    emit($t('mcp.toast.view') || 'MCP switched view', $viewMode);
+  }
+
+  onMount(() => {
+    interval = setInterval(() => {
+      const now = Date.now();
+      const next = toasts.filter((t) => t.expiresAt > now);
+      if (next.length !== toasts.length) toasts = next;
+    }, 500);
+  });
+  onDestroy(() => {
+    if (interval) clearInterval(interval);
+  });
+</script>
+
+{#if toasts.length > 0}
+  <aside class="stack" role="status" aria-live="polite">
+    {#each toasts as toast (toast.id)}
+      <div class="toast">
+        <span class="badge">MCP</span>
+        <div class="text">
+          <span class="label">{toast.label}</span>
+          <code class="detail">{toast.detail}</code>
+        </div>
+        <button
+          class="dismiss"
+          on:click={() => dismiss(toast.id)}
+          title={$t('keyboard.row.close') || 'Dismiss'}
+          aria-label="Dismiss"
+        >×</button>
+      </div>
+    {/each}
+    <button class="stop" on:click={stopFollowing}>
+      {$t('mcp.toast.stop') || 'Stop following MCP'}
+    </button>
+  </aside>
+{/if}
+
+<style>
+  .stack {
+    position: fixed;
+    right: 16px;
+    bottom: 40px; /* sit above the status bar */
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    z-index: 800;
+    max-width: 360px;
+  }
+  .toast {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 10px;
+    background: var(--bg-1);
+    border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--bg-3));
+    border-left: 3px solid var(--accent);
+    border-radius: 6px;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
+    font-size: 12px;
+    color: var(--fg-1);
+    animation: slide-in 180ms ease-out;
+  }
+  .badge {
+    background: color-mix(in srgb, var(--accent) 20%, var(--bg-2));
+    color: var(--accent);
+    border-radius: 4px;
+    padding: 2px 6px;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+  }
+  .text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+  .label {
+    color: var(--fg-2);
+    font-size: 10.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .detail {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--fg-0);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .dismiss {
+    background: transparent;
+    border: 0;
+    color: var(--fg-2);
+    cursor: pointer;
+    font-size: 14px;
+    line-height: 1;
+    padding: 0 2px;
+  }
+  .dismiss:hover {
+    color: var(--accent);
+  }
+  .stop {
+    align-self: flex-end;
+    background: var(--bg-2);
+    border: 1px solid var(--bg-3);
+    color: var(--fg-1);
+    padding: 4px 10px;
+    border-radius: 4px;
+    font: inherit;
+    font-size: 11px;
+    cursor: pointer;
+  }
+  .stop:hover {
+    border-color: var(--accent-2);
+    color: var(--accent-2);
+  }
+  @keyframes slide-in {
+    from {
+      transform: translateX(100%);
+      opacity: 0;
+    }
+    to {
+      transform: translateX(0);
+      opacity: 1;
+    }
+  }
+</style>

--- a/app/src/i18n/de.json
+++ b/app/src/i18n/de.json
@@ -98,5 +98,9 @@
   "keyboard.row.zoom": "Zoom rein / raus (alle Viewer)",
   "keyboard.hint": "Hinweis: in Eingabefeldern sind diese Shortcuts deaktiviert.",
   "welcome.recent": "Zuletzt geöffnet",
-  "welcome.forget": "Aus Liste entfernen"
+  "welcome.forget": "Aus Liste entfernen",
+  "mcp.toast.file": "MCP hat Datei geöffnet",
+  "mcp.toast.class": "MCP hat Klasse geöffnet",
+  "mcp.toast.view": "MCP hat Ansicht gewechselt",
+  "mcp.toast.stop": "MCP-Sync stoppen"
 }

--- a/app/src/i18n/en.json
+++ b/app/src/i18n/en.json
@@ -98,5 +98,9 @@
   "keyboard.row.zoom": "Zoom in / out (any viewer)",
   "keyboard.hint": "Tip: typing inside a text field disables these shortcuts.",
   "welcome.recent": "Recent",
-  "welcome.forget": "Remove from list"
+  "welcome.forget": "Remove from list",
+  "mcp.toast.file": "MCP opened file",
+  "mcp.toast.class": "MCP opened class",
+  "mcp.toast.view": "MCP switched view",
+  "mcp.toast.stop": "Stop following MCP"
 }

--- a/app/src/i18n/es.json
+++ b/app/src/i18n/es.json
@@ -98,5 +98,9 @@
   "keyboard.row.zoom": "Acercar / alejar (cualquier visor)",
   "keyboard.hint": "Consejo: estos atajos se desactivan dentro de campos de texto.",
   "welcome.recent": "Recientes",
-  "welcome.forget": "Quitar de la lista"
+  "welcome.forget": "Quitar de la lista",
+  "mcp.toast.file": "MCP abrió un archivo",
+  "mcp.toast.class": "MCP abrió una clase",
+  "mcp.toast.view": "MCP cambió de vista",
+  "mcp.toast.stop": "Dejar de seguir MCP"
 }

--- a/app/src/i18n/fr.json
+++ b/app/src/i18n/fr.json
@@ -98,5 +98,9 @@
   "keyboard.row.zoom": "Zoom avant / arrière (tous les visualiseurs)",
   "keyboard.hint": "Astuce : ces raccourcis sont désactivés dans les champs de saisie.",
   "welcome.recent": "Récemment ouverts",
-  "welcome.forget": "Retirer de la liste"
+  "welcome.forget": "Retirer de la liste",
+  "mcp.toast.file": "MCP a ouvert un fichier",
+  "mcp.toast.class": "MCP a ouvert une classe",
+  "mcp.toast.view": "MCP a changé de vue",
+  "mcp.toast.stop": "Arrêter le suivi MCP"
 }

--- a/app/src/i18n/it.json
+++ b/app/src/i18n/it.json
@@ -98,5 +98,9 @@
   "keyboard.row.zoom": "Zoom avanti / indietro (qualsiasi viewer)",
   "keyboard.hint": "Suggerimento: queste scorciatoie sono disabilitate nei campi di testo.",
   "welcome.recent": "Aperti di recente",
-  "welcome.forget": "Rimuovi dalla lista"
+  "welcome.forget": "Rimuovi dalla lista",
+  "mcp.toast.file": "MCP ha aperto un file",
+  "mcp.toast.class": "MCP ha aperto una classe",
+  "mcp.toast.view": "MCP ha cambiato vista",
+  "mcp.toast.stop": "Interrompi sincronizzazione MCP"
 }


### PR DESCRIPTION
Improvement #8 (lighter Variante): Bottom-right Toast für jede MCP-getriebene View-Änderung mit "Stop following MCP" Button. Volle Approval-Schleife wäre eine separate Epic-Arbeit.

- Toasts auto-fade nach 4s, max. 3 gestapelt
- Stop-following button schaltet `followingMcp` aus
- 5-Sprachen-i18n
- Read-only: blockt View-Change nicht, weil `file_access::canonical_file_in_repo` eh schon Paths ausserhalb des offenen Repos rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)