### PR TITLE
feat(walkthrough): diff focus rail — scroll + pulse the right hunk (#126)

### DIFF
--- a/app/src/components/DiffView.svelte
+++ b/app/src/components/DiffView.svelte
@@ -1,20 +1,39 @@
 <script lang="ts">
-  import { showDiff } from '../lib/api';
+  import { tick } from 'svelte';
+  import { showDiff, type DiffFocus } from '../lib/api';
   import { t } from '../lib/i18n';
   import { createShiftWheelZoom } from '../lib/shiftWheelZoom';
+  import { focusLineIndex, type DiffLine } from '../lib/diffFocus';
 
   export let reference: string;
   export let to: string | null = null;
+  /// Optional focus inside the diff (#126). When set, the matching
+  /// hunk / line is scrolled into view and pulsed once. Tour steps
+  /// without a focus pass `null`/`undefined` and the diff renders
+  /// exactly like before.
+  export let focus: DiffFocus | null = null;
 
   let raw = '';
-  let lines: { kind: 'meta' | 'header' | 'add' | 'del' | 'context' | 'hunk'; text: string }[] = [];
+  let lines: DiffLine[] = [];
   let loading = false;
   let error: string | null = null;
+
+  /// `index → element ref` map of rendered diff lines. Populated by
+  /// the `bind:this` on the `<span class="line">` block; used to
+  /// scroll the focused line into view.
+  let lineEls: HTMLSpanElement[] = [];
+  /// Index of the line that should currently pulse, or `null` for no
+  /// pulse. Cleared after the CSS animation finishes so the same
+  /// focus can be re-triggered when the tour pointer moves.
+  let pulseIdx: number | null = null;
 
   // Shift + wheel zoom, persisted under the per-component key.
   const { zoom, action: zoomAction } = createShiftWheelZoom('projectmind.diffview.zoom');
 
   $: if (reference) void load(reference, to);
+  /// React to focus changes after the load — the user can scrub through
+  /// tour steps that share `reference`/`to` but tweak the focus.
+  $: if (lines.length > 0 && focus !== undefined) void applyFocus(focus);
 
   async function load(ref: string, target: string | null) {
     loading = true;
@@ -22,6 +41,10 @@
     try {
       raw = await showDiff(ref, target ?? undefined);
       lines = parse(raw);
+      lineEls = [];
+      // Wait for the bind:this refs to land, then react to the current focus.
+      await tick();
+      await applyFocus(focus);
     } catch (err) {
       error = String(err);
       lines = [];
@@ -30,7 +53,29 @@
     }
   }
 
-  function parse(diff: string): typeof lines {
+  async function applyFocus(f: DiffFocus | null | undefined) {
+    if (!f || lines.length === 0) {
+      pulseIdx = null;
+      return;
+    }
+    const idx = focusLineIndex(lines, f);
+    if (idx === null) {
+      pulseIdx = null;
+      return;
+    }
+    await tick();
+    const el = lineEls[idx];
+    if (!el) return;
+    el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    pulseIdx = idx;
+    // Clear the pulse after the animation duration so re-focusing the
+    // same line later still triggers the highlight.
+    window.setTimeout(() => {
+      if (pulseIdx === idx) pulseIdx = null;
+    }, 1400);
+  }
+
+  function parse(diff: string): DiffLine[] {
     return diff.split('\n').map((text) => {
       if (text.startsWith('diff --git ')) return { kind: 'header' as const, text };
       if (
@@ -67,7 +112,7 @@
     <div class="status">{$t('diff.noChanges')}</div>
   {:else}
     <pre class="diff"><!--
-   --><!-- prettier-ignore -->{#each lines as l, i (i)}<span class="line {l.kind}">{l.text || ' '}</span>
+   --><!-- prettier-ignore -->{#each lines as l, i (i)}<span class="line {l.kind}" class:pulse={pulseIdx === i} bind:this={lineEls[i]}>{l.text || ' '}</span>
 {/each}</pre>
   {/if}
 </section>
@@ -176,5 +221,22 @@
     color: var(--diff-del-fg);
     background: color-mix(in srgb, var(--diff-del-bg) 22%, transparent);
     border-left-color: var(--diff-del-bg);
+  }
+  /* Tour focus pulse (#126). Plays once when the focused line scrolls
+     into view; cleared after 1.4s so the same line can be re-pulsed
+     when the tour pointer moves. */
+  .line.pulse {
+    animation: diff-pulse 1.4s ease-out;
+    border-left-color: var(--accent-2);
+  }
+  @keyframes diff-pulse {
+    0% {
+      background-color: color-mix(in srgb, var(--accent-2) 50%, transparent);
+      box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-2) 40%, transparent);
+    }
+    100% {
+      background-color: transparent;
+      box-shadow: none;
+    }
   }
 </style>

--- a/app/src/components/WalkthroughView.svelte
+++ b/app/src/components/WalkthroughView.svelte
@@ -845,7 +845,11 @@
             ><span class="lineno">{lineNo}</span><span class="content">{line}</span>
 </span>{/each}</code></pre>
           {:else if step.target.kind === 'diff'}
-            <DiffView reference={step.target.reference} to={step.target.to ?? null} />
+            <DiffView
+              reference={step.target.reference}
+              to={step.target.to ?? null}
+              focus={step.target.focus ?? null}
+            />
           {/if}
         </div>
 

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -416,10 +416,21 @@ export interface LineRange {
   to: number;
 }
 
+/// Optional spotlight inside a diff target (#126).
+export interface DiffFocus {
+  /// Repo-relative path or basename. Substring match on the
+  /// `+++ b/<path>` header.
+  file?: string;
+  /// 0-based hunk index inside `file` (or the whole diff when no file).
+  hunk?: number;
+  /// 1-based line number in the new file.
+  line?: number;
+}
+
 export type WalkthroughTarget =
   | { kind: 'class'; fqn: string; highlight?: LineRange[] }
   | { kind: 'file'; path: string; anchor?: string | null; highlight?: LineRange[] }
-  | { kind: 'diff'; reference: string; to?: string | null }
+  | { kind: 'diff'; reference: string; to?: string | null; focus?: DiffFocus }
   | { kind: 'note' };
 
 export interface WalkthroughStep {

--- a/app/src/lib/diffFocus.test.ts
+++ b/app/src/lib/diffFocus.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { focusLineIndex, parseHunkHeader, type DiffLine } from './diffFocus';
+
+const SAMPLE: DiffLine[] = [
+  { kind: 'header', text: 'diff --git a/src/a.ts b/src/a.ts' },
+  { kind: 'meta', text: 'index 1234..5678 100644' },
+  { kind: 'meta', text: '--- a/src/a.ts' },
+  { kind: 'meta', text: '+++ b/src/a.ts' },
+  { kind: 'hunk', text: '@@ -10,3 +10,4 @@' },
+  { kind: 'context', text: ' ten' },
+  { kind: 'add', text: '+eleven' },
+  { kind: 'context', text: ' twelve' },
+  { kind: 'context', text: ' thirteen' },
+  { kind: 'hunk', text: '@@ -100,2 +101,3 @@' },
+  { kind: 'context', text: ' hundred-one' },
+  { kind: 'add', text: '+hundred-two' },
+  { kind: 'context', text: ' hundred-three' },
+  { kind: 'header', text: 'diff --git a/src/b.ts b/src/b.ts' },
+  { kind: 'meta', text: '--- a/src/b.ts' },
+  { kind: 'meta', text: '+++ b/src/b.ts' },
+  { kind: 'hunk', text: '@@ -1,2 +1,3 @@' },
+  { kind: 'context', text: ' one' },
+  { kind: 'add', text: '+two' },
+  { kind: 'context', text: ' three' },
+];
+
+describe('parseHunkHeader', () => {
+  it('extracts old + new starts from canonical headers', () => {
+    expect(parseHunkHeader('@@ -10,3 +10,4 @@ extra')).toEqual({ oldStart: 10, newStart: 10 });
+  });
+
+  it('handles single-line hunks without a count', () => {
+    expect(parseHunkHeader('@@ -5 +5 @@')).toEqual({ oldStart: 5, newStart: 5 });
+  });
+
+  it('returns null for malformed headers', () => {
+    expect(parseHunkHeader('@@ broken')).toBeNull();
+  });
+});
+
+describe('focusLineIndex', () => {
+  it('returns null when no focus is requested', () => {
+    expect(focusLineIndex(SAMPLE, undefined)).toBeNull();
+    expect(focusLineIndex(SAMPLE, {})).toBeNull();
+  });
+
+  it('jumps to the first hunk of a named file when `hunk` and `line` are omitted', () => {
+    expect(focusLineIndex(SAMPLE, { file: 'b.ts' })).toBe(16);
+  });
+
+  it('jumps to a specific hunk index inside a file', () => {
+    expect(focusLineIndex(SAMPLE, { file: 'a.ts', hunk: 1 })).toBe(9);
+  });
+
+  it('clamps an out-of-range hunk index to the first hunk', () => {
+    expect(focusLineIndex(SAMPLE, { file: 'a.ts', hunk: 99 })).toBe(4);
+  });
+
+  it('walks forward to the first add/context line matching `line`', () => {
+    // file=a.ts, second hunk starts new-side at 101.
+    // Lines: 101=hundred-one (context), 102=hundred-two (add), 103=hundred-three (context).
+    expect(focusLineIndex(SAMPLE, { file: 'a.ts', hunk: 1, line: 102 })).toBe(11);
+  });
+
+  it('falls back to the hunk anchor when `line` does not match any line in the hunk', () => {
+    expect(focusLineIndex(SAMPLE, { file: 'a.ts', hunk: 1, line: 9999 })).toBe(9);
+  });
+
+  it('returns -1 sentinel (null) when the requested file is not in the diff', () => {
+    expect(focusLineIndex(SAMPLE, { file: 'c.ts' })).toBeNull();
+  });
+
+  it('handles `line` without a file by searching the first hunk', () => {
+    // Without a file, the first hunk (@@ -10,3 +10,4 @@) starts new-side at 10.
+    // Line 11 is the +eleven add line at index 6.
+    expect(focusLineIndex(SAMPLE, { line: 11 })).toBe(6);
+  });
+});

--- a/app/src/lib/diffFocus.ts
+++ b/app/src/lib/diffFocus.ts
@@ -1,0 +1,123 @@
+/// Diff focus helpers for the tour focus rail (#126).
+///
+/// Pure functions: take a parsed unified-diff line stream and a
+/// `DiffFocus` request, return the line index to scroll to. Lifted out
+/// of `DiffView.svelte` so vitest can pin the math without booting the
+/// component.
+
+import type { DiffFocus } from './api';
+
+/// Tagged unified-diff line — same shape `DiffView.svelte` produces.
+export interface DiffLine {
+  kind: 'meta' | 'header' | 'add' | 'del' | 'context' | 'hunk';
+  text: string;
+}
+
+/// Find the 0-based index in `lines` that the focus request points at.
+/// Returns `null` when nothing matches — caller leaves the diff at its
+/// natural starting position.
+///
+/// Resolution order:
+///   1. Restrict the search to `focus.file`'s file-block when set.
+///      Match is substring on the `+++ b/<path>` line so callers can
+///      pass full paths or basenames.
+///   2. Within that scope, pick the `hunk`-th hunk header (0-based).
+///   3. If `line` is set, walk forward from that hunk and find the
+///      first `add` or `context` line whose new-side line number
+///      equals `line`. (Hunk header `@@ -a,b +c,d @@` → start at `c`.)
+export function focusLineIndex(
+  lines: readonly DiffLine[],
+  focus: DiffFocus | undefined,
+): number | null {
+  if (!focus || (!focus.file && focus.hunk === undefined && focus.line === undefined)) {
+    return null;
+  }
+
+  const { fileStart, fileEnd } = fileWindow(lines, focus.file);
+  if (fileStart === -1) return null;
+
+  const hunkStarts: number[] = [];
+  for (let i = fileStart; i < fileEnd; i++) {
+    if (lines[i].kind === 'hunk') hunkStarts.push(i);
+  }
+
+  // No hunks at all → bail out gracefully.
+  if (hunkStarts.length === 0) return fileStart < lines.length ? fileStart : null;
+
+  const hunkIdx =
+    focus.hunk !== undefined && focus.hunk >= 0 && focus.hunk < hunkStarts.length
+      ? focus.hunk
+      : 0;
+  const hunkAt = hunkStarts[hunkIdx];
+
+  if (focus.line === undefined) return hunkAt;
+
+  // Walk forward through the hunk body looking for a +/context line whose
+  // new-side line number equals `focus.line`.
+  const newStart = parseHunkHeader(lines[hunkAt].text)?.newStart ?? null;
+  if (newStart === null) return hunkAt;
+
+  let cur = newStart;
+  for (let i = hunkAt + 1; i < fileEnd; i++) {
+    const l = lines[i];
+    if (l.kind === 'hunk') break; // next hunk — out of scope
+    if (l.kind === 'header' || l.kind === 'meta') continue;
+    if (l.kind === 'add' || l.kind === 'context') {
+      if (cur === focus.line) return i;
+      cur += 1;
+    }
+    // `del` lines don't advance the new-side counter.
+  }
+  return hunkAt;
+}
+
+/// Find `[start, end)` of the diff block that contains `file`, or
+/// `[0, lines.length)` when no file is requested. Returns `-1` for the
+/// start when the file isn't in the diff.
+export function fileWindow(
+  lines: readonly DiffLine[],
+  file: string | undefined,
+): { fileStart: number; fileEnd: number } {
+  if (!file) return { fileStart: 0, fileEnd: lines.length };
+  const blocks = fileBlocks(lines);
+  for (const b of blocks) {
+    // The header lives a few lines after `diff --git` — match on any
+    // header / meta line that mentions the requested path.
+    for (let i = b.start; i < b.end; i++) {
+      const l = lines[i];
+      if ((l.kind === 'header' || l.kind === 'meta') && l.text.includes(file)) {
+        return { fileStart: b.start, fileEnd: b.end };
+      }
+    }
+  }
+  return { fileStart: -1, fileEnd: -1 };
+}
+
+/// Split the diff into per-file blocks delimited by `diff --git` headers.
+function fileBlocks(lines: readonly DiffLine[]): { start: number; end: number }[] {
+  const out: { start: number; end: number }[] = [];
+  let cur = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].kind === 'header') {
+      if (cur !== -1) out.push({ start: cur, end: i });
+      cur = i;
+    }
+  }
+  if (cur !== -1) out.push({ start: cur, end: lines.length });
+  // Diffs without any file header (e.g. when only `+`/`-` lines were
+  // captured) still need a single window so the focus logic doesn't
+  // bail out.
+  if (out.length === 0 && lines.length > 0) out.push({ start: 0, end: lines.length });
+  return out;
+}
+
+/// Parse a `@@ -a,b +c,d @@` hunk header. Returns the new-side line
+/// numbers (1-based start). `null` for malformed headers.
+export function parseHunkHeader(
+  header: string,
+): { oldStart: number; newStart: number } | null {
+  // `@@ -a,b +c,d @@ optional-context`
+  const m = /^@@\s+-(\d+)(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/.exec(header);
+  if (!m) return null;
+  return { oldStart: Number(m[1]), newStart: Number(m[2]) };
+}

--- a/crates/core/src/walkthrough.rs
+++ b/crates/core/src/walkthrough.rs
@@ -76,9 +76,39 @@ pub enum WalkthroughTarget {
         /// Optional target ref. `None` means working tree.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         to: Option<String>,
+        /// Optional focus inside the diff (#126). When present the GUI
+        /// scrolls + pulses the matching hunk; old tour payloads that
+        /// don't set it render the diff exactly like before.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        focus: Option<DiffFocus>,
     },
     /// Pure narration; nothing rendered in the target pane.
     Note,
+}
+
+/// Optional spotlight inside a diff target (#126).
+///
+/// All fields are independent: `file` alone scrolls the diff to the first
+/// hunk of that file; `file + hunk` jumps to a specific hunk inside it;
+/// `file + line` jumps to a particular line. The GUI tolerates any
+/// combination — a `line` without a `file` falls back to "first hunk
+/// containing that line", which is usually unique inside a single
+/// commit-sized patch.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DiffFocus {
+    /// Repository-relative path of the file to scroll to. Match is
+    /// substring on the `+++ b/<path>` header so callers can pass
+    /// either the relative path or just the basename.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    /// 0-based hunk index *within `file`* (or the whole diff when no
+    /// file is set). Ignored when out of range.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hunk: Option<u32>,
+    /// 1-based line number in the new file (i.e. the right side of the
+    /// diff). Ignored when out of range.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<u32>,
 }
 
 /// 1-based inclusive line range.

--- a/crates/mcp-server/src/tools.rs
+++ b/crates/mcp-server/src/tools.rs
@@ -138,6 +138,15 @@ fn walkthrough_step_schema() -> Value {
                     "anchor": { "type": "string", "description": "Heading slug (kind=file, markdown only)" },
                     "ref":  { "type": "string", "description": "Base git ref (kind=diff)" },
                     "to":   { "type": "string", "description": "Target git ref or omit for working tree (kind=diff)" },
+                    "focus": {
+                        "type": "object",
+                        "description": "Optional spotlight inside the diff (kind=diff). The GUI scrolls + pulses the matching hunk; tours without `focus` render exactly like before.",
+                        "properties": {
+                            "file": { "type": "string", "description": "Repo-relative path or basename — substring match on the `+++ b/<path>` header." },
+                            "hunk": { "type": "integer", "minimum": 0, "description": "0-based hunk index inside `file` (or the whole diff when `file` is omitted)." },
+                            "line": { "type": "integer", "minimum": 1, "description": "1-based line number in the new file." }
+                        }
+                    },
                     "highlight": {
                         "type": "array",
                         "description": "Line ranges to colour (kind=class or kind=file with non-markdown extension). 1-based inclusive.",


### PR DESCRIPTION
## Summary
Adds an optional \`focus\` field to walk-through diff targets so a tour
can spotlight a specific file / hunk / line inside a multi-hunk diff
instead of dumping the user at the top.

## Changes
- **Backend** (\`core::walkthrough\`): new optional \`DiffFocus\` struct
  on \`WalkthroughTarget::Diff\`. Tours that don't use it round-trip
  cleanly.
- **MCP** (\`walkthrough_step_schema\`): diff target accepts an
  optional \`focus\` object (file / hunk / line).
- **Frontend** (\`DiffView\`): new optional \`focus\` prop. After
  loading, the matching line is \`scrollIntoView({ block: 'center' })\`
  and pulsed once via a 1.4s CSS animation.
- **Logic** (\`app/src/lib/diffFocus.ts\`): pure resolver — file-window
  scoping, hunk-index clamping, walk-through to the requested
  new-side line, hunk-header parsing. **11 vitest specs**, 77 total.

## Acceptance criteria (from #126)
- [x] Existing diff view still works for plain \`reference\`/\`to\` targets.
- [x] Focus metadata can scroll to and highlight a specific
      file/hunk/line.
- [x] Empty diffs and invalid focus metadata show a readable fallback
      (no scroll, no pulse, no error).

## Out of scope (follow-up)
- The dedicated rail showing all changed files as clickable markers.
  Pure additive on top of \`fileBlocks\` once the focus plumbing here
  is in.

## Test plan
- [x] \`cargo test --workspace --lib\` (passes; no new Rust tests this
      PR — \`DiffFocus\` is a pure data struct exercised by the
      existing JSON round-trip path).
- [x] \`cd app && npx svelte-check\` (0 errors / 0 warnings)
- [x] \`cd app && npm run test\` (77 frontend tests pass; +11 new diffFocus)
- [x] \`cargo fmt\` + \`cargo clippy --workspace --all-targets -- -D warnings\`
- [ ] Manual smoke: tour step with \`focus.file + focus.line\` against
      a multi-file diff → confirm the right line scrolls into view
      and pulses; clear focus → confirm normal rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)