### PR TITLE
chore(housekeeping): add clean-logs5 + clean-logAll tasks

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -2,11 +2,11 @@ name: Housekeeping
 
 # Manually-triggered chores. Pick a task from the dropdown:
 #
-#  * **clean-logs** — delete every completed Action run except the latest 20.
-#    Use this when the Actions tab gets noisy from failed dependabot runs or
-#    abandoned PR check histories. Currently-running and queued runs are left
-#    alone.
+#  * **clean-logs**     — keep the latest 20 completed runs across the whole repo.
+#  * **clean-logs5**    — keep the latest 5 completed runs *per workflow*.
+#  * **clean-logAll**   — delete every completed run for every workflow.
 #
+# Currently-running and queued runs are always left alone.
 # Add new tasks by extending the `task` choice and the corresponding step.
 
 on:
@@ -15,10 +15,12 @@ on:
       task:
         description: 'Task to run'
         required: true
-        default: 'clean-logs'
+        default: 'clean-logs5'
         type: choice
         options:
           - clean-logs
+          - clean-logs5
+          - clean-logAll
 
 permissions:
   actions: write
@@ -29,15 +31,13 @@ jobs:
     name: ${{ inputs.task }}
     runs-on: ubuntu-22.04
     steps:
-      - name: clean-logs — keep latest 20 runs
+      - name: clean-logs — keep latest 20 runs (repo-wide)
         if: inputs.task == 'clean-logs'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          # Collect every completed run id (paginated). Sort by created_at
-          # descending so the slice past the keep-window is what we delete.
           mapfile -t ids < <(
             gh api --paginate "repos/${REPO}/actions/runs?per_page=100" \
               --jq '.workflow_runs
@@ -61,3 +61,77 @@ jobs:
             fi
           done
           echo "::notice::deleted=${deleted} failed=${failed} kept=${keep} total_before=${total}"
+
+      - name: clean-logs5 — keep latest 5 runs per workflow
+        if: inputs.task == 'clean-logs5'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mapfile -t workflow_ids < <(
+            gh api --paginate "repos/${REPO}/actions/workflows?per_page=100" \
+              --jq '.workflows[].id'
+          )
+          total_deleted=0
+          total_failed=0
+          total_kept=0
+          for wf in "${workflow_ids[@]}"; do
+            mapfile -t ids < <(
+              gh api --paginate "repos/${REPO}/actions/workflows/${wf}/runs?per_page=100" \
+                --jq '.workflow_runs
+                      | map(select(.conclusion != null))
+                      | sort_by(.created_at) | reverse
+                      | .[].id'
+            )
+            count=${#ids[@]}
+            keep=5
+            if [ "$count" -le "$keep" ]; then
+              echo "::notice::workflow=${wf} only ${count} completed — keeping all"
+              total_kept=$((total_kept + count))
+              continue
+            fi
+            wf_deleted=0
+            wf_failed=0
+            for id in "${ids[@]:$keep}"; do
+              if gh api -X DELETE "repos/${REPO}/actions/runs/${id}" 2>/dev/null; then
+                wf_deleted=$((wf_deleted + 1))
+              else
+                wf_failed=$((wf_failed + 1))
+              fi
+            done
+            echo "::notice::workflow=${wf} deleted=${wf_deleted} failed=${wf_failed} kept=${keep}"
+            total_deleted=$((total_deleted + wf_deleted))
+            total_failed=$((total_failed + wf_failed))
+            total_kept=$((total_kept + keep))
+          done
+          echo "::notice::TOTAL deleted=${total_deleted} failed=${total_failed} kept=${total_kept}"
+
+      - name: clean-logAll — delete every completed run for every workflow
+        if: inputs.task == 'clean-logAll'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mapfile -t ids < <(
+            gh api --paginate "repos/${REPO}/actions/runs?per_page=100" \
+              --jq '.workflow_runs
+                    | map(select(.conclusion != null))
+                    | .[].id'
+          )
+          total=${#ids[@]}
+          if [ "$total" -eq 0 ]; then
+            echo "::notice::no completed runs to delete"
+            exit 0
+          fi
+          deleted=0
+          failed=0
+          for id in "${ids[@]}"; do
+            if gh api -X DELETE "repos/${REPO}/actions/runs/${id}" 2>/dev/null; then
+              deleted=$((deleted + 1))
+            else
+              failed=$((failed + 1))
+            fi
+          done
+          echo "::notice::deleted=${deleted} failed=${failed} total=${total}"


### PR DESCRIPTION
## Summary
- Add **clean-logs5** task — keep the latest 5 completed runs *per workflow*
- Add **clean-logAll** task — delete every completed run for every workflow
- Existing **clean-logs** (repo-wide top-20) stays untouched
- Default dropdown selection switched to `clean-logs5` (the everyday option)

## Test plan
- [x] YAML lint via GitHub Actions parse
- [ ] Trigger `clean-logs5` and verify the run completes
- [ ] (Optional) Trigger `clean-logAll` once for a full sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)