### PR TITLE
fix(app): handle macOS Finder open-files event for .md double-click

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -969,7 +969,8 @@ pub fn run() {
         ));
     }
     let setup_state = Arc::clone(&state);
-    builder
+    let run_state = Arc::clone(&state);
+    let app = builder
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
@@ -1014,8 +1015,26 @@ pub fn run() {
             spawn_heartbeat();
             Ok(())
         })
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application");
+
+    // macOS delivers Finder-double-click paths via the Apple `openFiles` event,
+    // not argv and not the `single_instance` callback. Tauri 2 surfaces this as
+    // `RunEvent::Opened`; we route the first markdown URL through the same
+    // queue the argv / single-instance paths use, so the frontend reacts the
+    // same way regardless of how the file got to us.
+    app.run(move |app_handle, event| {
+        if let tauri::RunEvent::Opened { urls } = event {
+            for url in urls {
+                if let Ok(path) = url.to_file_path() {
+                    if is_markdown_path(&path) {
+                        queue_markdown_file(app_handle, &run_state, path);
+                        break;
+                    }
+                }
+            }
+        }
+    });
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Wires `RunEvent::Opened` into the existing `queue_markdown_file()` pipeline so a Finder double-click on a `.md` file actually opens that file in ProjectMind instead of landing on the welcome screen.
- macOS delivers Finder-launched paths via the Apple `openFiles` event, not argv and not the `single_instance` callback — both existing paths therefore missed it on macOS.
- No behaviour change on Linux/Windows: argv and `single_instance` still drive the same queue.

## Test plan
- [ ] Build a release bundle (e.g. `./scripts/...` or `cargo tauri build`), install the `.app`, double-click any `.md` in Finder while ProjectMind is **not** running — expect the document to open directly in the file viewer.
- [ ] Repeat with ProjectMind already running — expect the existing window to focus and switch to the dropped document (no duplicate window).
- [ ] Regression: drop a folder onto the window / launch via CLI on Linux — unchanged behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)