### PR TITLE
chore(release): v0.3.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/Plaintext-Gmbh/projectmind"
@@ -49,8 +49,8 @@ struct_field_names = "allow"
 ignored_unit_patterns = "allow"
 
 [workspace.dependencies]
-projectmind-plugin-api = { path = "crates/plugin-api", version = "0.3.4" }
-projectmind-core       = { path = "crates/core",       version = "0.3.4" }
+projectmind-plugin-api = { path = "crates/plugin-api", version = "0.3.5" }
+projectmind-core       = { path = "crates/core",       version = "0.3.5" }
 
 # General
 anyhow      = "1.0"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "projectmind-app",
   "private": true,
-  "version": "0.3.4",
+  "version": "0.3.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -21,10 +21,10 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 projectmind-plugin-api = { workspace = true }
 projectmind-core       = { workspace = true }
-projectmind-lang-java  = { path = "../../plugins/lang-java", version = "0.3.4" }
-projectmind-lang-rust  = { path = "../../plugins/lang-rust", version = "0.3.4" }
-projectmind-framework-spring = { path = "../../plugins/framework-spring", version = "0.3.4" }
-projectmind-framework-lombok = { path = "../../plugins/framework-lombok", version = "0.3.4" }
+projectmind-lang-java  = { path = "../../plugins/lang-java", version = "0.3.5" }
+projectmind-lang-rust  = { path = "../../plugins/lang-rust", version = "0.3.5" }
+projectmind-framework-spring = { path = "../../plugins/framework-spring", version = "0.3.5" }
+projectmind-framework-lombok = { path = "../../plugins/framework-lombok", version = "0.3.5" }
 
 tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-dialog = "2"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "ProjectMind",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "identifier": "ch.plaintext.projectmind",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/crates/browser-host/Cargo.toml
+++ b/crates/browser-host/Cargo.toml
@@ -14,10 +14,10 @@ workspace = true
 [dependencies]
 projectmind-core = { workspace = true }
 projectmind-plugin-api = { workspace = true }
-projectmind-lang-java = { path = "../../plugins/lang-java", version = "0.3.4" }
-projectmind-lang-rust = { path = "../../plugins/lang-rust", version = "0.3.4" }
-projectmind-framework-spring = { path = "../../plugins/framework-spring", version = "0.3.4" }
-projectmind-framework-lombok = { path = "../../plugins/framework-lombok", version = "0.3.4" }
+projectmind-lang-java = { path = "../../plugins/lang-java", version = "0.3.5" }
+projectmind-lang-rust = { path = "../../plugins/lang-rust", version = "0.3.5" }
+projectmind-framework-spring = { path = "../../plugins/framework-spring", version = "0.3.5" }
+projectmind-framework-lombok = { path = "../../plugins/framework-lombok", version = "0.3.5" }
 
 anyhow = { workspace = true }
 rand = "0.8"

--- a/crates/mcp-server/Cargo.toml
+++ b/crates/mcp-server/Cargo.toml
@@ -18,13 +18,13 @@ workspace = true
 [dependencies]
 projectmind-plugin-api = { workspace = true }
 projectmind-core       = { workspace = true }
-projectmind-browser-host = { path = "../browser-host", version = "0.3.4" }
+projectmind-browser-host = { path = "../browser-host", version = "0.3.5" }
 
 # Local plugins linked statically for Phase 1
-projectmind-lang-java         = { path = "../../plugins/lang-java", version = "0.3.4" }
-projectmind-lang-rust         = { path = "../../plugins/lang-rust", version = "0.3.4" }
-projectmind-framework-spring  = { path = "../../plugins/framework-spring", version = "0.3.4" }
-projectmind-framework-lombok  = { path = "../../plugins/framework-lombok", version = "0.3.4" }
+projectmind-lang-java         = { path = "../../plugins/lang-java", version = "0.3.5" }
+projectmind-lang-rust         = { path = "../../plugins/lang-rust", version = "0.3.5" }
+projectmind-framework-spring  = { path = "../../plugins/framework-spring", version = "0.3.5" }
+projectmind-framework-lombok  = { path = "../../plugins/framework-lombok", version = "0.3.5" }
 
 anyhow      = { workspace = true }
 clap        = { workspace = true }


### PR DESCRIPTION
Patch release picking up:

- Auto-update via tauri-plugin-updater (#107)
- Repo-switcher reset fix (no more orphaned viewer after switching projects)

Merge → tag-push: `git tag v0.3.5 origin/master && git push origin v0.3.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)