### PR TITLE
chore(ci): camelCase workflow names + housekeeping rename + bump CodeQL action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: ci
 
 on:
   push:
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   rust:
-    name: Rust ${{ matrix.os }}
+    name: rust / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -80,8 +80,8 @@ jobs:
           PROJECTMIND_SKIP_TAURI_APP: ${{ runner.os == 'Linux' && '1' || '' }}
         run: ./scripts/ci.sh test
 
-  release-build:
-    name: Release build (Linux)
+  releaseBuild:
+    name: releaseBuild (linux)
     runs-on: ubuntu-22.04
     needs: rust
     permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-name: CodeQL (advanced)
+name: codeqlAdvanced
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
 
 jobs:
   analyze:
-    name: Analyze ${{ matrix.language }}
+    name: analyze / ${{ matrix.language }}
     runs-on: ${{ matrix.os }}
     permissions:
       security-events: write
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3
+        uses: github/codeql-action/init@c3f298df8c1fea2fefe20c785e6aa00f32df8260 # v4.35.3
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
@@ -72,13 +72,13 @@ jobs:
 
       - name: Autobuild
         if: matrix.language != 'rust'
-        uses: github/codeql-action/autobuild@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3
+        uses: github/codeql-action/autobuild@c3f298df8c1fea2fefe20c785e6aa00f32df8260 # v4.35.3
 
       - name: Build Rust for CodeQL
         if: matrix.language == 'rust'
         run: cargo build --workspace --exclude projectmind-app
 
       - name: Analyze
-        uses: github/codeql-action/analyze@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3
+        uses: github/codeql-action/analyze@c3f298df8c1fea2fefe20c785e6aa00f32df8260 # v4.35.3
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -1,10 +1,9 @@
-name: Housekeeping
+name: housekeeping
 
 # Manually-triggered chores. Pick a task from the dropdown:
 #
-#  * **clean-logs**     — keep the latest 20 completed runs across the whole repo.
-#  * **clean-logs5**    — keep the latest 5 completed runs *per workflow*.
-#  * **clean-logAll**   — delete every completed run for every workflow.
+#  * **deleteLogs5**  — keep the latest 5 completed runs *per workflow*.
+#  * **deleteLogAll** — delete every completed run for every workflow.
 #
 # Currently-running and queued runs are always left alone.
 # Add new tasks by extending the `task` choice and the corresponding step.
@@ -15,12 +14,11 @@ on:
       task:
         description: 'Task to run'
         required: true
-        default: 'clean-logs5'
+        default: 'deleteLogs5'
         type: choice
         options:
-          - clean-logs
-          - clean-logs5
-          - clean-logAll
+          - deleteLogs5
+          - deleteLogAll
 
 permissions:
   actions: write
@@ -31,39 +29,8 @@ jobs:
     name: ${{ inputs.task }}
     runs-on: ubuntu-22.04
     steps:
