### PR TITLE
chore(folder-map): extract recency/author colour helpers + tests

### DIFF
--- a/app/src/components/DiagramView.svelte
+++ b/app/src/components/DiagramView.svelte
@@ -14,6 +14,11 @@
     viewMode,
     repo,
   } from '../lib/store';
+  import {
+    recencyColor,
+    authorColor,
+    authorIdentity,
+  } from '../lib/folderMapColors';
 
   export let kind: DiagramKind;
   export let folderLayout: 'hierarchy' | 'solar' | 'td' = 'solar';
@@ -203,15 +208,6 @@
       factsByPath = new Map();
       factsForRoot = root;
     }
-  }
-
-  /// Pick the stablest per-author identity from a name + email pair. Email
-  /// wins when present (people change display names but not email); falls
-  /// back to the display name; null when the signature was empty.
-  function authorIdentity(name: string | null, email: string | null): string | null {
-    if (email && email.trim()) return email.trim().toLowerCase();
-    if (name && name.trim()) return name.trim();
-    return null;
   }
 
   /// Fetch (and cache) the per-file change status against `diffRef` for the
@@ -546,39 +542,6 @@
       return `hsl(${h}, ${Math.max(20, s - 25)}%, ${Math.min(75, l + 18)}%)`;
     }
     return `hsl(${h}, ${s}%, ${l}%)`;
-  }
-
-  /// Map a "seconds since last commit" value onto an HSL colour. Brand-new
-  /// edits land in hot orange (~hue 18°); a year-old file decays into cool
-  /// grey-blue (~hue 220°). Saturation drops with age so old code recedes
-  /// visually. Log scale because the interesting structure lives in the
-  /// last few days vs. the long tail of stale files.
-  function recencyColor(secs_ago: number): string {
-    const day = 86_400;
-    const safe = Math.max(secs_ago, 60);
-    // t=0 at <1 day, t≈0.33 at ~10 days, t≈0.67 at ~year, t≥1 at 1000+ days.
-    const t = Math.min(1, Math.max(0, Math.log10(safe / day) / 3));
-    const hue = 18 + (220 - 18) * t;
-    const sat = 78 - 50 * t;
-    const light = 52 - 18 * t;
-    return `hsl(${hue.toFixed(0)}, ${sat.toFixed(0)}%, ${light.toFixed(0)}%)`;
-  }
-
-  /// Map an author identity (email when available, else display name) onto
-  /// a stable HSL colour. djb2-style 32-bit hash → hue; saturation and
-  /// lightness are fixed so all authors render at the same chroma. This
-  /// is intentionally not "primary author by line count" — that would
-  /// require git blame and far more work; "most recent committer per file"
-  /// is a cheap proxy that correlates well in practice.
-  function authorColor(identity: string): string {
-    let h = 5381;
-    for (let i = 0; i < identity.length; i++) {
-      h = ((h << 5) + h + identity.charCodeAt(i)) | 0;
-    }
-    // Use the unsigned 32-bit mod 360 so identical strings always map to
-    // the same hue across reloads / processes.
-    const hue = ((h >>> 0) % 360);
-    return `hsl(${hue}, 60%, 52%)`;
   }
 
   /// Helper used by all three folder-map layouts. Returns the `<circle>`

