### PR TITLE
chore(actions): bump GitHub Actions to latest stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install Linux Tauri deps
         if: runner.os == 'Linux' && env.PROJECTMIND_SKIP_TAURI_APP != '1'
@@ -48,12 +48,12 @@ jobs:
       # tauri::generate_context!() validates frontendDist: "../dist" at compile
       # time. Without app/dist, clippy panics on the projectmind-app crate.
       - name: Install pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         with:
           version: 9
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
           cache: pnpm
@@ -91,17 +91,17 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       # projectmind-mcp embeds app/dist via include_dir!, so the frontend
       # must exist before the Rust build starts. Same pnpm + node setup as
       # the `rust` job above.
       - name: Install pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         with:
           version: 9
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
           cache: pnpm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@53e96ec3b35fce51c141c0d6f0e31028a448722d # v3
+        uses: github/codeql-action/init@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
@@ -51,13 +51,13 @@ jobs:
       # constraint as the regular CI workflow).
       - name: Install pnpm
         if: matrix.language == 'javascript-typescript' || matrix.language == 'rust'
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         with:
           version: 9
 
       - name: Setup Node
         if: matrix.language == 'javascript-typescript' || matrix.language == 'rust'
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
           cache: pnpm
@@ -72,13 +72,13 @@ jobs:
 
       - name: Autobuild
         if: matrix.language != 'rust'
-        uses: github/codeql-action/autobuild@53e96ec3b35fce51c141c0d6f0e31028a448722d # v3
+        uses: github/codeql-action/autobuild@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3
 
       - name: Build Rust for CodeQL
         if: matrix.language == 'rust'
         run: cargo build --workspace --exclude projectmind-app
 
       - name: Analyze
-        uses: github/codeql-action/analyze@53e96ec3b35fce51c141c0d6f0e31028a448722d # v3
+        uses: github/codeql-action/analyze@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,16 +152,16 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       # projectmind-mcp embeds app/dist via include_dir!, so the frontend
       # must exist before the Rust build starts.
       - name: Install pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         with:
           version: 9
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
           cache: pnpm
@@ -225,17 +225,17 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.rust_targets }}
 
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: app-${{ matrix.asset_suffix }}
 
       - name: Install pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         with:
           version: 9
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
           cache: pnpm


### PR DESCRIPTION
## Summary

Audit + bump of every GitHub Action used in this repo. Four actions had updates worth taking; the rest were already on the latest tagged SHA.

| Action | From | To | Why |
|---|---|---|---|
| `actions/setup-node` | v4 | **v6.4.0** | Clears the *"Node.js 20 actions are deprecated"* warning GitHub started annotating every release build with (Node 24 becomes the runner default on 2026-09-16). |
| `pnpm/action-setup` | v4 | **v6.0.5** | Same Node 20 deprecation source. v6 still honours our `with: version: 9`. |
| `Swatinem/rust-cache` | v2 | v2.9.1 | Patch updates around cross-platform cache scoping. Same args, no migration. |
| `github/codeql-action` | v3 | v3.35.3 | Minor on the supported v3 line. Stayed on v3 (not v4) because v4 sometimes requires a newer CodeQL CLI bundle than what runners pin — safer to upgrade in a follow-up with an explicit smoke. |

**Already up to date** (verified via `gh api repos/<owner>/<repo>/commits/<tag>`, same SHA as latest release):
- `actions/checkout` v6.0.2
- `actions/upload-artifact` v7.0.1
- `actions/download-artifact` v8.0.1
- `softprops/action-gh-release` v3.0.0

**Left as-is:**
- `dtolnay/rust-toolchain` — pinned to a master SHA per the action's intended usage (thin rustup wrapper, no semver tags beyond `v1`).

## Test plan

- [ ] CI passes on this PR — exercises `setup-node` v6, `pnpm/action-setup` v6, and `Swatinem/rust-cache` v2.9.1 in both the `rust` matrix and the `release-build` job.
- [ ] CodeQL run finishes green (the v3.35.3 init/autobuild/analyze trio).
- [ ] Release workflow not exercised here directly — covered by the next tag-push, but the diff is small (same param surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)