### PR TITLE
fix(diagram): non-passive wheel zoom + home button + nav glue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3252,7 +3252,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-app"
-version = "0.3.7"
+version = "0.5.0"
 dependencies = [
  "notify",
  "parking_lot",
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-browser-host"
-version = "0.3.7"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "open",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-core"
-version = "0.3.7"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3315,7 +3315,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-framework-lombok"
-version = "0.3.7"
+version = "0.5.0"
 dependencies = [
  "projectmind-plugin-api",
  "serde_json",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-framework-spring"
-version = "0.3.7"
+version = "0.5.0"
 dependencies = [
  "projectmind-plugin-api",
  "tracing",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-lang-java"
-version = "0.3.7"
+version = "0.5.0"
 dependencies = [
  "projectmind-plugin-api",
  "tracing",
@@ -3341,7 +3341,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-lang-rust"
-version = "0.3.7"
+version = "0.5.0"
 dependencies = [
  "projectmind-plugin-api",
  "tracing",
@@ -3351,7 +3351,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-mcp"
-version = "0.3.7"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-plugin-api"
-version = "0.3.7"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3252,7 +3252,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-app"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "notify",
  "parking_lot",
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-browser-host"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "open",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3315,7 +3315,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-framework-lombok"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "projectmind-plugin-api",
  "serde_json",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-framework-spring"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "projectmind-plugin-api",
  "tracing",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-lang-java"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "projectmind-plugin-api",
  "tracing",
@@ -3341,7 +3341,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-lang-rust"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "projectmind-plugin-api",
  "tracing",
@@ -3351,7 +3351,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-mcp"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "projectmind-plugin-api"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/Plaintext-Gmbh/projectmind"
@@ -49,8 +49,8 @@ struct_field_names = "allow"
 ignored_unit_patterns = "allow"
 
 [workspace.dependencies]
-projectmind-plugin-api = { path = "crates/plugin-api", version = "0.5.0" }
-projectmind-core       = { path = "crates/core",       version = "0.5.0" }
+projectmind-plugin-api = { path = "crates/plugin-api", version = "0.6.0" }
+projectmind-core       = { path = "crates/core",       version = "0.6.0" }
 
 # General
 anyhow      = "1.0"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "projectmind-app",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -21,10 +21,10 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 projectmind-plugin-api = { workspace = true }
 projectmind-core       = { workspace = true }
-projectmind-lang-java  = { path = "../../plugins/lang-java", version = "0.5.0" }
-projectmind-lang-rust  = { path = "../../plugins/lang-rust", version = "0.5.0" }
-projectmind-framework-spring = { path = "../../plugins/framework-spring", version = "0.5.0" }
-projectmind-framework-lombok = { path = "../../plugins/framework-lombok", version = "0.5.0" }
+projectmind-lang-java  = { path = "../../plugins/lang-java", version = "0.6.0" }
+projectmind-lang-rust  = { path = "../../plugins/lang-rust", version = "0.6.0" }
+projectmind-framework-spring = { path = "../../plugins/framework-spring", version = "0.6.0" }
+projectmind-framework-lombok = { path = "../../plugins/framework-lombok", version = "0.6.0" }
 
 tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-dialog = "2"

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -707,7 +707,14 @@ fn list_module_files(
     Ok(files::list_module_files(
         &module.root,
         &[
+            // Image / PDF
             "pdf", "png", "jpg", "jpeg", "webp", "gif", "svg", "bmp", "ico",
+            // Markdown + HTML — surfaced as module-scoped filter chips so
+            // the user sees the per-module count when they pick a module.
+            // The repo-wide MarkdownIndex / HtmlIndex remain reachable via
+            // the "md" / "html" shortcut chips shown when no module is
+            // filtered.
+            "md", "markdown", "html", "htm",
         ],
     ))
 }

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -30,6 +30,7 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": "all",
     "icon": [
       "icons/icon.png",

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "ProjectMind",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "identifier": "ch.plaintext.projectmind",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/src/App.svelte
+++ b/app/src/App.svelte
@@ -138,6 +138,22 @@
     }
   }
 
+  /// "Home" — return to the file/class overview with every filter axis
+  /// cleared. This is the user's escape hatch from any sub-mode (md, html,
+  /// file, diagram detail, walkthrough, diff) and is intentionally more
+  /// aggressive than `activateTab(files)`: it also drops the module,
+  /// stereotype, file-kind and package filters so the list is fresh.
+  function goHome() {
+    followingMcp.set(false);
+    selectedClass.set(null);
+    fileView.set(null);
+    moduleFilter.set(null);
+    packageFilter.set(null);
+    stereotypeFilter.set(null);
+    fileKindFilter.set(null);
+    viewMode.set('classes');
+  }
+
   function toggleLang() {
     // Cycle through the configured languages (codex's i18n module ships
     // five). Wrap to the first one once we hit the end.
@@ -642,7 +658,8 @@
             v.diagram_kind === 'inheritance-tree' ||
             v.diagram_kind === 'doc-graph' ||
             v.diagram_kind === 'c4-container' ||
-            v.diagram_kind === 'architecture-layers'
+            v.diagram_kind === 'architecture-layers' ||
+            v.diagram_kind === 'language-stats'
           ) {
             diagramKind = v.diagram_kind;
           }
@@ -962,6 +979,12 @@
     </div>
     <nav>
       {#if $repo}
+        <button
+          class="home-btn"
+          on:click={goHome}
+          title={$t('nav.home') || 'Home — Filter zurücksetzen'}
+          aria-label={$t('nav.home') || 'Home'}
+        >⌂</button>
         {#each $repo.tabs as tab (tab.id)}
           <button
             class:active={isTabActive(tab, $viewMode)}
@@ -1710,6 +1733,19 @@
     font-size: 11px;
     font-weight: 600;
     line-height: 1;
+  }
+
+  .home-btn {
+    width: 34px;
+    padding: 6px 0;
+    text-align: center;
+    font-size: 17px;
+    line-height: 1;
+    color: var(--fg-1);
+  }
+  .home-btn:hover {
+    color: var(--accent-2);
+    border-color: var(--accent-2);
   }
 
   .sidebars-toggle {

--- a/app/src/App.svelte
+++ b/app/src/App.svelte
@@ -65,6 +65,7 @@
   import type { HistoryEntry, DiagramKind, FolderMapLayout } from './lib/navigation';
   import * as recents from './lib/recentRepos';
   import { recentRepos } from './lib/recentRepos';
+  import { openUrl } from './lib/openUrl';
   const lazyDiagramIndex = () =>
     loadComponent('DiagramIndex', () => import('./components/DiagramIndex.svelte'));
   const lazyFileView = () =>
@@ -402,9 +403,22 @@
 
   // Distinct kinds present in the visible files — drives the filter pills
   // shown next to the stereotype pills. Sorted for stable UI ordering.
+  //
+  // md/html are special-cased: when no module is filtered, the repo-wide
+  // markdown_count / html_count shortcut chips below already represent
+  // those buckets (and link into the dedicated MarkdownIndex / HtmlIndex
+  // viewers), so adding them here too would double up. When a module is
+  // active those shortcuts hide, and md/html chips here become the
+  // per-module filter — single source of truth in each mode.
   $: fileKindsPresent = (() => {
     const set = new Set<string>();
     for (const f of $filteredModuleFiles) set.add(f.kind);
+    if (!$moduleFilter) {
+      set.delete('md');
+      set.delete('markdown');
+      set.delete('html');
+      set.delete('htm');
+    }
     return Array.from(set).sort();
   })();
 
@@ -446,6 +460,12 @@
     }));
     if (f.kind === 'pdf') {
       viewMode.set('pdf');
+    } else if (f.kind === 'md' || f.kind === 'markdown' || f.kind === 'html' || f.kind === 'htm') {
+      // FileView renders both markdown (with TOC + anchor support) and html
+      // (sanitised). The dedicated MarkdownIndex / HtmlIndex viewers are
+      // still reachable via the repo-wide shortcut chips — these per-module
+      // chips just open the file directly.
+      viewMode.set('file');
     } else {
       viewMode.set('image');
     }
@@ -815,8 +835,31 @@
     );
   }
 
+  /// Last-line-of-defence link guard. Any `<a href="http(s)://…">` click that
+  /// bubbles up to the document — i.e. wasn't already prevented by a more
+  /// specific component handler (FileView, WalkthroughView) — is rerouted to
+  /// the system browser instead of letting the Tauri webview navigate away
+  /// from the SPA. Without this, a stray link in SVG / mermaid / any future
+  /// rendered HTML kills the entire app shell and the user gets stranded.
+  function globalLinkGuard(ev: MouseEvent) {
+    if (ev.defaultPrevented) return;
+    let node: HTMLElement | null = ev.target as HTMLElement | null;
+    while (node && node !== document.body) {
+      if (node.tagName === 'A') break;
+      node = node.parentElement;
+    }
+    if (!node || node.tagName !== 'A') return;
+    const href = (node as HTMLAnchorElement).getAttribute('href') ?? '';
+    if (!href) return;
+    if (/^(https?:|mailto:)/i.test(href)) {
+      ev.preventDefault();
+      void openUrl(href);
+    }
+  }
+
   onMount(async () => {
     window.addEventListener('keydown', onNavKey);
+    document.addEventListener('click', globalLinkGuard, true);
     startUpdateChecks();
     browserMode = !isTauriRuntime();
     if (browserMode && !browserToken()) {
@@ -893,6 +936,7 @@
 
   onDestroy(() => {
     window.removeEventListener('keydown', onNavKey);
+    document.removeEventListener('click', globalLinkGuard, true);
     unlistenState?.();
     unlistenOpenMarkdownFile?.();
     unlistenDragDrop?.();
@@ -984,7 +1028,25 @@
           on:click={goHome}
           title={$t('nav.home') || 'Home — Filter zurücksetzen'}
           aria-label={$t('nav.home') || 'Home'}
-        >⌂</button>
+        >
+          <!-- Inline SVG: bold house glyph. The Unicode ⌂ (U+2302) was too
+               thin at button size; this Lucide-style path has 2.2 px strokes
+               that read clearly at the 17 px font size we use. currentColor
+               so it inherits the button's hover/active palette. -->
+          <svg
+            class="home-icon"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M3 11.5 12 4l9 7.5" />
+            <path d="M5 10v9a1 1 0 0 0 1 1h4v-6h4v6h4a1 1 0 0 0 1-1v-9" />
+          </svg>
+        </button>
         {#each $repo.tabs as tab (tab.id)}
           <button
             class:active={isTabActive(tab, $viewMode)}
@@ -1228,7 +1290,16 @@
                 {kind} <span class="count">{$filteredModuleFiles.filter((f) => f.kind === kind).length}</span>
               </button>
             {/each}
-            {#if $repo && $repo.markdown_count > 0}
+            <!-- md / html chips are repo-wide shortcuts into the dedicated
+                 MarkdownIndex / HtmlIndex viewers — they show *every*
+                 markdown/html file in the repo, not just the ones inside
+                 the active module. Hiding them when a module filter is
+                 active keeps the chip row honest: every chip shown there
+                 reflects the count of files that actually live in the
+                 selected module. When no module filter is active ("All
+                 modules"), the global counts are accurate and the chips
+                 stay as quick-access tabs. -->
+            {#if !$moduleFilter && $repo && $repo.markdown_count > 0}
               <button
                 class="chip md"
                 on:click={() => {
@@ -1240,7 +1311,7 @@
                 md <span class="count">{$repo.markdown_count}</span>
               </button>
             {/if}
-            {#if $repo && $repo.html_count > 0}
+            {#if !$moduleFilter && $repo && $repo.html_count > 0}
               <button
                 class="chip html"
                 on:click={() => {
@@ -1738,14 +1809,20 @@
   .home-btn {
     width: 34px;
     padding: 6px 0;
-    text-align: center;
-    font-size: 17px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     line-height: 1;
     color: var(--fg-1);
   }
   .home-btn:hover {
     color: var(--accent-2);
     border-color: var(--accent-2);
+  }
+  .home-icon {
+    width: 18px;
+    height: 18px;
+    display: block;
   }
 
   .sidebars-toggle {
@@ -2034,7 +2111,9 @@
     display: flex;
     align-items: center;
     gap: 6px;
-    padding: 6px 8px;
+    /* Right padding mirrors .filter so the .pane-collapse button
+       cannot overlap the package-path readout when both are shown. */
+    padding: 6px 36px 6px 8px;
     background: color-mix(in srgb, var(--accent-2) 15%, var(--bg-1));
     border-bottom: 1px solid var(--bg-3);
     font-size: 12px;
@@ -2072,7 +2151,13 @@
   }
 
   .filter {
-    padding: 8px;
+    /* Right padding reserves space for the absolutely-positioned
+       .pane-collapse button so the last chip in the top row doesn't
+       slip underneath it (the chevron used to overlap "MD"/"HTML"
+       chips on narrow sidebars). flex-wrap means overflow chips
+       cleanly fall onto a second line — no hidden-with-chevron
+       overflow control needed. */
+    padding: 8px 36px 8px 8px;
     display: flex;
     flex-wrap: wrap;
     gap: 4px;

--- a/app/src/components/DiagramView.svelte
+++ b/app/src/components/DiagramView.svelte
@@ -21,6 +21,7 @@
     authorColor,
     authorIdentity,
   } from '../lib/folderMapColors';
+  import { wheelDelta } from '../lib/shiftWheelZoom';
 
   export let kind: DiagramKind;
   export let folderLayout: 'hierarchy' | 'solar' | 'td' = 'solar';
@@ -268,13 +269,21 @@
   let dragStartTx = 0;
   let dragStartTy = 0;
 
-  // SVG size at scale=1 (after fit-to-stage). Zoom is applied by resizing the
-  // SVG itself (so the vector re-rasterises crisply at the new resolution)
-  // rather than by CSS `transform: scale()` which would blur a bitmap.
+  // SVG fit-to-stage size at scale=1. We still set width/height once during
+  // render() so the SVG occupies the stage sensibly; live zoom is then
+  // applied via a CSS transform on the wrapper (see `diagramTransform`
+  // below). The previous approach — mutating SVG width/height on every
+  // wheel tick — was crisper at extreme zoom but unreliable under WKWebView:
+  // querySelector('svg') sometimes missed the freshly-attached node after
+  // HMR / async render, so the wrapper translated without the SVG scaling
+  // ("ganze Panel verschoben, aber nicht skaliert"). CSS transform always
+  // applies regardless of when the SVG mounts.
   let baseW = 0;
   let baseH = 0;
 
-  $: applyScale(scale);
+  // Combined translate + scale for the .diagram wrapper. Reactive so any
+  // tx/ty/scale update lands in one transform string.
+  $: diagramTransform = `translate(${tx}px, ${ty}px) scale(${scale})`;
 
   $: if (kind) {
     void render(kind, folderLayout, docGraphLayout);
@@ -439,7 +448,7 @@
           baseH = sh;
         }
         node.style.display = 'block';
-        applyScale(scale);
+        applyBaseSize();
       }
     } catch (err) {
       error = String(err);
@@ -1125,24 +1134,28 @@
     }
   }
 
-  function applyScale(s: number) {
+  function applyBaseSize() {
+    // Stamp the SVG at scale=1 once per render so it fills the stage; live
+    // zoom then happens via `diagramTransform`. Safe to call multiple times
+    // — idempotent for a given baseW/baseH and current SVG node.
     if (!stage || !baseW || !baseH) return;
     const node = stage.querySelector('svg');
     if (!node) return;
-    // Resize the SVG so the renderer re-rasterises the vector at the new size.
-    // `width`/`height` attributes (rather than CSS) keep `viewBox` scaling
-    // crisp at any zoom level.
-    node.setAttribute('width', String(baseW * s));
-    node.setAttribute('height', String(baseH * s));
+    node.setAttribute('width', String(baseW));
+    node.setAttribute('height', String(baseH));
   }
 
   function onWheel(e: WheelEvent) {
     // Plain wheel = zoom (matches user expectation from every IDE / map app).
+    // Shift+wheel also zooms, for parity with the text/code viewers across
+    // the rest of the app — the user-facing rule is "Shift+Wheel zooms in
+    // every viewer". `wheelDelta` handles the macOS axis-swap so the same
+    // gesture works on Linux/Windows where deltaY survives intact.
     // `preventDefault` only works when the listener is registered as
     // non-passive, which `nonPassiveWheel` (below) guarantees.
-    e.preventDefault();
+    if (e.cancelable) e.preventDefault();
     e.stopPropagation();
-    const delta = Math.abs(e.deltaY) >= Math.abs(e.deltaX) ? e.deltaY : e.deltaX;
+    const delta = wheelDelta(e);
     if (delta === 0) return;
     const rect = stage.getBoundingClientRect();
     const cx = e.clientX - rect.left;
@@ -1153,6 +1166,8 @@
     tx = cx - (cx - tx) * (nextScale / scale);
     ty = cy - (cy - ty) * (nextScale / scale);
     scale = nextScale;
+    // The `diagramTransform` reactive picks scale + tx + ty up in a single
+    // transform string applied via inline style — no querySelector needed.
   }
 
   // Svelte's `on:wheel` registers a passive listener on browsers that
@@ -1306,7 +1321,7 @@
       </span>
     {/if}
     {#if !drawIoXml}
-      <span class="hint">Drag to pan • Wheel to zoom</span>
+      <span class="hint">Drag to pan • Wheel or Shift+Wheel to zoom</span>
     {/if}
   </div>
   {#if loading}
@@ -1336,7 +1351,7 @@
     >
       <div
         class="diagram"
-        style="transform: translate({tx}px, {ty}px); transform-origin: 0 0;"
+        style="transform: {diagramTransform}; transform-origin: 0 0;"
       >
         {@html svg}
       </div>

--- a/app/src/components/DiagramView.svelte
+++ b/app/src/components/DiagramView.svelte
@@ -14,6 +14,7 @@
     stereotypeFilter,
     viewMode,
     repo,
+    followingMcp,
   } from '../lib/store';
   import {
     recencyColor,
@@ -330,6 +331,7 @@
 
   function openFolderNode(path: string, nodeKind: string) {
     if (nodeKind !== 'file') return;
+    followingMcp.set(false);
     fileView.update((cur) => ({
       path,
       anchor: null,
@@ -935,6 +937,9 @@
   }
 
   function openDoc(path: string) {
+    // The user is taking an explicit action; if we were mirroring an MCP
+    // intent, stop doing so or applyState will clobber the view shortly.
+    followingMcp.set(false);
     fileView.update((cur) => ({
       path,
       anchor: null,
@@ -1133,10 +1138,10 @@
 
   function onWheel(e: WheelEvent) {
     // Plain wheel = zoom (matches user expectation from every IDE / map app).
-    // Shift+wheel keeps working as zoom too, for trackpads that emit deltaX
-    // on horizontal swipes. ctrlKey/metaKey would conflict with browser zoom,
-    // so we don't gate on them.
+    // `preventDefault` only works when the listener is registered as
+    // non-passive, which `nonPassiveWheel` (below) guarantees.
     e.preventDefault();
+    e.stopPropagation();
     const delta = Math.abs(e.deltaY) >= Math.abs(e.deltaX) ? e.deltaY : e.deltaX;
     if (delta === 0) return;
     const rect = stage.getBoundingClientRect();
@@ -1148,6 +1153,27 @@
     tx = cx - (cx - tx) * (nextScale / scale);
     ty = cy - (cy - ty) * (nextScale / scale);
     scale = nextScale;
+  }
+
+  // Svelte's `on:wheel` registers a passive listener on browsers that
+  // default `wheel` to passive (Chrome on document scrollers, some
+  // embeddings). A passive listener silently ignores `preventDefault`,
+  // which means the browser keeps its default scroll behaviour — the
+  // exact "wheel only scrolls left/right" symptom users were seeing.
+  // This action explicitly registers a non-passive listener so the zoom
+  // handler can suppress the default scroll.
+  function nonPassiveWheel(node: HTMLDivElement, handler: (e: WheelEvent) => void) {
+    let current = handler;
+    const fn = (e: WheelEvent) => current(e);
+    node.addEventListener('wheel', fn, { passive: false });
+    return {
+      update(next: (e: WheelEvent) => void) {
+        current = next;
+      },
+      destroy() {
+        node.removeEventListener('wheel', fn);
+      },
+    };
   }
 
   function onMouseDown(e: MouseEvent) {
@@ -1299,7 +1325,7 @@
       class="stage"
       class:dragging
       bind:this={stage}
-      on:wheel={onWheel}
+      use:nonPassiveWheel={onWheel}
       on:click={onClick}
       on:mousedown={onMouseDown}
       on:mousemove={onMouseMove}

--- a/app/src/components/DrawIoFrame.svelte
+++ b/app/src/components/DrawIoFrame.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
+  import { wheelDelta } from '../lib/shiftWheelZoom';
 
   export let xml: string;
   export let title = 'draw.io diagram';
@@ -13,10 +14,41 @@
   // diagrams, build the Tauri shell with a self-hosted draw.io viewer or
   // run the .drawio file through a local converter first.
   const EMBED_ORIGIN = 'https://embed.diagrams.net';
-  const EMBED_URL = `${EMBED_ORIGIN}/?embed=1&ui=atlas&proto=json&splash=0&toolbar=0&libraries=0&dark=auto`;
+  // URL parameter cheatsheet for the diagrams.net embed:
+  //   embed=1       — embed mode (required for postMessage protocol)
+  //   ui=atlas      — UI variant (left over from the menu/toolbar layout)
+  //   proto=json    — load XML via postMessage(json) instead of URL
+  //   splash=0      — no welcome splash
+  //   toolbar=0     — no top toolbar
+  //   libraries=0   — no shape library panel
+  //   chrome=0      — kill the rest of the chrome (menubar, status bar,
+  //                   format/outline sidebars) so only the canvas shows.
+  //                   Pan/zoom inside the iframe is now disabled because
+  //                   `pointer-events: none` on the frame routes the mouse
+  //                   to our wrapper instead — see the .stage block below.
+  //   dark=auto     — follow OS dark mode
+  const EMBED_URL = `${EMBED_ORIGIN}/?embed=1&ui=atlas&proto=json&splash=0&toolbar=0&libraries=0&chrome=0&dark=auto`;
 
   let frame: HTMLIFrameElement;
+  let stage: HTMLDivElement;
   let initialised = false;
+
+  // Pan + zoom state — identical model to DiagramView so the gesture feels
+  // the same everywhere: plain wheel and Shift+wheel both zoom (Shift parity
+  // matches the text/code viewers), drag-anywhere pans. We apply a single
+  // `translate(...) scale(...)` transform to the iframe; `pointer-events:
+  // none` on the iframe forwards the mouse to this wrapper so the iframe's
+  // own draw.io scroll/pan can't fight us.
+  let scale = 1;
+  let tx = 0;
+  let ty = 0;
+  let dragging = false;
+  let dragStartX = 0;
+  let dragStartY = 0;
+  let dragStartTx = 0;
+  let dragStartTy = 0;
+
+  $: frameTransform = `translate(${tx}px, ${ty}px) scale(${scale})`;
 
   $: if (xml) initialised = false;
 
@@ -58,21 +90,105 @@
     }
   }
 
+  function onWheel(e: WheelEvent) {
+    if (e.cancelable) e.preventDefault();
+    e.stopPropagation();
+    const delta = wheelDelta(e);
+    if (delta === 0) return;
+    const rect = stage.getBoundingClientRect();
+    const cx = e.clientX - rect.left;
+    const cy = e.clientY - rect.top;
+    const factor = Math.exp(-delta * 0.0015);
+    const nextScale = Math.min(8, Math.max(0.2, scale * factor));
+    // Zoom toward cursor: keep the world-point under the cursor stable.
+    tx = cx - (cx - tx) * (nextScale / scale);
+    ty = cy - (cy - ty) * (nextScale / scale);
+    scale = nextScale;
+  }
+
+  // Svelte's `on:wheel` registers a passive listener so `preventDefault`
+  // wouldn't take effect — explicit non-passive registration here.
+  function nonPassiveWheel(node: HTMLDivElement, handler: (e: WheelEvent) => void) {
+    let current = handler;
+    const fn = (e: WheelEvent) => current(e);
+    node.addEventListener('wheel', fn, { passive: false });
+    return {
+      update(next: (e: WheelEvent) => void) {
+        current = next;
+      },
+      destroy() {
+        node.removeEventListener('wheel', fn);
+      },
+    };
+  }
+
+  function onMouseDown(e: MouseEvent) {
+    if (e.button !== 0) return;
+    dragging = true;
+    dragStartX = e.clientX;
+    dragStartY = e.clientY;
+    dragStartTx = tx;
+    dragStartTy = ty;
+  }
+
+  function onMouseMove(e: MouseEvent) {
+    if (!dragging) return;
+    tx = dragStartTx + (e.clientX - dragStartX);
+    ty = dragStartTy + (e.clientY - dragStartY);
+  }
+
+  function endDrag() {
+    dragging = false;
+  }
+
   onMount(() => window.addEventListener('message', onMessage));
   onDestroy(() => window.removeEventListener('message', onMessage));
 </script>
 
-<iframe
-  bind:this={frame}
-  class="frame"
-  {title}
-  src={EMBED_URL}
-  allow="clipboard-read; clipboard-write"
-></iframe>
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="stage"
+  class:dragging
+  bind:this={stage}
+  use:nonPassiveWheel={onWheel}
+  on:mousedown={onMouseDown}
+  on:mousemove={onMouseMove}
+  on:mouseup={endDrag}
+  on:mouseleave={endDrag}
+>
+  <iframe
+    bind:this={frame}
+    class="frame"
+    style="transform: {frameTransform}; transform-origin: 0 0;"
+    {title}
+    src={EMBED_URL}
+    allow="clipboard-read; clipboard-write"
+  ></iframe>
+</div>
 
 <style>
-  .frame {
+  .stage {
     flex: 1;
+    width: 100%;
+    height: 100%;
+    position: relative;
+    overflow: hidden;
+    cursor: grab;
+    background: var(--bg-0);
+  }
+  .stage.dragging {
+    cursor: grabbing;
+  }
+  .frame {
+    /* Block the iframe from receiving pointer events so plain mouse
+       interactions (wheel, drag) hit the wrapper above and feed our pan/
+       zoom handlers. The user couldn't interact with the embed's UI
+       anyway — chrome=0 hid the toolbar / menus. Selectable text and
+       hyperlinks inside the diagram are also disabled as a side effect,
+       which matches the "view-only" intent. */
+    pointer-events: none;
+    position: absolute;
+    inset: 0;
     width: 100%;
     height: 100%;
     border: 0;

--- a/app/src/components/FileView.svelte
+++ b/app/src/components/FileView.svelte
@@ -7,6 +7,7 @@
   import type { MarkdownFile } from '../lib/api';
   import { repo, fileView } from '../lib/store';
   import { createShiftWheelZoom } from '../lib/shiftWheelZoom';
+  import { openUrl } from '../lib/openUrl';
 
   export let path: string;
   /// Optional heading slug to scroll to after rendering. If a slug doesn't
@@ -299,6 +300,55 @@
     if (current !== activeHeadingId) activeHeadingId = current;
   }
 
+  /// Intercept link clicks inside rendered markdown. Without this, anchor tags
+  /// follow browser-default navigation — which replaces the SPA in the webview
+  /// and kills the back history. We route:
+  ///   - `#slug` → smooth-scroll inside the current document
+  ///   - `http(s)://` / `mailto:` → openUrl (system browser)
+  ///   - relative / absolute filesystem path → update fileView store so the
+  ///     viewer loads it; App.svelte's history snapshot then captures the move
+  ///     and the back button works.
+  /// Unknown schemes are blocked rather than allowed to navigate away.
+  function onContentClick(ev: MouseEvent) {
+    let node: HTMLElement | null = ev.target as HTMLElement | null;
+    while (node && node !== host) {
+      if (node.tagName === 'A') break;
+      node = node.parentElement;
+    }
+    if (!node || node.tagName !== 'A') return;
+    const href = (node as HTMLAnchorElement).getAttribute('href') ?? '';
+    if (!href) return;
+    if (href.startsWith('#')) {
+      ev.preventDefault();
+      void scrollToAnchor(href.slice(1));
+      return;
+    }
+    if (/^(https?:|mailto:)/i.test(href)) {
+      ev.preventDefault();
+      void openUrl(href);
+      return;
+    }
+    if (/^[a-z][a-z0-9+.-]*:/i.test(href)) {
+      // Unknown scheme — don't let the webview wander off.
+      ev.preventDefault();
+      console.warn('FileView: unsupported link scheme', href);
+      return;
+    }
+    ev.preventDefault();
+    const hashIdx = href.indexOf('#');
+    const targetRaw = hashIdx === -1 ? href : href.slice(0, hashIdx);
+    const targetAnchor = hashIdx === -1 ? null : href.slice(hashIdx + 1) || null;
+    if (!targetRaw) {
+      if (targetAnchor) void scrollToAnchor(targetAnchor);
+      return;
+    }
+    const dir = parentDir(path);
+    const abs = targetRaw.startsWith('/')
+      ? normalizePath(targetRaw)
+      : normalizePath(`${dir}/${targetRaw}`);
+    fileView.set({ path: abs, anchor: targetAnchor, nonce: Date.now() });
+  }
+
   async function rewriteImages(filePath: string) {
     if (!host) return;
     const dir = parentDir(filePath);
@@ -544,6 +594,8 @@
             class="content"
             bind:this={host}
             style="font-size: {$zoom}em;"
+            on:click={onContentClick}
+            role="presentation"
           >
             {@html html}
           </div>

--- a/app/src/i18n/de.json
+++ b/app/src/i18n/de.json
@@ -3,6 +3,7 @@
   "app.noRepository": "kein Repository",
   "nav.code": "Code",
   "nav.files": "Dateien",
+  "nav.home": "Home — Übersicht mit gelöschten Filtern",
   "nav.diagrams": "Diagramme",
   "nav.markdownTitle": "Markdown-Dateien in diesem Repository durchsuchen",
   "nav.htmlTitle": "HTML-Dateien und Snippets in diesem Repository durchsuchen",

--- a/app/src/i18n/en.json
+++ b/app/src/i18n/en.json
@@ -3,6 +3,7 @@
   "app.noRepository": "no repository",
   "nav.code": "Code",
   "nav.files": "Files",
+  "nav.home": "Home — Overview with filters cleared",
   "nav.diagrams": "Diagrams",
   "nav.markdownTitle": "Browse markdown files in this repository",
   "nav.htmlTitle": "Browse HTML files and snippets in this repository",

--- a/app/src/lib/navigation.ts
+++ b/app/src/lib/navigation.ts
@@ -19,7 +19,8 @@ export type DiagramKind =
   | 'inheritance-tree'
   | 'doc-graph'
   | 'c4-container'
-  | 'architecture-layers';
+  | 'architecture-layers'
+  | 'language-stats';
 export type FolderMapLayout = 'hierarchy' | 'solar' | 'td';
 
 /// Frozen snapshot of every navigation-relevant piece of state.

--- a/app/src/lib/shiftWheelZoom.test.ts
+++ b/app/src/lib/shiftWheelZoom.test.ts
@@ -1,0 +1,181 @@
+/// Tests for the shared shift-wheel zoom helper.
+///
+/// The user-facing guarantee these tests pin down: "Shift+Wheel zooms in
+/// every viewer that uses createShiftWheelZoom" — regardless of whether the
+/// OS swapped deltaY → deltaX (macOS does, Linux/Windows don't).
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { clampZoom, readZoom, wheelDelta, writeZoom, createShiftWheelZoom } from './shiftWheelZoom';
+import { get } from 'svelte/store';
+
+describe('clampZoom', () => {
+  it('clamps to [min, max]', () => {
+    expect(clampZoom(0.1, 0.6, 2.0)).toBe(0.6);
+    expect(clampZoom(5.0, 0.6, 2.0)).toBe(2.0);
+    expect(clampZoom(1.0, 0.6, 2.0)).toBe(1.0);
+  });
+
+  it('rounds to two decimals', () => {
+    expect(clampZoom(1.234567)).toBe(1.23);
+    expect(clampZoom(1.235)).toBe(1.24);
+  });
+});
+
+describe('wheelDelta', () => {
+  function makeEvent(deltaY: number, deltaX: number, shiftKey = false): WheelEvent {
+    return { deltaY, deltaX, shiftKey } as unknown as WheelEvent;
+  }
+
+  it('returns deltaY when it dominates (no axis swap)', () => {
+    // Linux/Windows Shift+Wheel: deltaY survives, deltaX is 0
+    expect(wheelDelta(makeEvent(120, 0, true))).toBe(120);
+    expect(wheelDelta(makeEvent(-120, 0, true))).toBe(-120);
+  });
+
+  it('returns deltaX when the OS axis-swapped (macOS Shift+Wheel)', () => {
+    // macOS Shift+Wheel: deltaY → deltaX
+    expect(wheelDelta(makeEvent(0, 120, true))).toBe(120);
+    expect(wheelDelta(makeEvent(0, -120, true))).toBe(-120);
+  });
+
+  it('returns 0 when both axes are 0', () => {
+    expect(wheelDelta(makeEvent(0, 0))).toBe(0);
+  });
+
+  it('prefers the larger-magnitude axis when both are non-zero', () => {
+    expect(wheelDelta(makeEvent(50, 200))).toBe(200);
+    expect(wheelDelta(makeEvent(200, 50))).toBe(200);
+  });
+});
+
+describe('readZoom / writeZoom', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns 1.0 when the key is missing', () => {
+    expect(readZoom('projectmind.test.missing')).toBe(1.0);
+  });
+
+  it('round-trips a clamped value', () => {
+    writeZoom('projectmind.test.rt', 1.5);
+    expect(readZoom('projectmind.test.rt')).toBe(1.5);
+  });
+
+  it('clamps stored values that fall outside [min, max] on read', () => {
+    writeZoom('projectmind.test.clamp', 9.9);
+    expect(readZoom('projectmind.test.clamp', 0.6, 2.0)).toBe(2.0);
+  });
+
+  it('returns 1.0 for unparseable storage', () => {
+    localStorage.setItem('projectmind.test.bad', 'not-a-number');
+    expect(readZoom('projectmind.test.bad')).toBe(1.0);
+  });
+});
+
+describe('createShiftWheelZoom', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  // The svelte action attaches a `wheel` listener to `window` and filters
+  // by `node.contains(ev.target)`. happy-dom doesn't propagate node-level
+  // dispatches up to the window the same way a real browser does, so the
+  // tests synthesise the upward path: dispatch on `window` directly, with
+  // the `target` overridden to the inside-node we want to model. That's
+  // exactly what the production handler observes — `ev.target` is what the
+  // listener inspects, and the window-level dispatch matches `addEventListener('wheel', ...)`.
+  function fireWheel(target: Node, init: WheelEventInit) {
+    // happy-dom's WheelEvent doesn't accept deltaX / deltaY through the
+    // standard constructor reliably and doesn't propagate node dispatches
+    // up to window — both gaps relative to a real browser. Fabricate the
+    // event shape the production handler reads (deltaX/deltaY/shiftKey/target)
+    // directly and dispatch on window, which is where the listener lives.
+    const ev = new Event('wheel', { bubbles: true, cancelable: true }) as unknown as WheelEvent & {
+      deltaX: number;
+      deltaY: number;
+      shiftKey: boolean;
+    };
+    ev.deltaX = init.deltaX ?? 0;
+    ev.deltaY = init.deltaY ?? 0;
+    ev.shiftKey = init.shiftKey ?? false;
+    Object.defineProperty(ev, 'target', { value: target, configurable: true });
+    window.dispatchEvent(ev);
+  }
+
+  it('zooms in when shift+wheel-up fires inside the bound node (Linux/Windows shape)', () => {
+    const { zoom, action } = createShiftWheelZoom('projectmind.test.cswz1', { step: 0.1 });
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const handle = action(host);
+    expect(get(zoom)).toBe(1.0);
+
+    fireWheel(host, { deltaY: -120, deltaX: 0, shiftKey: true });
+
+    expect(get(zoom)).toBeCloseTo(1.1, 5);
+    handle.destroy();
+    host.remove();
+  });
+
+  it('zooms in when shift+wheel arrives axis-swapped (macOS shape)', () => {
+    const { zoom, action } = createShiftWheelZoom('projectmind.test.cswz2', { step: 0.1 });
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const handle = action(host);
+
+    fireWheel(host, { deltaY: 0, deltaX: -120, shiftKey: true });
+
+    expect(get(zoom)).toBeCloseTo(1.1, 5);
+    handle.destroy();
+    host.remove();
+  });
+
+  it('ignores wheel events without shift', () => {
+    const { zoom, action } = createShiftWheelZoom('projectmind.test.cswz3', { step: 0.1 });
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const handle = action(host);
+
+    fireWheel(host, { deltaY: -120, shiftKey: false });
+
+    expect(get(zoom)).toBe(1.0);
+    handle.destroy();
+    host.remove();
+  });
+
+  it('ignores wheel events outside the bound node', () => {
+    const { zoom, action } = createShiftWheelZoom('projectmind.test.cswz4', { step: 0.1 });
+    const host = document.createElement('div');
+    const outside = document.createElement('div');
+    document.body.appendChild(host);
+    document.body.appendChild(outside);
+    const handle = action(host);
+
+    fireWheel(outside, { deltaY: -120, shiftKey: true });
+
+    expect(get(zoom)).toBe(1.0);
+    handle.destroy();
+    host.remove();
+    outside.remove();
+  });
+
+  it('persists across instances via the same key', () => {
+    const first = createShiftWheelZoom('projectmind.test.cswz5', { step: 0.1 });
+    first.zoom.set(1.4);
+
+    const second = createShiftWheelZoom('projectmind.test.cswz5', { step: 0.1 });
+    expect(get(second.zoom)).toBe(1.4);
+  });
+
+  it('clamps imperative zoom writes', () => {
+    const { zoom } = createShiftWheelZoom('projectmind.test.cswz6', {
+      min: 0.5,
+      max: 1.8,
+      step: 0.1,
+    });
+    zoom.set(5.0);
+    expect(get(zoom)).toBe(1.8);
+    zoom.set(0.1);
+    expect(get(zoom)).toBe(0.5);
+  });
+});

--- a/crates/browser-host/Cargo.toml
+++ b/crates/browser-host/Cargo.toml
@@ -14,10 +14,10 @@ workspace = true
 [dependencies]
 projectmind-core = { workspace = true }
 projectmind-plugin-api = { workspace = true }
-projectmind-lang-java = { path = "../../plugins/lang-java", version = "0.5.0" }
-projectmind-lang-rust = { path = "../../plugins/lang-rust", version = "0.5.0" }
-projectmind-framework-spring = { path = "../../plugins/framework-spring", version = "0.5.0" }
-projectmind-framework-lombok = { path = "../../plugins/framework-lombok", version = "0.5.0" }
+projectmind-lang-java = { path = "../../plugins/lang-java", version = "0.6.0" }
+projectmind-lang-rust = { path = "../../plugins/lang-rust", version = "0.6.0" }
+projectmind-framework-spring = { path = "../../plugins/framework-spring", version = "0.6.0" }
+projectmind-framework-lombok = { path = "../../plugins/framework-lombok", version = "0.6.0" }
 
 anyhow = { workspace = true }
 rand = "0.8"

--- a/crates/browser-host/src/lib.rs
+++ b/crates/browser-host/src/lib.rs
@@ -564,7 +564,11 @@ fn route_api(
             Ok(serde_json::to_value(files::list_module_files(
                 &module.root,
                 &[
+                    // Image / PDF
                     "pdf", "png", "jpg", "jpeg", "webp", "gif", "svg", "bmp", "ico",
+                    // Markdown + HTML — per-module so the kind-filter chips
+                    // can show an accurate count when a module is selected.
+                    "md", "markdown", "html", "htm",
                 ],
             ))?)
         }

--- a/crates/mcp-server/Cargo.toml
+++ b/crates/mcp-server/Cargo.toml
@@ -18,13 +18,13 @@ workspace = true
 [dependencies]
 projectmind-plugin-api = { workspace = true }
 projectmind-core       = { workspace = true }
-projectmind-browser-host = { path = "../browser-host", version = "0.5.0" }
+projectmind-browser-host = { path = "../browser-host", version = "0.6.0" }
 
 # Local plugins linked statically for Phase 1
-projectmind-lang-java         = { path = "../../plugins/lang-java", version = "0.5.0" }
-projectmind-lang-rust         = { path = "../../plugins/lang-rust", version = "0.5.0" }
-projectmind-framework-spring  = { path = "../../plugins/framework-spring", version = "0.5.0" }
-projectmind-framework-lombok  = { path = "../../plugins/framework-lombok", version = "0.5.0" }
+projectmind-lang-java         = { path = "../../plugins/lang-java", version = "0.6.0" }
+projectmind-lang-rust         = { path = "../../plugins/lang-rust", version = "0.6.0" }
+projectmind-framework-spring  = { path = "../../plugins/framework-spring", version = "0.6.0" }
+projectmind-framework-lombok  = { path = "../../plugins/framework-lombok", version = "0.6.0" }
 
 anyhow      = { workspace = true }
 clap        = { workspace = true }


### PR DESCRIPTION
## Summary
User-reported follow-up after v0.5.0:
- **Wheel zoom did nothing in any diagram, only horizontal scroll fired.** Svelte's `on:wheel` registered a *passive* listener in the runtime webview, so `e.preventDefault()` was silently ignored and the browser kept its default scroll. New `use:nonPassiveWheel` action explicitly registers wheel with `{ passive: false }`. Zoom-toward-cursor lands at the mouse position now (no Shift needed).
- **Doc-graph node click → MD viewer**: `openDoc` now also clears `followingMcp` so an in-flight `applyState` from the state watcher can't clobber the view a tick later. Same `followingMcp` guard added to `openFolderNode`.
- **DiagramKind enum** in `lib/navigation.ts` was missing `language-stats`, which made the type import in `App.svelte` conflict with the broader `api.ts` `DiagramKind`. `svelte-check` now clean.
- **applyState** lost `language-stats` from its `diagram_kind` switch — an MCP `view_diagram` intent for the new stats diagram now actually flips the GUI.
- **New ⌂ home button** in the header: clears every filter axis (module, package, stereotype, file-kind), drops the selected class + open file, and returns to the classes overview. Escape hatch from any sub-mode (md / html / file / diagram detail).

## Caveat
Two of the reported issues — "Tabs collapse buttons don't work" and "switching between diagrams and document doesn't work" — I couldn't reproduce from a code-only inspection. The collapse buttons are still wired to the stores and the navigation works on tab click. If they still misbehave after this PR, please share which view-mode you start from and what the click does (or doesn't do).

## Test plan
- [x] `cargo fmt` clean, `cargo clippy` clean, `cargo test` workspace green
- [x] `svelte-check` clean (601 files, 0 errors)
- [ ] Open a Mermaid diagram (bean-graph, package-tree, …) → mouse wheel zooms toward cursor
- [ ] Open the doc-graph → click a node → the .md file opens in the file viewer
- [ ] Click ⌂ in the header from any sub-mode → classes overview shows with no filter chips active

🤖 Generated with [Claude Code](https://claude.com/claude-code)