### PR TITLE
feat(release): bundle projectmind-mcp as a Tauri sidecar in every desktop bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@
 # Tauri
 **/src-tauri/target/
 **/src-tauri/gen/
+# Sidecar binaries staged into the Tauri bundle by scripts/ci.sh — built
+# at release time and copied here so tauri-bundler picks them up via the
+# `externalBin` entry in tauri.conf.json. Never committed.
+app/src-tauri/binaries/
 
 # Frontend
 node_modules/

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ to whichever config the client uses (e.g. `.mcp.json` for Claude Code,
   "mcpServers": {
     "projectmind": {
       "type": "stdio",
-      "command": "/absolute/path/to/projectmind/target/release/projectmind-mcp",
+      "command": "/absolute/path/to/projectmind-mcp",
       "env": {
         "PROJECTMIND_LOG": "info"
       }
@@ -196,6 +196,36 @@ to whichever config the client uses (e.g. `.mcp.json` for Claude Code,
   }
 }
 ```
+
+### Where is `projectmind-mcp` on disk?
+
+Pick whichever of these you have installed:
+
+- **Desktop app installed** — the MCP server is bundled next to the GUI
+  binary, so you can point your client straight at the in-app path. No
+  separate install step:
+  - **macOS:** `/Applications/ProjectMind.app/Contents/MacOS/projectmind-mcp`
+  - **Linux (`.deb` / `.AppImage`):** `/usr/bin/projectmind-mcp` (`.deb`
+    installs to `/usr/bin/`; `.AppImage` mounts a temporary FUSE root —
+    extract the AppImage with `--appimage-extract` if you need the binary
+    on a stable path)
+  - **Windows (`.msi`):** `C:\Program Files\ProjectMind\projectmind-mcp.exe`
+- **MCP-only install** (without the desktop app) — use the standalone
+  tarball from the [Releases page](https://github.com/Plaintext-Gmbh/projectmind/releases/latest)
+  or the helper scripts under [`scripts/`](scripts/). The binary lands
+  wherever you placed it (commonly `~/.local/bin/projectmind-mcp`).
+- **From source** — `target/release/projectmind-mcp` after
+  `cargo build --release --bin projectmind-mcp`.
+
+Claude Code users can register the bundled binary in one line:
+
+```bash
+# macOS
+claude mcp add projectmind /Applications/ProjectMind.app/Contents/MacOS/projectmind-mcp
+```
+
+Re-running the same command after a desktop-app upgrade is a no-op, so
+the MCP server stays in lockstep with the GUI version automatically.
 
 Restart the client. From a session, you can then ask things like:
 

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -38,7 +38,10 @@
     ],
     "category": "DeveloperTool",
     "shortDescription": "Read-only architecture browser",
-    "longDescription": "A read-only architecture browser that pairs with LLM coding agents via MCP."
+    "longDescription": "A read-only architecture browser that pairs with LLM coding agents via MCP.",
+    "externalBin": [
+      "binaries/projectmind-mcp"
+    ]
   },
   "plugins": {}
 }

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -68,6 +68,8 @@ cmd_check() {
     local cargo_args=(--workspace --all-targets)
     if [[ "${PROJECTMIND_SKIP_TAURI_APP:-}" == "1" ]]; then
         cargo_args+=(--exclude projectmind-app)
+    else
+        ensure_sidecar_placeholder
     fi
     cargo clippy "${cargo_args[@]}" -- -D warnings
 }
@@ -76,9 +78,32 @@ cmd_test() {
     local cargo_args=(--workspace)
     if [[ "${PROJECTMIND_SKIP_TAURI_APP:-}" == "1" ]]; then
         cargo_args+=(--exclude projectmind-app)
+    else
+        ensure_sidecar_placeholder
     fi
     cargo test "${cargo_args[@]}" --all-targets
     cargo test "${cargo_args[@]}" --doc
+}
+
+# tauri-build's build script validates `bundle.externalBin` paths on
+# every cargo invocation that touches the projectmind-app crate, even
+# `cargo check` / `clippy`. Stage an empty placeholder so check/test
+# don't have to do a full release build of the MCP binary just to
+# satisfy that lookup. Real release builds replace the placeholder via
+# `stage-mcp-sidecar` before `tauri build`.
+ensure_sidecar_placeholder() {
+    local sidecar_dir="$ROOT_DIR/app/src-tauri/binaries"
+    local host_triple
+    host_triple="$(rustc -vV | sed -n 's/^host: //p')"
+    local ext=""
+    case "$host_triple" in *windows*) ext=".exe" ;; esac
+    local path="$sidecar_dir/projectmind-mcp-${host_triple}${ext}"
+    if [[ -f "$path" ]]; then
+        return
+    fi
+    mkdir -p "$sidecar_dir"
+    : > "$path"
+    chmod +x "$path" 2>/dev/null || true
 }
 
 cmd_install_deps() {

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -36,6 +36,14 @@ Commands:
                               platform (.app/.dmg on macOS, .deb/.AppImage on Linux,
                               .msi/.exe on Windows). Optional Rust target triple
                               for cross-arch builds (e.g. universal-apple-darwin).
+                              Stages the MCP binary as a Tauri sidecar first so
+                              the bundle ships both binaries.
+  stage-mcp-sidecar [<target>]
+                              Build projectmind-mcp for the given target (host
+                              triple if omitted; per-arch + lipo for
+                              universal-apple-darwin) and copy it to
+                              app/src-tauri/binaries/ where tauri-bundler's
+                              externalBin lookup finds it.
   app-package <target> <suffix>
                               Collect every Tauri bundle artefact under
                               target/<target>/release/bundle into
@@ -149,6 +157,12 @@ cmd_release_package() {
 
 cmd_app_build() {
     local target="${1:-}"
+    # Stage the MCP server as a Tauri sidecar before kicking off the
+    # bundle build. tauri.conf.json declares `externalBin` so the bundler
+    # picks up `app/src-tauri/binaries/projectmind-mcp-<triple>{ext}` and
+    # ships it next to the GUI binary inside the .app/.deb/.msi.
+    cmd_stage_mcp_sidecar "$target"
+
     cd "$ROOT_DIR/app"
     if [[ ! -d node_modules ]]; then
         echo "app-build: installing js deps (first run)"
@@ -162,6 +176,50 @@ cmd_app_build() {
         pnpm tauri build
     fi
     cd "$ROOT_DIR"
+}
+
+# Build the MCP server binary for the requested target(s) and copy it
+# into `app/src-tauri/binaries/` under the Rust target triple Tauri's
+# externalBin lookup expects. On macOS universal builds we lipo the two
+# arch slices into one fat binary because Tauri 2 doesn't auto-combine
+# external binaries the way it does the main bundle.
+cmd_stage_mcp_sidecar() {
+    local target="${1:-}"
+    local sidecar_dir="$ROOT_DIR/app/src-tauri/binaries"
+    mkdir -p "$sidecar_dir"
+
+    if [[ -z "$target" ]]; then
+        # Host build — let cargo pick the default triple.
+        local host_triple
+        host_triple="$(rustc -vV | sed -n 's/^host: //p')"
+        local ext=""
+        case "$host_triple" in *windows*) ext=".exe" ;; esac
+        echo "stage-mcp-sidecar: host target $host_triple"
+        cargo build --release --bin projectmind-mcp
+        cp "$ROOT_DIR/target/release/projectmind-mcp${ext}" \
+           "$sidecar_dir/projectmind-mcp-${host_triple}${ext}"
+        return
+    fi
+
+    if [[ "$target" == "universal-apple-darwin" ]]; then
+        echo "stage-mcp-sidecar: universal-apple-darwin (lipo aarch64 + x86_64)"
+        for t in aarch64-apple-darwin x86_64-apple-darwin; do
+            cargo build --release --bin projectmind-mcp --target "$t"
+            cp "$ROOT_DIR/target/$t/release/projectmind-mcp" \
+               "$sidecar_dir/projectmind-mcp-$t"
+        done
+        lipo -create -output "$sidecar_dir/projectmind-mcp-universal-apple-darwin" \
+            "$sidecar_dir/projectmind-mcp-aarch64-apple-darwin" \
+            "$sidecar_dir/projectmind-mcp-x86_64-apple-darwin"
+        return
+    fi
+
+    local ext=""
+    case "$target" in *windows*) ext=".exe" ;; esac
+    echo "stage-mcp-sidecar: $target"
+    cargo build --release --bin projectmind-mcp --target "$target"
+    cp "$ROOT_DIR/target/$target/release/projectmind-mcp${ext}" \
+       "$sidecar_dir/projectmind-mcp-${target}${ext}"
 }
 
 cmd_app_package() {
@@ -215,11 +273,12 @@ case "${1:-}" in
     check)           shift; cmd_check "$@" ;;
     test)            shift; cmd_test "$@" ;;
     install-deps)    shift; cmd_install_deps "$@" ;;
-    release-build)   shift; cmd_release_build "$@" ;;
-    release-smoke)   shift; cmd_release_smoke "$@" ;;
-    release-package) shift; cmd_release_package "$@" ;;
-    app-build)       shift; cmd_app_build "$@" ;;
-    app-package)     shift; cmd_app_package "$@" ;;
+    release-build)     shift; cmd_release_build "$@" ;;
+    release-smoke)     shift; cmd_release_smoke "$@" ;;
+    release-package)   shift; cmd_release_package "$@" ;;
+    stage-mcp-sidecar) shift; cmd_stage_mcp_sidecar "$@" ;;
+    app-build)         shift; cmd_app_build "$@" ;;
+    app-package)       shift; cmd_app_package "$@" ;;
     all)             cmd_check; cmd_test ;;
     -h|--help|help|"") usage ;;
     *) echo "unknown command: $1" >&2; usage; exit 2 ;;


### PR DESCRIPTION
## Summary
- Desktop installer now ships the MCP server next to the GUI, so upgrading the .app/.deb/.msi keeps the MCP binary in lockstep automatically — no separate `cargo install`, no GUI/MCP version skew
- Tauri's `externalBin` mechanism handles platform-correct placement and code-signing on macOS
- README updated with per-OS in-app paths and a one-liner for `claude mcp add`

## Implementation
- `app/src-tauri/tauri.conf.json`: `bundle.externalBin: ["binaries/projectmind-mcp"]`
- `scripts/ci.sh`: new `stage-mcp-sidecar [<target>]` step, called from `app-build` automatically. For `universal-apple-darwin` it lipos the two arch slices because Tauri 2 doesn't auto-combine `externalBin` entries.
- `.gitignore`: `app/src-tauri/binaries/` is staged fresh per build, never committed.

## Local verification (aarch64-apple-darwin)
- `cargo fmt --check` ✅
- `./scripts/ci.sh check` (clippy --workspace -D warnings) ✅
- `./scripts/ci.sh test` ✅ (workspace + doctests pass)
- `./scripts/ci.sh app-build aarch64-apple-darwin` produces `ProjectMind.app/Contents/MacOS/` with **both** `projectmind-app` (14 MB) and `projectmind-mcp` (6.7 MB) ✅
- Bundled MCP responds correctly to `initialize` + `tools/list` (smoke test of the in-bundle binary) ✅
  - DMG generation step failed locally (`bundle_dmg.sh` env quirk), unrelated to this change — CI will produce DMGs cleanly.

## Test plan (CI)
- [ ] macOS universal-apple-darwin: `.dmg` contains an `.app` whose `Contents/MacOS/` has both binaries; the MCP slice is universal (aarch64 + x86_64).
- [ ] Linux x86_64: `.deb` installs `/usr/bin/projectmind-mcp` alongside `/usr/bin/projectmind-app`.
- [ ] Windows x86_64: `.msi` installs `projectmind-mcp.exe` alongside `projectmind-app.exe` under `C:\Program Files\ProjectMind\`.

## Follow-up
After merge: cut a `v0.3.2` patch release so users can upgrade and re-point their MCP client at the bundled path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)