### PR TITLE
feat(layout): collapsible modules + files sidebars

### DIFF
--- a/app/src/App.svelte
+++ b/app/src/App.svelte
@@ -23,6 +23,8 @@
     walkthroughCursor,
     diffViewRef,
     followingMcp,
+    moduleSidebarVisible,
+    classSidebarVisible,
   } from './lib/store';
   import {
     openRepo,
@@ -948,19 +950,32 @@
       </div>
     </section>
   {:else if $viewMode === 'classes' || $viewMode === 'pdf' || $viewMode === 'image' || $viewMode === 'md' || $viewMode === 'html' || $viewMode === 'file'}
-    <section class="layout">
-      <ModuleSidebar />
-      <div
-        class="resizer"
-        use:resizable={{
-          storageKey: 'projectmind.layout.code.col1',
-          cssVar: '--code-col-1',
-          min: 140,
-          max: 480,
-          initial: 220,
-        }}
-        title="Drag to resize · double-click to reset"
-      ></div>
+    <section
+      class="layout"
+      class:modules-collapsed={!$moduleSidebarVisible}
+      class:files-collapsed={!$classSidebarVisible}
+    >
+      {#if $moduleSidebarVisible}
+        <ModuleSidebar />
+        <div
+          class="resizer"
+          use:resizable={{
+            storageKey: 'projectmind.layout.code.col1',
+            cssVar: '--code-col-1',
+            min: 140,
+            max: 480,
+            initial: 220,
+          }}
+          title="Drag to resize · double-click to reset"
+        ></div>
+      {:else}
+        <button
+          class="pane-rail"
+          on:click={() => moduleSidebarVisible.set(true)}
+          title={$t('layout.modules.show')}
+          aria-label={$t('layout.modules.show')}
+        >›</button>
+      {/if}
       {#if $viewMode === 'md'}
         <div class="files-fullspan">
           {#await lazyMarkdownIndex() then mod}
@@ -973,8 +988,21 @@
             <svelte:component this={mod.default} />
           {/await}
         </div>
+      {:else if !$classSidebarVisible}
+        <button
+          class="pane-rail"
+          on:click={() => classSidebarVisible.set(true)}
+          title={$t('layout.files.show')}
+          aria-label={$t('layout.files.show')}
+        >›</button>
       {:else}
         <aside class="sidebar">
+          <button
+            class="pane-collapse"
+            on:click={() => classSidebarVisible.set(false)}
+            title={$t('layout.files.hide')}
+            aria-label={$t('layout.files.hide')}
+          >‹</button>
           {#if $packageFilter !== null}
             <div class="path-bar">
               <span class="path-label">{$t('files.package.label')}</span>
@@ -1564,6 +1592,16 @@
     overflow: hidden;
   }
 
+  .layout.modules-collapsed {
+    grid-template-columns: 28px var(--code-col-2, 360px) 6px 1fr;
+  }
+  .layout.files-collapsed {
+    grid-template-columns: var(--code-col-1, 220px) 6px 28px 1fr;
+  }
+  .layout.modules-collapsed.files-collapsed {
+    grid-template-columns: 28px 28px 1fr;
+  }
+
   /* When the Files tab hosts MD or HTML browsers (no class-list / viewer
      split), the embedded component should span the second resizer + the
      remaining three grid tracks so the right pane is one continuous
@@ -1574,6 +1612,27 @@
     display: flex;
     flex-direction: column;
     min-width: 0;
+  }
+  .layout.modules-collapsed .files-fullspan {
+    grid-column: 2 / -1;
+  }
+
+  .pane-rail {
+    background: var(--bg-1);
+    border: none;
+    border-right: 1px solid var(--bg-3);
+    color: var(--fg-2);
+    font-size: 14px;
+    line-height: 1;
+    padding: 0;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .pane-rail:hover {
+    background: var(--bg-2);
+    color: var(--accent-2);
   }
   .files-fullspan > :global(*) {
     flex: 1;
@@ -1604,6 +1663,29 @@
     overflow: hidden;
     display: flex;
     flex-direction: column;
+    position: relative;
+  }
+
+  .pane-collapse {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    border: 1px solid var(--bg-3);
+    border-radius: 4px;
+    background: var(--bg-1);
+    color: var(--fg-2);
+    font-size: 14px;
+    line-height: 1;
+    cursor: pointer;
+    z-index: 2;
+  }
+  .pane-collapse:hover {
+    background: var(--bg-2);
+    color: var(--accent-2);
+    border-color: var(--accent-2);
   }
 
   .path-bar {

--- a/app/src/components/ModuleSidebar.svelte
+++ b/app/src/components/ModuleSidebar.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
-  import { modules, moduleFilter, fileCountByModule, moduleFilesByModule } from '../lib/store';
+  import {
+    modules,
+    moduleFilter,
+    fileCountByModule,
+    moduleFilesByModule,
+    moduleSidebarVisible,
+  } from '../lib/store';
+  import { t } from '../lib/i18n';
 
   function setModule(id: string | null) {
     moduleFilter.update((cur) => (cur === id ? null : id));
@@ -22,7 +29,15 @@
 <aside>
   <header>
     <h3>Modules</h3>
-    <span class="count">{$modules.length}</span>
+    <div class="actions">
+      <span class="count">{$modules.length}</span>
+      <button
+        class="collapse"
+        on:click={() => moduleSidebarVisible.set(false)}
+        title={$t('layout.modules.hide')}
+        aria-label={$t('layout.modules.hide')}
+      >‹</button>
+    </div>
   </header>
   <ul>
     <li class:active={$moduleFilter === null}>
@@ -72,10 +87,35 @@
     font-weight: 600;
   }
 
+  .actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
   .count {
     color: var(--fg-2);
     font-family: var(--mono);
     font-size: 11px;
+  }
+
+  .collapse {
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    border: 1px solid var(--bg-3);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--fg-2);
+    font-size: 13px;
+    line-height: 1;
+    cursor: pointer;
+  }
+
+  .collapse:hover {
+    background: var(--bg-2);
+    color: var(--accent-2);
+    border-color: var(--accent-2);
   }
 
   ul {

--- a/app/src/i18n/de.json
+++ b/app/src/i18n/de.json
@@ -126,5 +126,9 @@
   "outline.hide": "Übersicht ausblenden",
   "outline.inheritance": "Vererbung",
   "gutter.show": "Annotierten Gutter einblenden",
-  "gutter.hide": "Annotierten Gutter ausblenden"
+  "gutter.hide": "Annotierten Gutter ausblenden",
+  "layout.modules.show": "Modul-Seitenleiste einblenden",
+  "layout.modules.hide": "Modul-Seitenleiste ausblenden",
+  "layout.files.show": "Datei-Seitenleiste einblenden",
+  "layout.files.hide": "Datei-Seitenleiste ausblenden"
 }

--- a/app/src/i18n/en.json
+++ b/app/src/i18n/en.json
@@ -126,5 +126,9 @@
   "outline.hide": "Hide outline",
   "outline.inheritance": "Inheritance",
   "gutter.show": "Show annotated gutter",
-  "gutter.hide": "Hide annotated gutter"
+  "gutter.hide": "Hide annotated gutter",
+  "layout.modules.show": "Show modules sidebar",
+  "layout.modules.hide": "Hide modules sidebar",
+  "layout.files.show": "Show files sidebar",
+  "layout.files.hide": "Hide files sidebar"
 }

--- a/app/src/lib/store.ts
+++ b/app/src/lib/store.ts
@@ -110,3 +110,37 @@ export const fileCountByModule = derived(moduleFilesByModule, ($byMod) => {
   }
   return counts;
 });
+
+/// Persisted boolean store backed by localStorage. Used for the
+/// sidebar-collapse toggles below — survives reloads so the layout
+/// stays the way the user left it.
+function persistedBool(key: string, fallback: boolean) {
+  let initial = fallback;
+  try {
+    const v = typeof localStorage !== 'undefined' ? localStorage.getItem(key) : null;
+    if (v === '1') initial = true;
+    else if (v === '0') initial = false;
+  } catch {
+    // localStorage unavailable
+  }
+  const inner = writable<boolean>(initial);
+  inner.subscribe((v) => {
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(key, v ? '1' : '0');
+      }
+    } catch {
+      // ignore — storage unavailable / quota exceeded
+    }
+  });
+  return inner;
+}
+
+/// Whether the modules sidebar (leftmost column) is rendered. When false,
+/// a thin rail with a `›` button takes its place so the user can re-open
+/// the panel.
+export const moduleSidebarVisible = persistedBool('projectmind.layout.modulesVisible', true);
+
+/// Whether the class/file sidebar (middle column) is rendered. When false,
+/// the viewer expands to fill the freed space.
+export const classSidebarVisible = persistedBool('projectmind.layout.filesVisible', true);


### PR DESCRIPTION
## Summary
- Both left columns can now be collapsed to give the viewer more room
- Each panel grows a small ‹ button to hide; a 28px rail with › appears in the column's place to restore
- Visibility persists in localStorage (`projectmind.layout.{modulesVisible,filesVisible}`)
- Grid template adapts to either or both sidebars being collapsed; the md/html "files-fullspan" view shifts left when modules are hidden

Extracted from the now-superseded #93 — smaller surface (no nav-history coupling).

## Test plan
- [x] pnpm check (0 errors), pnpm build, pnpm test --run (24 pass)
- [ ] Toggle the modules sidebar; viewer expands; rail opens it again
- [ ] Toggle the files sidebar; same
- [ ] Toggle both; reload — both stay collapsed
- [ ] On the markdown/HTML chip, collapse modules — content shifts left to fill the row

🤖 Generated with [Claude Code](https://claude.com/claude-code)