### PR TITLE
feat(index): module filter on Markdown + HTML indexes

### DIFF
--- a/app/src/components/HtmlIndex.svelte
+++ b/app/src/components/HtmlIndex.svelte
@@ -5,7 +5,7 @@
     readFileText,
   } from '../lib/api';
   import type { HtmlFile, HtmlSnippet } from '../lib/api';
-  import { repo } from '../lib/store';
+  import { repo, modules, moduleFilter } from '../lib/store';
   import { t } from '../lib/i18n';
   import { resizable } from '../lib/resizable';
   import { createShiftWheelZoom } from '../lib/shiftWheelZoom';
@@ -37,9 +37,31 @@
   let detailLoading = false;
   let detailError: string | null = null;
 
-  $: filteredFiles = filterFiles(files, query);
-  $: filteredSnippets = filterSnippets(snippets, query);
+  /// When a module is selected in the modules sidebar, restrict both files
+  /// and snippets to those whose abs path lives under that module's root.
+  $: selectedModuleRoot = pickModuleRoot($moduleFilter, $modules);
+  $: visibleFiles = restrict(files, selectedModuleRoot, (f) => f.abs);
+  $: visibleSnippets = restrict(snippets, selectedModuleRoot, (s) => s.abs);
+  $: filteredFiles = filterFiles(visibleFiles, query);
+  $: filteredSnippets = filterSnippets(visibleSnippets, query);
   $: void load($repo?.root ?? null);
