### PR TITLE
fix(layout): viewer no longer blanks when files sidebar collapses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Viewer pane went blank when the files sidebar was collapsed.** Hitting either the new header sidebar-toggle or the pre-existing per-column `‹` collapse button replaced the entire `<aside class="sidebar"> + resizer + <main class="viewer">` block with just a `pane-rail`, so the actively-shown class / file / PDF / image content disappeared too. Restructured the conditional so the inner `{#if classSidebarVisible}` swaps **only** sidebar+resizer for the rail; the viewer renders unconditionally. Affects every viewMode that uses the layout grid (`classes` / `pdf` / `image` / `file`); `md` and `html` are unaffected since they already render through `files-fullspan`.
 - **Welcome screen rendered raw i18n keys** — `welcome.title`, `welcome.tagline`, `welcome.openButton`, `welcome.empty`, `welcome.hint.{browser,tauri}` and the browser-mode token panel keys (`browserMode.banner`, `browserMode.tokenLabel`, `browserMode.tokenSubmit`) were referenced from `App.svelte` but had no entry in any locale file, so the i18n fallback dumped the key string verbatim. Added across `en` / `de` / `fr` / `it` / `es`. Same patch fills several other long-standing gaps surfaced while auditing the welcome view (`diagram.hint`, `drop.overlay`, `files.aria.list`, `files.filter.{all,md.title,html.title}`, `files.package.{label,clear}`, `files.placeholder`, `status.followingMcp{,Title}`, `status.walkthroughTitle`, `layout.both.{show,hide}`).
 
 ## [0.3.2] — 2026-05-03

--- a/app/src/App.svelte
+++ b/app/src/App.svelte
@@ -1076,14 +1076,15 @@
             <svelte:component this={mod.default} />
           {/await}
         </div>
-      {:else if !$classSidebarVisible}
-        <button
-          class="pane-rail"
-          on:click={() => classSidebarVisible.set(true)}
-          title={$t('layout.files.show')}
-          aria-label={$t('layout.files.show')}
-        >›</button>
       {:else}
+        {#if !$classSidebarVisible}
+          <button
+            class="pane-rail"
+            on:click={() => classSidebarVisible.set(true)}
+            title={$t('layout.files.show')}
+            aria-label={$t('layout.files.show')}
+          >›</button>
+        {:else}
         <aside class="sidebar">
           <button
             class="pane-collapse"
@@ -1203,6 +1204,7 @@
           }}
           title="Drag to resize · double-click to reset"
         ></div>
+        {/if}
         <main class="viewer">
           {#if $viewMode === 'pdf' && $fileView}
             <PdfView path={$fileView.path} />


### PR DESCRIPTION
## Summary

Bug surfaced via the new header sidebar-toggle in v0.3.3, but also affected the pre-existing per-column `‹` collapse button. In `viewMode === file | classes | pdf | image`, the conditional that swapped `<aside class=\"sidebar\"> + resizer + <main class=\"viewer\">` for a thin `pane-rail` ate the viewer too, so toggling the files column blanked whatever the user was looking at.

Fix: restructured the if/else so the inner `{#if classSidebarVisible}` swaps **only** sidebar+resizer for the rail; the viewer is now outside the inner branch and always renders. `md` and `html` viewmodes are unaffected (they go through `.files-fullspan` which has its own grid-column rules).

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm exec vitest run` — 24/24 passing
- [ ] Manual: open an .md file in the viewer, hit the sidebar-toggle, viewer keeps its content (left to the merger / next install bundle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)