### PR TITLE
feat(walkthrough): change-compass strip in tour step header (#127)

### DIFF
--- a/app/src/components/WalkthroughView.svelte
+++ b/app/src/components/WalkthroughView.svelte
@@ -33,6 +33,7 @@
   import { readZoom, writeZoom, clampZoom, wheelDelta } from '../lib/shiftWheelZoom';
   import { openUrl } from '../lib/openUrl';
   import { expandStepRefs, matchLineAnchor } from '../lib/walkthroughText';
+  import { compassFor, compassIconFor } from '../lib/compass';
 
   export let cursorId: string;
   export let cursorStep: number;
@@ -184,6 +185,7 @@
     const idx = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'));
     return idx === -1 ? p : p.slice(idx + 1);
   }
+
 
   // ----- Navigation ---------------------------------------------------------
 
@@ -626,6 +628,16 @@
               {/if}
             </div>
           {/if}
+          {#if compassFor(step.target).length > 0}
+            <nav class="compass" aria-label="Tour compass — where this step sits in the codebase">
+              <span class="compass-icon" aria-hidden="true">{compassIconFor(step.target)}</span>
+              <ol class="compass-trail">
+                {#each compassFor(step.target) as crumb, i (crumb + i)}
+                  <li class="compass-crumb" class:compass-tail={i === compassFor(step.target).length - 1}>{crumb}</li>
+                {/each}
+              </ol>
+            </nav>
+          {/if}
         </header>
 
         <div class="target" bind:this={targetEl}>
@@ -978,6 +990,52 @@
     background: var(--bg-2);
     padding: 1px 6px;
     border-radius: 3px;
+  }
+
+  /* Change-compass strip (#127). Sits below the target hint and shows where
+     this step lives — module breadcrumb for class targets, folder
+     breadcrumb for file targets, ref range for diff targets. */
+  .compass {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 4px;
+    font-size: 10px;
+    color: var(--fg-2);
+  }
+  .compass-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    border-radius: 3px;
+    background: var(--bg-2);
+    color: var(--fg-1);
+    font-family: var(--mono);
+    font-weight: 600;
+  }
+  .compass-trail {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 4px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+  .compass-crumb {
+    font-family: var(--mono);
+    color: var(--fg-2);
+  }
+  .compass-crumb:not(:last-child)::after {
+    content: '›';
+    color: var(--bg-3);
+    margin-left: 4px;
+  }
+  .compass-tail {
+    color: var(--fg-1);
+    font-weight: 600;
   }
 
   .target {

--- a/app/src/lib/compass.test.ts
+++ b/app/src/lib/compass.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { compassFor, compassIconFor } from './compass';
+
+describe('compassFor', () => {
+  it('returns last three FQN segments for a deeply-nested class', () => {
+    expect(compassFor({ kind: 'class', fqn: 'com.example.svc.user.UserService' })).toEqual([
+      'svc',
+      'user',
+      'UserService',
+    ]);
+  });
+
+  it('keeps the full FQN when there is only one segment', () => {
+    expect(compassFor({ kind: 'class', fqn: 'Standalone' })).toEqual(['Standalone']);
+  });
+
+  it('caps file paths at four segments and keeps the basename', () => {
+    expect(
+      compassFor({
+        kind: 'file',
+        path: '/Users/mad/work/repo/src/main/java/com/example/UserCtrl.java',
+      }),
+    ).toEqual(['java', 'com', 'example', 'UserCtrl.java']);
+  });
+
+  it('returns short paths verbatim', () => {
+    expect(compassFor({ kind: 'file', path: 'src/lib/foo.ts' })).toEqual([
+      'src',
+      'lib',
+      'foo.ts',
+    ]);
+  });
+
+  it('formats diff targets with `..` for explicit ranges', () => {
+    expect(compassFor({ kind: 'diff', reference: 'HEAD~5', to: 'HEAD' })).toEqual([
+      'HEAD~5..HEAD',
+    ]);
+  });
+
+  it('marks working-tree diffs explicitly', () => {
+    expect(compassFor({ kind: 'diff', reference: 'main' })).toEqual([
+      'main → working tree',
+    ]);
+  });
+
+  it('returns no crumbs for note targets', () => {
+    expect(compassFor({ kind: 'note' })).toEqual([]);
+  });
+
+  it('returns no crumbs for an undefined target', () => {
+    expect(compassFor(undefined)).toEqual([]);
+  });
+});
+
+describe('compassIconFor', () => {
+  it.each([
+    ['class', 'C'],
+    ['file', 'F'],
+    ['diff', 'Δ'],
+    ['note', '·'],
+  ])('maps %s to %s', (kind, expected) => {
+    expect(compassIconFor({ kind } as WalkthroughStep['target'])).toBe(expected);
+  });
+
+  it('returns empty for an undefined target', () => {
+    expect(compassIconFor(undefined)).toBe('');
+  });
+});
+
+// Tiny shim for the type-only import the it.each block needs at compile time.
+type WalkthroughStep = import('./api').WalkthroughStep;

--- a/app/src/lib/compass.ts
+++ b/app/src/lib/compass.ts
@@ -1,0 +1,53 @@
+/// Change-compass orientation helpers (#127).
+///
+/// The walkthrough viewer renders a single-line strip below each step's
+/// target hint that shows *where this step sits in the codebase*. The
+/// helpers here keep the logic out of the Svelte component so vitest can
+/// pin the breadcrumb math without booting a DOM.
+import type { WalkthroughStep } from './api';
+
+/// Breadcrumb segments for a tour step. Empty for `note` targets — those
+/// are stage-direction cards without a code anchor.
+///
+/// - **class**: last three FQN segments (`com.foo.bar.baz.UserSvc` →
+///   `bar`, `baz`, `UserSvc`). Falls back to the full FQN when the
+///   class lives in a top-level namespace.
+/// - **file**: last four path segments. Repos with deep nesting (Maven
+///   `src/main/java/...`) would otherwise dominate the strip.
+/// - **diff**: a single segment with the ref range (`HEAD~5..HEAD` or
+///   `HEAD~5 → working tree`).
+/// - **note** / unknown: no crumbs.
+export function compassFor(t: WalkthroughStep['target'] | undefined): string[] {
+  if (!t) return [];
+  if (t.kind === 'class' && t.fqn) {
+    const parts = t.fqn.split('.').filter(Boolean);
+    const tail = parts.slice(-3);
+    return tail.length > 1 ? tail : parts;
+  }
+  if (t.kind === 'file' && t.path) {
+    const parts = t.path.split(/[\\/]/).filter(Boolean);
+    return parts.length > 4 ? parts.slice(-4) : parts;
+  }
+  if (t.kind === 'diff') {
+    const range = t.to ? `${t.reference}..${t.to}` : `${t.reference} → working tree`;
+    return [range];
+  }
+  return [];
+}
+
+/// Single-letter glyph displayed next to the breadcrumb.
+export function compassIconFor(t: WalkthroughStep['target'] | undefined): string {
+  if (!t) return '';
+  switch (t.kind) {
+    case 'class':
+      return 'C';
+    case 'file':
+      return 'F';
+    case 'diff':
+      return 'Δ';
+    case 'note':
+      return '·';
+    default:
+      return '';
+  }
+}


### PR DESCRIPTION
## Summary
First slice of #127 (\"Tour UX: change compass overlay\"). Adds a one-line
orientation strip below each step's target hint:

- Class targets → last three FQN segments (\`bar › baz › UserSvc\`)
- File targets → last four path segments (caps deeply-nested Maven-style sources)
- Diff targets → the ref range (\`HEAD~5..HEAD\` / \`HEAD~5 → working tree\`)
- Note targets → no strip

Helpers extracted into \`app/src/lib/compass.ts\` so vitest can pin the
breadcrumb math without a DOM. **13 new tests, 58 total**, all green.

## Out of scope (future PR)
- **Hover-to-expand** with a mini list of related changed files —
  needs the tour body to carry a \`diff_ref\` and the GUI to call
  \`list_changes_since\` when the tour loads.
- **Click-to-drill** opens \`pm:file\`/\`pm:diff\` — same dependency.

This MVP gives the orientation signal the user is missing today; the
two follow-ups land cleanly on top once the diff-context plumbing is in.

## Test plan
- [x] \`cd app && npx svelte-check\` (0 errors / 0 warnings)
- [x] \`cd app && npm run test\` (58 frontend tests pass, +13 new)
- [ ] Manual smoke: open a tour, confirm the compass shows the right
      crumbs for class / file / diff targets and is hidden on \`note\`
      targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)