### PR TITLE
fix(macos): stable bundle Identifier so TCC permissions persist

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -201,6 +201,55 @@ cmd_app_build() {
         pnpm tauri build
     fi
     cd "$ROOT_DIR"
+
+    cmd_macos_stabilize_bundle_id "$target"
+}
+
+# Tauri's bundler leaves the .app with the linker's auto ad-hoc signature,
+# whose Identifier is "<crate_name>-<random_hash>" instead of the configured
+# bundle.identifier. macOS keys TCC permissions (Schreibtisch, Documents, …)
+# off (Identifier, CodeRequirement) — a wandering Identifier means the
+# permission prompt re-fires after every rebuild / auto-update.
+#
+# Re-sign ad-hoc with --identifier set to the value from tauri.conf.json so
+# the Identifier half of that tuple is stable across rebuilds. This is the
+# best we can do without an Apple Developer ID; with a real cert macOS would
+# also accept hash drift via designated-requirement matching.
+cmd_macos_stabilize_bundle_id() {
+    local target="${1:-}"
+    case "$(uname -s)" in
+        Darwin) ;;
+        *) return ;;
+    esac
+    case "$target" in
+        ""|*-apple-darwin|universal-apple-darwin) ;;
+        *) return ;;
+    esac
+
+    local bundle_root
+    if [[ -n "$target" ]]; then
+        bundle_root="$ROOT_DIR/target/$target/release/bundle/macos"
+    else
+        bundle_root="$ROOT_DIR/target/release/bundle/macos"
+    fi
+    if [[ ! -d "$bundle_root" ]]; then
+        return
+    fi
+
+    local conf="$ROOT_DIR/app/src-tauri/tauri.conf.json"
+    local identifier
+    identifier="$(node -e "console.log(require('$conf').identifier)")"
+    if [[ -z "$identifier" ]]; then
+        echo "macos-stabilize: no identifier in $conf" >&2
+        return 1
+    fi
+
+    local app
+    while IFS= read -r app; do
+        echo "macos-stabilize: re-sign $app with identifier=$identifier"
+        codesign --force --deep --sign - --identifier "$identifier" "$app"
+        codesign -dv "$app" 2>&1 | grep -E '^(Identifier|Signature)=' || true
+    done < <(find "$bundle_root" -maxdepth 2 -name '*.app' -type d)
 }
 
 # Build the MCP server binary for the requested target(s) and copy it


### PR DESCRIPTION
## Summary

- macOS-Sicherheitsprompts (Schreibtisch / Dokumente / Downloads) tauchten nach jedem Rebuild und nach jedem Auto-Update wieder auf, obwohl der User \"Erlauben\" geklickt hatte.
- Ursache: Tauri's bundler hinterlässt die `.app` mit der vom Linker auto-erzeugten ad-hoc-Signatur. Deren `Identifier` ist `projectmind_app-<random_hash>`, nicht der in `tauri.conf.json` konfigurierte `ch.plaintext.projectmind`. macOS schlüsselt TCC-Berechtigungen über `(Identifier, CodeRequirement)` — wandert der Identifier, ist die Berechtigung weg.
- Fix: Post-build Re-Sign-Step in `scripts/ci.sh`, der die `.app` (inkl. eingebettetem Sidecar `projectmind-mcp`) ad-hoc neu signiert und dabei `--identifier` explizit setzt.

## Verifikation lokal

```
Vorher:  Identifier=projectmind_app-acf6828ac18d151a   Signature=adhoc
Nachher: Identifier=ch.plaintext.projectmind           Signature=adhoc
```

Sidecar `projectmind-mcp` bekommt durch `--deep` denselben Identifier.

## Beschränkung

Solange wir ohne Apple Developer ID releasen, wandert der CDHash bei jedem Rebuild weiter. macOS toleriert das mit ad-hoc nicht in jeder Version garantiert, aber empirisch hilft der stabile Identifier-Teil der TCC-Tuple deutlich. Eine vollständige Lösung (kein erneutes Prompt nach Auto-Update) braucht eine echte Developer-ID-Signatur plus Notarization — separat trackbar.

## Test plan

- [ ] CI: macOS-Build läuft durch (`scripts/ci.sh app-build`)
- [ ] CI/Release-Asset: nach `tauri build` zeigt `codesign -dv` `Identifier=ch.plaintext.projectmind`
- [ ] Manuell: Auto-Update von einer alten v0.3.5 auf die nächste Release-Version triggert keinen erneuten Schreibtisch-Permission-Dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)