### PR TITLE
fix(app): cfg-gate RunEvent::Opened handler to macOS

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1020,22 +1020,30 @@ pub fn run() {
 
     // macOS delivers Finder-double-click paths via the Apple `openFiles` event,
     // not argv and not the `single_instance` callback. Tauri 2 surfaces this as
-    // `RunEvent::Opened`; we route the first markdown URL through the same
-    // queue the argv / single-instance paths use, so the frontend reacts the
-    // same way regardless of how the file got to us.
+    // `RunEvent::Opened`, which only exists on macOS — Linux/Windows builds
+    // would fail to compile against the variant, so the handler is cfg-gated
+    // to a helper that's a no-op there.
     app.run(move |app_handle, event| {
-        if let tauri::RunEvent::Opened { urls } = event {
-            for url in urls {
-                if let Ok(path) = url.to_file_path() {
-                    if is_markdown_path(&path) {
-                        queue_markdown_file(app_handle, &run_state, path);
-                        break;
-                    }
+        handle_run_event(app_handle, &run_state, event);
+    });
+}
+
+#[cfg(target_os = "macos")]
+fn handle_run_event(app: &AppHandle, state: &Arc<AppState>, event: tauri::RunEvent) {
+    if let tauri::RunEvent::Opened { urls } = event {
+        for url in urls {
+            if let Ok(path) = url.to_file_path() {
+                if is_markdown_path(&path) {
+                    queue_markdown_file(app, state, path);
+                    break;
                 }
             }
         }
-    });
+    }
 }
+
+#[cfg(not(target_os = "macos"))]
+fn handle_run_event(_app: &AppHandle, _state: &Arc<AppState>, _event: tauri::RunEvent) {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary
- Hotfix for v0.4.0 release build: `RunEvent::Opened` is a macOS-only variant in Tauri 2, so the Linux/Windows release jobs failed with `E0599: no variant named Opened`.
- Moves the handler into a `#[cfg(target_os = \"macos\")]` helper with a no-op `cfg(not)` twin so all three platforms compile while macOS keeps the Finder-double-click pipeline introduced in #148.

## Test plan
- [x] `./scripts/ci.sh check` (fmt + clippy) green locally on macOS.
- [ ] CI: `rust / ubuntu-22.04`, `rust / macos-14`, `releaseBuild (linux)` all green.
- [ ] After merge + tag re-push (`v0.4.0` or `v0.4.1`) the desktopApp matrix completes and `publishGithubRelease` produces a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)