+
+  function pickModuleRoot(
+    moduleId: string | null,
+    mods: Array<{ id: string; root: string }>,
+  ): string | null {
+    if (!moduleId) return null;
+    return mods.find((m) => m.id === moduleId)?.root ?? null;
+  }
+
+  function restrict<T>(list: T[], root: string | null, abs: (item: T) => string): T[] {
+    if (!root) return list;
+    const prefix = root.endsWith('/') ? root : `${root}/`;
+    return list.filter((item) => {
+      const a = abs(item);
+      return a === root || a.startsWith(prefix);
+    });
+  }
 
   function filterFiles(list: HtmlFile[], q: string): HtmlFile[] {
     if (!q.trim()) return list;
@@ -218,8 +240,22 @@
       <h2>{$t('html.title')}</h2>
       {#if $repo}
         <span class="subtitle">
-          {$t('html.summary', { files: files.length, snippets: snippets.length, root: $repo.root })}
+          {$t('html.summary', {
+            files: visibleFiles.length,
+            snippets: visibleSnippets.length,
+            root: $repo.root,
+          })}
         </span>
+        {#if $moduleFilter}
+          <button
+            class="module-chip"
+            on:click={() => moduleFilter.set(null)}
+            title={$t('index.moduleFilter.clear')}
+          >
+            <span class="chip-label">{$moduleFilter}</span>
+            <span class="chip-x" aria-hidden="true">×</span>
+          </button>
+        {/if}
       {:else}
         <span class="subtitle">{$t('markdown.noRepositoryOpen')}</span>
       {/if}
@@ -253,7 +289,7 @@
         <div class="error">⚠ {error}</div>
       {:else if tab === 'files'}
         {#if filteredFiles.length === 0}
-          <div class="empty">{files.length === 0 ? $t('html.noFiles') : $t('html.noMatches')}</div>
+          <div class="empty">{visibleFiles.length === 0 ? $t('html.noFiles') : $t('html.noMatches')}</div>
         {:else}
           {#each groupedFiles as [dir, entries] (dir)}
             <section class="group">
@@ -281,7 +317,7 @@
           {/each}
         {/if}
       {:else if filteredSnippets.length === 0}
-        <div class="empty">{snippets.length === 0 ? $t('html.noSnippets') : $t('html.noMatches')}</div>
+        <div class="empty">{visibleSnippets.length === 0 ? $t('html.noSnippets') : $t('html.noMatches')}</div>
       {:else}
         {#each groupedSnippets as [rel, entries] (rel)}
           <section class="group">
@@ -414,6 +450,30 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     max-width: 460px;
+  }
+
+  .module-chip {
+    align-self: flex-start;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 2px;
+    padding: 1px 6px 1px 8px;
+    background: color-mix(in srgb, var(--accent-2) 18%, var(--bg-2));
+    border: 1px solid color-mix(in srgb, var(--accent-2) 40%, var(--bg-3));
+    border-radius: 10px;
+    color: var(--fg-0);
+    font-family: var(--mono);
+    font-size: 11px;
+    cursor: pointer;
+  }
+  .module-chip:hover {
+    border-color: var(--accent-2);
+  }
+  .module-chip .chip-x {
+    color: var(--fg-2);
+    font-size: 13px;
+    line-height: 1;
   }
 
   .tabs {

--- a/app/src/components/MarkdownIndex.svelte
+++ b/app/src/components/MarkdownIndex.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { searchMarkdown } from '../lib/api';
   import type { MarkdownFile, MarkdownHit } from '../lib/api';
-  import { repo, fileView, viewMode } from '../lib/store';
+  import { repo, fileView, viewMode, modules, moduleFilter } from '../lib/store';
   import { t } from '../lib/i18n';
   import { createShiftWheelZoom } from '../lib/shiftWheelZoom';
 
@@ -79,9 +79,29 @@
     return idx === -1 ? '·' : rel.slice(0, idx);
   }
 
+  /// When a module is selected in the modules sidebar, narrow the index to
+  /// markdown files that live under that module's root. Lookup happens against
+  /// `$modules` so we can match the module id back to its absolute root path.
+  $: selectedModuleRoot = pickModuleRoot($moduleFilter, $modules);
+  $: visibleHits = filterByModuleRoot(hits, selectedModuleRoot);
+
+  function pickModuleRoot(
+    moduleId: string | null,
+    mods: Array<{ id: string; root: string }>,
+  ): string | null {
+    if (!moduleId) return null;
+    return mods.find((m) => m.id === moduleId)?.root ?? null;
+  }
+
+  function filterByModuleRoot(list: MarkdownHit[], root: string | null): MarkdownHit[] {
+    if (!root) return list;
+    const prefix = root.endsWith('/') ? root : `${root}/`;
+    return list.filter((h) => h.file.abs === root || h.file.abs.startsWith(prefix));
+  }
+
   /// Group hits when no query is active (browsing mode); flat scored list when
   /// a query is in flight (relevance order matters more than directory).
-  $: grouped = query.trim() ? null : groupByDir(hits);
+  $: grouped = query.trim() ? null : groupByDir(visibleHits);
 
   function groupByDir(list: MarkdownHit[]): Array<[string, MarkdownHit[]]> {
     const map = new Map<string, MarkdownHit[]>();
@@ -109,11 +129,21 @@
       {#if $repo}
         <span class="subtitle">
           {#if query.trim()}
-            {$t('markdown.hitsIn', { count: hits.length, root: $repo.root })}
+            {$t('markdown.hitsIn', { count: visibleHits.length, root: $repo.root })}
           {:else}
-            {$t('markdown.filesIn', { count: hits.length, root: $repo.root })}
+            {$t('markdown.filesIn', { count: visibleHits.length, root: $repo.root })}
           {/if}
         </span>
+        {#if $moduleFilter}
+          <button
+            class="module-chip"
+            on:click={() => moduleFilter.set(null)}
+            title={$t('index.moduleFilter.clear')}
+          >
+            <span class="chip-label">{$moduleFilter}</span>
+            <span class="chip-x" aria-hidden="true">×</span>
+          </button>
+        {/if}
       {:else}
         <span class="subtitle">{$t('markdown.noRepositoryOpen')}</span>
       {/if}
@@ -125,7 +155,7 @@
       placeholder={$t('markdown.searchPlaceholder')}
       autocomplete="off"
       spellcheck="false"
-      disabled={!$repo || (loadedFor !== null && hits.length === 0 && !query.trim())}
+      disabled={!$repo || (loadedFor !== null && visibleHits.length === 0 && !query.trim())}
     />
     {#if searching}
       <span class="searching" aria-live="polite">{$t('markdown.searching')}</span>
@@ -139,9 +169,9 @@
       <div class="empty">{$t('markdown.scanning')}</div>
     {:else if error}
       <div class="error">⚠ {error}</div>
-    {:else if hits.length === 0 && !query.trim()}
+    {:else if visibleHits.length === 0 && !query.trim()}
       <div class="empty">{$t('markdown.noFiles')}</div>
-    {:else if hits.length === 0}
+    {:else if visibleHits.length === 0}
       <div class="empty">{$t('markdown.noMatchesFor', { query })}</div>
     {:else if grouped}
       {#each grouped as [dir, entries] (dir)}
@@ -162,7 +192,7 @@
       {/each}
     {:else}
       <ul class="list flat">
-        {#each hits as h (h.file.abs)}
+        {#each visibleHits as h (h.file.abs)}
           <li>
             <button type="button" class="item" on:click={() => open(h.file)}>
               <span class="item-title">{h.file.title}</span>
@@ -216,6 +246,30 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     max-width: 460px;
+  }
+
+  .module-chip {
+    align-self: flex-start;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 2px;
+    padding: 1px 6px 1px 8px;
+    background: color-mix(in srgb, var(--accent-2) 18%, var(--bg-2));
+    border: 1px solid color-mix(in srgb, var(--accent-2) 40%, var(--bg-3));
+    border-radius: 10px;
+    color: var(--fg-0);
+    font-family: var(--mono);
+    font-size: 11px;
+    cursor: pointer;
+  }
+  .module-chip:hover {
+    border-color: var(--accent-2);
+  }
+  .module-chip .chip-x {
+    color: var(--fg-2);
+    font-size: 13px;
+    line-height: 1;
   }
 
   .search {

--- a/app/src/i18n/de.json
+++ b/app/src/i18n/de.json
@@ -131,5 +131,6 @@
   "layout.modules.show": "Modul-Seitenleiste einblenden",
   "layout.modules.hide": "Modul-Seitenleiste ausblenden",
   "layout.files.show": "Datei-Seitenleiste einblenden",
-  "layout.files.hide": "Datei-Seitenleiste ausblenden"
+  "layout.files.hide": "Datei-Seitenleiste ausblenden",
+  "index.moduleFilter.clear": "Modulfilter löschen"
 }

--- a/app/src/i18n/en.json
+++ b/app/src/i18n/en.json
@@ -131,5 +131,6 @@
   "layout.modules.show": "Show modules sidebar",
   "layout.modules.hide": "Hide modules sidebar",
   "layout.files.show": "Show files sidebar",
-  "layout.files.hide": "Hide files sidebar"
+  "layout.files.hide": "Hide files sidebar",
+  "index.moduleFilter.clear": "Clear module filter"
 }


### PR DESCRIPTION
## Summary
- The markdown and HTML indexes now honour the modules-sidebar selection: only files (and snippets) whose absolute path lives under the selected module's root are shown
- An active filter renders as a small chip next to the title; clicking it clears the filter
- Counts in the title bar and tab badges follow the visible list

Extracted from the now-superseded #93.

## Test plan
- [x] pnpm check (0 errors), pnpm build, pnpm test --run (24 pass)
- [ ] Open a multi-module repo, select a module → markdown index narrows; subtitle count drops
- [ ] Same on HTML index — both Files and Snippets tab counts drop
- [ ] Click the chip → filter clears; everything reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)