-      - name: clean-logs — keep latest 20 runs (repo-wide)
-        if: inputs.task == 'clean-logs'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          mapfile -t ids < <(
-            gh api --paginate "repos/${REPO}/actions/runs?per_page=100" \
-              --jq '.workflow_runs
-                    | map(select(.conclusion != null))
-                    | sort_by(.created_at) | reverse
-                    | .[].id'
-          )
-          total=${#ids[@]}
-          keep=20
-          if [ "$total" -le "$keep" ]; then
-            echo "::notice::only ${total} completed runs — nothing to delete"
-            exit 0
-          fi
-          deleted=0
-          failed=0
-          for id in "${ids[@]:$keep}"; do
-            if gh api -X DELETE "repos/${REPO}/actions/runs/${id}" 2>/dev/null; then
-              deleted=$((deleted + 1))
-            else
-              failed=$((failed + 1))
-            fi
-          done
-          echo "::notice::deleted=${deleted} failed=${failed} kept=${keep} total_before=${total}"
-
-      - name: clean-logs5 — keep latest 5 runs per workflow
-        if: inputs.task == 'clean-logs5'
+      - name: deleteLogs5 — keep latest 5 runs per workflow
+        if: inputs.task == 'deleteLogs5'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -107,8 +74,8 @@ jobs:
           done
           echo "::notice::TOTAL deleted=${total_deleted} failed=${total_failed} kept=${total_kept}"
 
-      - name: clean-logAll — delete every completed run for every workflow
-        if: inputs.task == 'clean-logAll'
+      - name: deleteLogAll — delete every completed run for every workflow
+        if: inputs.task == 'deleteLogAll'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: release
 
 # Two trigger paths into the same workflow file:
 #
@@ -44,7 +44,7 @@ jobs:
   # version reference, pushes a release/vX.Y.Z branch, opens a PR. Once the
   # PR is merged and a tag pushed, the build+publish path below takes over.
   bump:
-    name: Bump version + open PR
+    name: bumpVersion + openPr
     if: github.event_name == 'workflow_dispatch' && inputs.bump != ''
     runs-on: ubuntu-22.04
     permissions:
@@ -124,7 +124,7 @@ jobs:
   #          Linux, .msi/.exe on Windows).
 
   mcp:
-    name: MCP server / ${{ matrix.asset_suffix }}
+    name: mcpServer / ${{ matrix.asset_suffix }}
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ${{ matrix.os }}
     permissions:
@@ -190,7 +190,7 @@ jobs:
           retention-days: 30
 
   app:
-    name: Desktop app / ${{ matrix.asset_suffix }}
+    name: desktopApp / ${{ matrix.asset_suffix }}
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ${{ matrix.os }}
     permissions:
@@ -302,7 +302,7 @@ jobs:
           if-no-files-found: ignore
 
   publish:
-    name: Publish GitHub release
+    name: publishGithubRelease
     needs: [mcp, app]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary
- **Workflow display names** switched to camelCase:
  | old | new |
  |---|---|
  | \`CI\` | \`ci\` |
  | \`CodeQL (advanced)\` | \`codeqlAdvanced\` |
  | \`Housekeeping\` | \`housekeeping\` |
  | \`Release\` | \`release\` |
- **Housekeeping dropdown** reduced to two choices and renamed:
  - \`clean-logs5\` → \`deleteLogs5\` (default)
  - \`clean-logAll\` → \`deleteLogAll\`
  - the older repo-wide \`clean-logs\` (top-20) was dropped — \`deleteLogs5\`
    is the better default and a third option just clutters the picker.
- **\`github/codeql-action\` bumped from v3.35.3 → v4.35.3** (\`init\`,
  \`autobuild\`, \`analyze\`). v3 is deprecated upstream; our config
  (\`security-and-quality\` + \`paths-ignore\`) carries forward as-is.
- **Other action pins audited** against latest upstream releases —
  already current (actions/checkout v6.0.2, Swatinem/rust-cache v2.9.1,
  pnpm/action-setup v6.0.5, actions/setup-node v6.4.0,
  actions/upload-artifact v7.0.1, actions/download-artifact v8.0.1,
  softprops/action-gh-release v3.0.0).
- **Job-key tidying**: \`release-build\` → \`releaseBuild\`; job display
  names in the Release workflow follow the same convention
  (\`bumpVersion+openPr\`, \`mcpServer\`, \`desktopApp\`,
  \`publishGithubRelease\`).

## Failures audit
The last failed run on master (run \`25392754529\`) was a one-off
\`cargo fmt\` diff in the C4-container PR (#136), already corrected
before merge. No systemic / reproducible failure to chase.

## Test plan
- [x] \`yaml.safe_load\` on every workflow file (parses cleanly)
- [x] \`needs:\` references audited (\`needs: rust\` in ci, \`needs: [mcp, app]\`
      in release — both still resolve to existing jobs)
- [x] CodeQL action SHA pinned to v4.35.3 (\`c3f298df...\`)
- [ ] Once merged: trigger \`housekeeping\` once with \`deleteLogs5\` to
      confirm the dropdown choices render correctly in the UI.
- [ ] Wait for the next scheduled \`codeqlAdvanced\` run to confirm v4
      action pulls cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)