### PR TITLE
feat: open markdown documents directly

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -47,6 +47,7 @@ pub struct AppState {
     /// list / all queries never block adds, but mutations briefly take
     /// a write lock.
     pub annotations: RwLock<Option<projectmind_core::annotations::JsonAnnotationStore>>,
+    pub pending_markdown_file: RwLock<Option<PathBuf>>,
 }
 
 impl AppState {
@@ -60,6 +61,7 @@ impl AppState {
             engine,
             repo: RwLock::new(None),
             annotations: RwLock::new(None),
+            pending_markdown_file: RwLock::new(None),
         }
     }
 }
@@ -83,6 +85,8 @@ pub struct RepoSummary {
     /// instead of hard-coding the bean-graph / package-tree / folder-map
     /// triple.
     pub available_diagrams: Vec<String>,
+    /// Top-level UI tabs the active plugin set contributes for this repo.
+    pub tabs: Vec<projectmind_core::TabDescriptor>,
 }
 
 /// One class entry exposed to the UI.
@@ -181,10 +185,40 @@ fn open_repo(path: String, state: State<'_, Arc<AppState>>) -> Result<RepoSummar
         .engine
         .open_repo(std::path::Path::new(&path))
         .map_err(|e| e.to_string())?;
+    Ok(open_repository(repo, &state, ViewIntent::default()))
+}
+
+/// Tauri command: open a Markdown document as a virtual repository.
+#[tauri::command]
+fn open_markdown_file(
+    path: String,
+    state: State<'_, Arc<AppState>>,
+) -> Result<RepoSummary, String> {
+    let repo = state
+        .engine
+        .open_markdown_file(std::path::Path::new(&path))
+        .map_err(|e| e.to_string())?;
+    let file = repo.root.clone();
+    Ok(open_repository(
+        repo,
+        &state,
+        ViewIntent::File {
+            path: file,
+            anchor: None,
+        },
+    ))
+}
+
+fn open_repository(
+    repo: Repository,
+    state: &State<'_, Arc<AppState>>,
+    new_view: ViewIntent,
+) -> RepoSummary {
     let markdown_count = files::list_markdown_files(&repo.root).len();
     let html_count =
         html::list_html_files(&repo.root).len() + html::find_html_snippets(&repo.root).len();
     let available_diagrams = state.engine.available_diagrams(&repo);
+    let tabs = state.engine.available_tabs(&repo);
     let summary = RepoSummary {
         root: repo.root.clone(),
         modules: repo.modules.len(),
@@ -194,13 +228,19 @@ fn open_repo(path: String, state: State<'_, Arc<AppState>>) -> Result<RepoSummar
         markdown_count,
         html_count,
         available_diagrams,
+        tabs,
     };
     let root = repo.root.clone();
     *state.repo.write() = Some(repo);
     // (Re-)open the per-repo annotation store. A failure to load is
     // surfaced to logs but doesn't fail the open — the GUI just won't
     // have annotation features for this repo.
-    match projectmind_core::annotations::JsonAnnotationStore::open(&root) {
+    let annotation_root = if root.is_file() {
+        root.parent().unwrap_or(&root)
+    } else {
+        &root
+    };
+    match projectmind_core::annotations::JsonAnnotationStore::open(annotation_root) {
         Ok(store) => {
             *state.annotations.write() = Some(store);
         }
@@ -218,14 +258,15 @@ fn open_repo(path: String, state: State<'_, Arc<AppState>>) -> Result<RepoSummar
     let same_repo = prev.repo_root.as_ref() == Some(&root);
     publish_state(UiState {
         repo_root: Some(root),
-        view: if same_repo {
-            prev.view
-        } else {
-            ViewIntent::default()
-        },
+        view: if same_repo { prev.view } else { new_view },
         ..UiState::default()
     });
-    Ok(summary)
+    summary
+}
+
+#[tauri::command]
+fn pending_markdown_file(state: State<'_, Arc<AppState>>) -> Option<PathBuf> {
+    state.pending_markdown_file.write().take()
 }
 
 #[tauri::command]
@@ -574,8 +615,8 @@ fn list_markdown_files(root: String) -> Result<Vec<MarkdownFile>, String> {
     if !p.is_absolute() {
         return Err(format!("root must be absolute: {root}"));
     }
-    if !p.is_dir() {
-        return Err(format!("root is not a directory: {root}"));
+    if !p.is_dir() && !p.is_file() {
+        return Err(format!("root is not a directory or file: {root}"));
     }
     Ok(files::list_markdown_files(p))
 }
@@ -589,8 +630,8 @@ fn search_markdown(root: String, query: String, limit: usize) -> Result<Vec<Mark
     if !p.is_absolute() {
         return Err(format!("root must be absolute: {root}"));
     }
-    if !p.is_dir() {
-        return Err(format!("root is not a directory: {root}"));
+    if !p.is_dir() && !p.is_file() {
+        return Err(format!("root is not a directory or file: {root}"));
     }
     let cap = if limit == 0 { 200 } else { limit };
     Ok(files::search_markdown(p, &query, cap))
@@ -880,6 +921,25 @@ fn spawn_state_watcher(handle: AppHandle) {
     });
 }
 
+fn markdown_launch_arg(args: impl IntoIterator<Item = String>) -> Option<PathBuf> {
+    args.into_iter()
+        .map(PathBuf::from)
+        .find(|p| is_markdown_path(p))
+}
+
+fn is_markdown_path(path: &std::path::Path) -> bool {
+    path.extension()
+        .and_then(|s| s.to_str())
+        .is_some_and(|ext| matches!(ext.to_ascii_lowercase().as_str(), "md" | "markdown" | "mdx"))
+}
+
+fn queue_markdown_file(app: &AppHandle, state: &Arc<AppState>, path: PathBuf) {
+    *state.pending_markdown_file.write() = Some(path.clone());
+    if let Err(err) = app.emit("open-markdown-file", path) {
+        tracing::debug!(error = %err, "failed to emit open-markdown-file");
+    }
+}
+
 /// Tauri entrypoint.
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -893,16 +953,21 @@ pub fn run() {
     // Belt-and-suspenders with the MCP heartbeat check in `launch::ensure_gui_running`.
     #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
     {
+        let single_state = Arc::clone(&state);
         builder = builder.plugin(tauri_plugin_single_instance::init(
-            |app: &AppHandle, _args: Vec<String>, _cwd: String| {
+            move |app: &AppHandle, args: Vec<String>, _cwd: String| {
                 if let Some(window) = app.get_webview_window("main") {
                     let _ = window.unminimize();
                     let _ = window.show();
                     let _ = window.set_focus();
                 }
+                if let Some(path) = markdown_launch_arg(args) {
+                    queue_markdown_file(app, &single_state, path);
+                }
             },
         ));
     }
+    let setup_state = Arc::clone(&state);
     builder
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
@@ -911,6 +976,8 @@ pub fn run() {
         .manage(state)
         .invoke_handler(tauri::generate_handler![
             open_repo,
+            open_markdown_file,
+            pending_markdown_file,
             list_classes,
             list_modules,
             show_class,
@@ -938,7 +1005,10 @@ pub fn run() {
             open_external,
             get_build_integrity,
         ])
-        .setup(|app| {
+        .setup(move |app| {
+            if let Some(path) = markdown_launch_arg(std::env::args()) {
+                queue_markdown_file(app.handle(), &setup_state, path);
+            }
             spawn_state_watcher(app.handle().clone());
             spawn_heartbeat();
             Ok(())

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -41,6 +41,16 @@
     "longDescription": "A read-only architecture browser that pairs with LLM coding agents via MCP.",
     "externalBin": [
       "binaries/projectmind-mcp"
+    ],
+    "fileAssociations": [
+      {
+        "ext": ["md", "markdown", "mdx"],
+        "name": "Markdown document",
+        "description": "Markdown document",
+        "role": "Viewer",
+        "rank": "Default",
+        "mimeType": "text/markdown"
+      }
     ]
   },
   "plugins": {

--- a/app/src/App.svelte
+++ b/app/src/App.svelte
@@ -28,6 +28,7 @@
   } from './lib/store';
   import {
     openRepo,
+    openMarkdownFile,
     listClasses,
     listModules,
     listModuleFiles,
@@ -36,6 +37,7 @@
     browserToken,
     clearBrowserToken,
     isTauriRuntime,
+    pendingMarkdownFile,
     setBrowserToken,
   } from './lib/api';
   import type { ClassEntry, ModuleEntry, ModuleFile, TabDescriptor, UiState } from './lib/api';
@@ -300,6 +302,7 @@
   let browserAuthorized = true;
   let tokenInput = '';
   let unlistenState: (() => void) | null = null;
+  let unlistenOpenMarkdownFile: (() => void) | null = null;
   let statePoll: ReturnType<typeof setInterval> | null = null;
   let lastSeq = 0;
   // Drag-and-drop state. `dragOver` toggles the full-window overlay; in
@@ -551,6 +554,36 @@
     }
   }
 
+  async function loadMarkdownDocument(path: string, opts: { silent?: boolean } = {}) {
+    loading = true;
+    errorMessage.set(null);
+    try {
+      const summary = await openMarkdownFile(path);
+      repo.set(summary);
+      const [list, mods] = await Promise.all([listClasses(), listModules()]);
+      classes.set(list);
+      modules.set(mods);
+      selectedClass.set(null);
+      moduleFilter.set(null);
+      stereotypeFilter.set(null);
+      fileKindFilter.set(null);
+      packageFilter.set(null);
+      classSource = '';
+      fileView.update((cur) => ({
+        path: summary.root,
+        anchor: null,
+        nonce: (cur?.nonce ?? 0) + 1,
+      }));
+      viewMode.set('file');
+      recents.record(summary.root, summary.classes, summary.modules);
+    } catch (err) {
+      if (opts.silent) throw err;
+      errorMessage.set(String(err));
+    } finally {
+      loading = false;
+    }
+  }
+
   function handleSelect(c: ClassEntry) {
     selectedClass.set(c);
   }
@@ -682,6 +715,13 @@
   /// desktop side we infer directory-ness from the absence of an extension —
   /// good enough for the common drop targets (Finder folders, single files).
   async function handleDroppedPath(absPath: string, isDirectory: boolean): Promise<void> {
+    const ext = extOf(absPath);
+    if (!isDirectory && viewModeForExt(ext) === 'file') {
+      followingMcp.set(false);
+      await loadMarkdownDocument(absPath);
+      return;
+    }
+
     const repoPath = isDirectory ? absPath : dirname(absPath);
     if (!repoPath) {
       errorMessage.set(`Cannot derive repository directory from: ${absPath}`);
@@ -694,7 +734,6 @@
       viewMode.set('classes');
       return;
     }
-    const ext = extOf(absPath);
     const target = viewModeForExt(ext);
     if (target === null) {
       // Source files / unknown extensions land on the Code tab.
@@ -773,6 +812,15 @@
       unlistenState = await listen<UiState>('state-changed', (ev) => {
         void applyState(ev.payload);
       });
+      unlistenOpenMarkdownFile = await listen<string>('open-markdown-file', (ev) => {
+        followingMcp.set(false);
+        void loadMarkdownDocument(ev.payload);
+      });
+      const pending = await pendingMarkdownFile();
+      if (pending) {
+        followingMcp.set(false);
+        await loadMarkdownDocument(pending);
+      }
       // Register Tauri 2 webview-level drag-drop. Reports absolute paths
       // (which the browser DOM API hides) and fires enter/over/drop/leave.
       unlistenDragDrop = await getCurrentWebview().onDragDropEvent((event) => {
@@ -818,6 +866,7 @@
   onDestroy(() => {
     window.removeEventListener('keydown', onNavKey);
     unlistenState?.();
+    unlistenOpenMarkdownFile?.();
     unlistenDragDrop?.();
     if (statePoll) clearInterval(statePoll);
     if (browserDropHintTimer) clearTimeout(browserDropHintTimer);
@@ -1834,13 +1883,6 @@
     margin-top: 32px;
     color: var(--fg-2);
     font-size: 12px;
-  }
-
-  .welcome code {
-    font-family: var(--mono);
-    background: var(--bg-2);
-    padding: 1px 6px;
-    border-radius: 3px;
   }
 
   .layout {

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -116,6 +116,16 @@ export async function openRepo(path: string): Promise<RepoSummary> {
   return invoke<RepoSummary>('open_repo', { path });
 }
 
+export async function openMarkdownFile(path: string): Promise<RepoSummary> {
+  if (!isTauriRuntime()) return post<RepoSummary>('/api/open_markdown_file', { path });
+  return invoke<RepoSummary>('open_markdown_file', { path });
+}
+
+export async function pendingMarkdownFile(): Promise<string | null> {
+  if (!isTauriRuntime()) return null;
+  return invoke<string | null>('pending_markdown_file');
+}
+
 export async function listClasses(stereotype?: string, module?: string): Promise<ClassEntry[]> {
   if (!isTauriRuntime()) {
     return api<ClassEntry[]>(`/api/list_classes${query({ stereotype, module })}`);

--- a/crates/browser-host/src/lib.rs
+++ b/crates/browser-host/src/lib.rs
@@ -404,6 +404,11 @@ fn route_api(
             let summary = open_repo_locked(&mut guard, Path::new(&args.path))?;
             Ok(serde_json::to_value(summary)?)
         }
+        ("POST", "/api/open_markdown_file") => {
+            let args: PathArg = serde_json::from_slice(body)?;
+            let summary = open_markdown_file_locked(&mut guard, Path::new(&args.path))?;
+            Ok(serde_json::to_value(summary)?)
+        }
         ("GET", "/api/list_classes") => {
             let stereotype = query.get("stereotype").map(String::as_str);
             let module = query.get("module").map(String::as_str);
@@ -808,6 +813,30 @@ fn open_repo_locked(state: &mut HostState, path: &Path) -> anyhow::Result<RepoSu
         anyhow::bail!("repo path must be absolute: {}", path.display());
     }
     let repo = state.engine.open_repo(path)?;
+    open_repository_locked(state, repo, ViewIntent::default())
+}
+
+fn open_markdown_file_locked(state: &mut HostState, path: &Path) -> anyhow::Result<RepoSummary> {
+    if !path.is_absolute() {
+        anyhow::bail!("markdown file path must be absolute: {}", path.display());
+    }
+    let repo = state.engine.open_markdown_file(path)?;
+    let file = repo.root.clone();
+    open_repository_locked(
+        state,
+        repo,
+        ViewIntent::File {
+            path: file,
+            anchor: None,
+        },
+    )
+}
+
+fn open_repository_locked(
+    state: &mut HostState,
+    repo: Repository,
+    view: ViewIntent,
+) -> anyhow::Result<RepoSummary> {
     let markdown_count = files::list_markdown_files(&repo.root).len();
     let html_count =
         html::list_html_files(&repo.root).len() + html::find_html_snippets(&repo.root).len();
@@ -834,7 +863,7 @@ fn open_repo_locked(state: &mut HostState, path: &Path) -> anyhow::Result<RepoSu
     };
     state::write(UiState {
         repo_root: Some(repo.root.clone()),
-        view: ViewIntent::default(),
+        view,
         ..UiState::default()
     })?;
     state.repo = Some(repo);

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -246,6 +246,37 @@ impl Engine {
         Ok(repo)
     }
 
+    /// Open a single Markdown document as a virtual repository.
+    ///
+    /// The repository root is the canonical file path itself. This keeps the
+    /// UI context scoped to the selected document while still reusing the
+    /// existing repository-shaped state and file-view plumbing.
+    pub fn open_markdown_file(&self, path: &Path) -> Result<Repository, RepositoryError> {
+        let path = std::fs::canonicalize(path)
+            .map_err(|_| RepositoryError::InvalidPath(path.to_path_buf()))?;
+        if !path.is_file() || !is_markdown_path(&path) {
+            return Err(RepositoryError::InvalidMarkdownFile(path));
+        }
+
+        let module_root = path
+            .parent()
+            .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
+        let module = Module {
+            id: "document".into(),
+            name: path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("document")
+                .into(),
+            root: module_root,
+            classes: BTreeMap::new(),
+        };
+
+        let mut repo = Repository::new(path);
+        repo.insert_module(module);
+        Ok(repo)
+    }
+
     fn parse_root(&self, root: &Path) -> Result<Module, RepositoryError> {
         let mut module = Module {
             id: derive_module_id(root),
@@ -434,6 +465,12 @@ impl Engine {
     }
 }
 
+fn is_markdown_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|s| s.to_str())
+        .is_some_and(|ext| matches!(ext.to_ascii_lowercase().as_str(), "md" | "markdown" | "mdx"))
+}
+
 fn derive_module_id(root: &Path) -> String {
     root.file_name()
         .and_then(|s| s.to_str())
@@ -537,6 +574,33 @@ mod tests {
         let ids: Vec<_> = tabs.iter().map(|t| t.id.as_str()).collect();
         // Core tabs come first in declaration order, then plugin tabs.
         assert_eq!(ids, vec!["files", "diagrams", "tests"]);
+    }
+
+    #[test]
+    fn opens_markdown_file_as_virtual_repo() {
+        let dir = tempdir();
+        let file = dir.path().join("note.md");
+        std::fs::write(&file, "# Note").unwrap();
+
+        let engine = Engine::new();
+        let repo = engine.open_markdown_file(&file).unwrap();
+
+        assert_eq!(repo.root, std::fs::canonicalize(&file).unwrap());
+        assert_eq!(repo.modules.len(), 1);
+        assert_eq!(repo.class_count(), 0);
+        let module = repo.modules.get("document").unwrap();
+        assert_eq!(module.name, "note");
+        assert_eq!(module.root, std::fs::canonicalize(dir.path()).unwrap());
+    }
+
+    #[test]
+    fn rejects_non_markdown_virtual_repo_file() {
+        let dir = tempdir();
+        let file = dir.path().join("note.txt");
+        std::fs::write(&file, "not markdown").unwrap();
+
+        let engine = Engine::new();
+        assert!(engine.open_markdown_file(&file).is_err());
     }
 
     #[test]

--- a/crates/core/src/files.rs
+++ b/crates/core/src/files.rs
@@ -50,6 +50,34 @@ pub struct ModuleFile {
 pub fn list_markdown_files(root: &Path) -> Vec<MarkdownFile> {
     let mut out: Vec<MarkdownFile> = Vec::new();
 
+    if root.is_file() {
+        let Some(ext) = root.extension().and_then(|e| e.to_str()) else {
+            return out;
+        };
+        let lower = ext.to_ascii_lowercase();
+        if !matches!(lower.as_str(), "md" | "markdown" | "mdx") {
+            return out;
+        }
+        let title = first_h1(root).unwrap_or_else(|| {
+            root.file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .to_string()
+        });
+        let size = std::fs::metadata(root).map_or(0, |m| m.len());
+        out.push(MarkdownFile {
+            abs: root.to_path_buf(),
+            rel: root
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .to_string(),
+            title,
+            size,
+        });
+        return out;
+    }
+
     let walker = WalkBuilder::new(root)
         .standard_filters(true)
         .hidden(true)
@@ -365,6 +393,21 @@ mod tests {
         let files = list_markdown_files(&root);
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].title, "notes");
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn lists_single_markdown_file_root() {
+        let root = tmp_dir("single-file");
+        let file = root.join("brief.md");
+        std::fs::write(&file, "# Brief\nbody").unwrap();
+
+        let files = list_markdown_files(&file);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].abs, file);
+        assert_eq!(files[0].rel, "brief.md");
+        assert_eq!(files[0].title, "Brief");
+
         std::fs::remove_dir_all(&root).ok();
     }
 

--- a/crates/core/src/html.rs
+++ b/crates/core/src/html.rs
@@ -77,6 +77,9 @@ impl HtmlKind {
 }
 
 fn build_walker(root: &Path) -> ignore::Walk {
+    if root.is_file() {
+        return WalkBuilder::new(root).max_depth(Some(0)).build();
+    }
     WalkBuilder::new(root)
         .standard_filters(true)
         .hidden(true)

--- a/crates/core/src/repository.rs
+++ b/crates/core/src/repository.rs
@@ -77,6 +77,10 @@ pub enum RepositoryError {
     #[error("invalid repository path: {0}")]
     InvalidPath(PathBuf),
 
+    /// The provided path does not exist, is not a file, or is not Markdown.
+    #[error("invalid markdown file path: {0}")]
+    InvalidMarkdownFile(PathBuf),
+
     /// A plugin failed.
     #[error("plugin error: {0}")]
     Plugin(#[from] projectmind_plugin_api::Error),


### PR DESCRIPTION
## Summary
- open standalone Markdown files as virtual ProjectMind repositories
- register Markdown file associations for the desktop app
- handle Markdown launch args, second-instance opens, and drag/drop directly in the file viewer
- support single-file Markdown roots in the browser-host API and core Markdown listing/search plumbing

## Validation
- `cargo fmt --check`
- `cargo check --workspace --exclude projectmind-app`
- `cargo test -p projectmind-core markdown`
- `pnpm test`
- `pnpm check`
- `pnpm build`
- `./scripts/ci.sh stage-mcp-sidecar`
- `cargo check -p projectmind-app`