--- a/app/src/lib/folderMapColors.test.ts
+++ b/app/src/lib/folderMapColors.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { authorColor, authorIdentity, recencyColor } from './folderMapColors';
+
+/// Pull `H/S/L` triples out of an `hsl(h, s%, l%)` string for numeric
+/// comparison. The renderer rounds at emit time, so the test only has to
+/// match the rounded values.
+function parseHsl(s: string): { h: number; sat: number; light: number } {
+  const m = /^hsl\(\s*(\d+),\s*(\d+)%,\s*(\d+)%\)$/.exec(s);
+  if (!m) throw new Error(`not an hsl() string: ${s}`);
+  return { h: Number(m[1]), sat: Number(m[2]), light: Number(m[3]) };
+}
+
+describe('recencyColor', () => {
+  const day = 86_400;
+
+  it('emits a fresh, hot orange hue for very recent commits', () => {
+    // 5 minutes old — anchored at the floor (60 s clamp), still solidly
+    // on the "today" side of the scale.
+    const { h, sat, light } = parseHsl(recencyColor(300));
+    expect(h).toBeLessThanOrEqual(40); // close to 18°, the hot anchor
+    expect(sat).toBeGreaterThan(60);
+    expect(light).toBeGreaterThanOrEqual(45);
+  });
+
+  it('decays toward the cool blue end past a year', () => {
+    const tenYears = day * 365 * 10;
+    const { h, sat } = parseHsl(recencyColor(tenYears));
+    expect(h).toBeGreaterThanOrEqual(200); // close to 220°, the cool anchor
+    expect(sat).toBeLessThanOrEqual(35); // saturation drops with age
+  });
+
+  it('clamps `t` to [0, 1] for inputs outside the design range', () => {
+    // Negative input → secs_ago floors to 60s, t=0, hue stays at the hot
+    // anchor. Same as a brand-new commit.
+    const negative = recencyColor(-1_000);
+    const fiveMinutes = recencyColor(300);
+    expect(negative).toBe(fiveMinutes);
+
+    // Inputs past the 1000-days knee saturate at the cool anchor —
+    // a 100-year-old file should look the same as a 10-year-old file.
+    expect(recencyColor(day * 365 * 100)).toBe(recencyColor(day * 365 * 10));
+  });
+
+  it('moves monotonically toward blue as commits age', () => {
+    const samples = [day, day * 7, day * 30, day * 365, day * 1000].map(
+      (s) => parseHsl(recencyColor(s)).h,
+    );
+    for (let i = 1; i < samples.length; i++) {
+      expect(samples[i]).toBeGreaterThanOrEqual(samples[i - 1]);
+    }
+  });
+
+  it('produces a parseable hsl() string', () => {
+    expect(recencyColor(day * 30)).toMatch(/^hsl\(\d+, \d+%, \d+%\)$/);
+  });
+});
+
+describe('authorColor', () => {
+  it('is stable: the same identity always returns the same colour', () => {
+    expect(authorColor('alice@example.com')).toBe(authorColor('alice@example.com'));
+  });
+
+  it('produces visually distinct hues for different identities', () => {
+    // Three random-ish identities should land on three different hues.
+    // Not asserting "all 3 unique" because djb2 + mod 360 has collisions —
+    // this is just a smoke check that the hash isn't flat-lining.
+    const colours = new Set([
+      authorColor('alice@example.com'),
+      authorColor('bob@example.com'),
+      authorColor('charlie@example.com'),
+    ]);
+    expect(colours.size).toBeGreaterThanOrEqual(2);
+  });
+
+  it('handles unicode identities without throwing', () => {
+    expect(() => authorColor('müller@example.com')).not.toThrow();
+    expect(authorColor('müller@example.com')).toMatch(/^hsl\(\d+, 60%, 52%\)$/);
+  });
+
+  it('handles the empty identity by returning the seed hue', () => {
+    // djb2 seed is 5381 → hue = 5381 % 360 = 341°. Pinning the seed
+    // behaviour so a future refactor that changes it is loud.
+    expect(authorColor('')).toBe('hsl(341, 60%, 52%)');
+  });
+
+  it('treats different-cased emails as different identities', () => {
+    // The caller (authorIdentity) lowercases emails before this point, so
+    // the colour function does NOT do its own normalisation. Documenting
+    // that contract here so a well-meaning refactor doesn't silently
+    // collapse author hues.
+    expect(authorColor('Alice@example.com')).not.toBe(authorColor('alice@example.com'));
+  });
+});
+
+describe('authorIdentity', () => {
+  it('prefers email over name', () => {
+    expect(authorIdentity('Alice', 'alice@example.com')).toBe('alice@example.com');
+  });
+
+  it('lowercases the email so case differences collapse to one hue', () => {
+    expect(authorIdentity('Alice', 'ALICE@EXAMPLE.COM')).toBe('alice@example.com');
+  });
+
+  it('falls back to the trimmed name when email is missing', () => {
+    expect(authorIdentity('  Alice  ', null)).toBe('Alice');
+    expect(authorIdentity('Alice', '')).toBe('Alice');
+    expect(authorIdentity('Alice', '   ')).toBe('Alice');
+  });
+
+  it('returns null when both inputs are empty / missing', () => {
+    expect(authorIdentity(null, null)).toBeNull();
+    expect(authorIdentity('', '')).toBeNull();
+    expect(authorIdentity('   ', '   ')).toBeNull();
+    expect(authorIdentity(undefined, undefined)).toBeNull();
+  });
+});

