### PR TITLE
fix(mcp): single-instance guard so open_repo reuses the running window (#74)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3126,6 +3126,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "tauri-plugin-single-instance",
  "tracing",
  "tracing-subscriber",
 ]
@@ -4298,6 +4299,21 @@ dependencies = [
  "thiserror 2.0.18",
  "url",
  "windows",
+ "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
  "zbus",
 ]
 

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -39,3 +39,10 @@ tracing-subscriber = { workspace = true }
 [features]
 default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]
+
+# Desktop-only single-instance guard: a second `projectmind-app` started while
+# one is already running forwards its launch args to the existing instance and
+# then exits. Combined with the MCP-server heartbeat check this prevents the
+# `open_repo` "double window" bug (#74).
+[target.'cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))'.dependencies]
+tauri-plugin-single-instance = "2"

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -34,7 +34,7 @@ use projectmind_lang_java::JavaPlugin;
 use projectmind_lang_rust::RustPlugin;
 use projectmind_plugin_api::{Class, TypeRefKind, Visibility};
 use serde::Serialize;
-use tauri::{AppHandle, Emitter, State};
+use tauri::{AppHandle, Emitter, Manager, State};
 use tauri_plugin_opener::OpenerExt;
 
 /// Application state shared across Tauri command handlers.
@@ -725,7 +725,25 @@ fn spawn_state_watcher(handle: AppHandle) {
 pub fn run() {
     tracing_subscriber::fmt::try_init().ok();
     let state = Arc::new(AppState::new());
-    tauri::Builder::default()
+    let mut builder = tauri::Builder::default();
+    // Single-instance guard: when an `open -a ProjectMind.app` (or equivalent)
+    // fires while we're already running, the second process forwards its
+    // launch args here and exits. We focus the existing window so the user
+    // sees the running instance reacting instead of a stray new window.
+    // Belt-and-suspenders with the MCP heartbeat check in `launch::ensure_gui_running`.
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+    {
+        builder = builder.plugin(tauri_plugin_single_instance::init(
+            |app: &AppHandle, _args: Vec<String>, _cwd: String| {
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.unminimize();
+                    let _ = window.show();
+                    let _ = window.set_focus();
+                }
+            },
+        ));
+    }
+    builder
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .manage(state)


### PR DESCRIPTION
## Summary

Closes #74.

The MCP server already throttles its \`open -a\` launches with a heartbeat check (\`launch::ensure_gui_running\` / \`heartbeat::is_alive\`), but in practice a second \`projectmind-app\` window can still appear when an MCP-aware client calls \`open_repo\` while a GUI is running:

- the heartbeat is stale at the first request after a cold start,
- the MCP server and the running GUI resolve different cache dirs (sandboxed parent process vs. unsandboxed installed bundle),
- a race on launch where the heartbeat thread hasn't written its first sample yet.

This PR adds \`tauri-plugin-single-instance\` as the OS-level safety net. When a second \`projectmind-app\` starts while one is already running, the plugin forwards the launch args to the existing instance through a lock socket and exits the second process. The existing window then unminimises, shows, and grabs focus — the user sees the running GUI react to the MCP intent instead of a stray new window.

## Changes

- \`app/src-tauri/Cargo.toml\` — \`tauri-plugin-single-instance = \"2\"\`, scoped to desktop targets via a \`[target.'cfg(...)']\` block (no-op on mobile)
- \`app/src-tauri/src/lib.rs\` — register the plugin behind the same \`cfg\` gate; the callback unminimises and focuses the \`main\` window
- \`Cargo.lock\` — pulls \`tauri-plugin-single-instance v2.4.2\`

The pre-existing heartbeat check in the MCP server stays — together they form belt-and-suspenders: heartbeat avoids the redundant \`open -a\` in the common case, the plugin absorbs whatever still slips through.

## Test plan
- [ ] \`cargo check -p projectmind-app\` (clean — verified locally)
- [ ] \`cargo clippy -p projectmind-app\` (clean — verified locally)
- [ ] Manual: launch \`/Applications/ProjectMind.app\`, then call \`mcp__projectmind__open_repo\` from Claude Code → only one window should be visible after 1 s, and it should switch to the requested repo
- [ ] Manual: kill the running GUI, repeat \`open_repo\` — \`open -a\` should still launch the desktop app (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)