--- a/app/src/lib/folderMapColors.ts
+++ b/app/src/lib/folderMapColors.ts
@@ -1,0 +1,54 @@
+/// HSL fill colours for the folder map's git-driven overlays.
+///
+/// Lives in its own file so the maths can be unit-tested without dragging
+/// the whole `DiagramView` component into the test runner. The component
+/// imports both functions and the identity helper.
+
+/// Map a "seconds since last commit" value onto an HSL colour. Brand-new
+/// edits land in hot orange (~hue 18°); a year-old file decays into cool
+/// grey-blue (~hue 220°). Saturation drops with age so old code recedes
+/// visually. Log scale because the interesting structure lives in the
+/// last few days vs. the long tail of stale files.
+///
+/// `secs_ago` is clamped to a minimum of 60 s so commits with future
+/// timestamps and brand-new commits both anchor at the hot end of the
+/// scale. Negative inputs collapse to that same floor.
+export function recencyColor(secs_ago: number): string {
+  const day = 86_400;
+  const safe = Math.max(secs_ago, 60);
+  // t=0 at <1 day, t≈0.33 at ~10 days, t≈0.67 at ~year, t≥1 at 1000+ days.
+  const t = Math.min(1, Math.max(0, Math.log10(safe / day) / 3));
+  const hue = 18 + (220 - 18) * t;
+  const sat = 78 - 50 * t;
+  const light = 52 - 18 * t;
+  return `hsl(${hue.toFixed(0)}, ${sat.toFixed(0)}%, ${light.toFixed(0)}%)`;
+}
+
+/// Map an author identity (email when available, else display name) onto
+/// a stable HSL colour. djb2-style 32-bit hash → hue; saturation and
+/// lightness are fixed so all authors render at the same chroma. This
+/// is intentionally not "primary author by line count" — that would
+/// require git blame and far more work; "most recent committer per file"
+/// is a cheap proxy that correlates well in practice.
+export function authorColor(identity: string): string {
+  let h = 5381;
+  for (let i = 0; i < identity.length; i++) {
+    h = ((h << 5) + h + identity.charCodeAt(i)) | 0;
+  }
+  // Use the unsigned 32-bit mod 360 so identical strings always map to
+  // the same hue across reloads / processes.
+  const hue = (h >>> 0) % 360;
+  return `hsl(${hue}, 60%, 52%)`;
+}
+
+/// Pick the stablest per-author identity from a name + email pair. Email
+/// wins when present (people change display names but not email); falls
+/// back to the display name; null when the signature was empty.
+export function authorIdentity(
+  name: string | null | undefined,
+  email: string | null | undefined,
+): string | null {
+  if (email && email.trim()) return email.trim().toLowerCase();
+  if (name && name.trim()) return name.trim();
+  return null;
+}


### PR DESCRIPTION
## Summary
- Move `recencyColor`, `authorColor`, `authorIdentity` out of `DiagramView.svelte` into `app/src/lib/folderMapColors.ts`.
- Add 14 vitest cases covering hot/cool anchors, log-scale monotonicity, hash stability, unicode safety, and the email-lowercasing contract that `authorIdentity` enforces upstream.

## Why
These three functions are the load-bearing maths behind the recency heatmap and author overlay (already shipped via #129 and earlier). They had zero coverage because pulling a `.svelte` component into vitest is awkward — extracting them to a plain `.ts` module keeps the test surface small and clean.

Pure refactor: `DiagramView` imports the same three names; behaviour is unchanged.

## Test plan
- [x] `pnpm vitest run` — 38 / 38 (14 new)
- [x] `pnpm svelte-check` — 0 errors / 0 warnings
- [x] `cargo fmt --all -- --check` (no Rust touched but ran for completeness)
- [ ] Manual: open the folder map, toggle S/R/A — colours unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)