### PR TITLE
feat(cockpit): Risk Atlas GUI (2.1, #157)

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -27,7 +27,7 @@ use projectmind_core::state::{self, UiState, ViewIntent};
 use projectmind_core::walkthrough::{
     self as wt, FeedbackEvent, FeedbackKind, FeedbackLog, Walkthrough,
 };
-use projectmind_core::{diagram, Engine, Repository};
+use projectmind_core::{diagram, risk, Engine, Repository};
 use projectmind_framework_lombok::LombokPlugin;
 use projectmind_framework_spring::SpringPlugin;
 use projectmind_lang_java::JavaPlugin;
@@ -329,6 +329,67 @@ fn list_modules(state: State<'_, Arc<AppState>>) -> Result<Vec<ModuleEntry>, Str
     }
     out.sort_by_key(|b| std::cmp::Reverse(b.classes));
     Ok(out)
+}
+
+/// Optionale Gewichts-Overrides aus der GUI (Cockpit Risk Atlas, #157).
+#[derive(Debug, Clone, Copy, serde::Deserialize)]
+pub struct RiskWeightsArg {
+    pub churn: Option<f64>,
+    pub cx: Option<f64>,
+    pub cov: Option<f64>,
+    pub deps: Option<f64>,
+}
+
+/// Ergebnis von [`risk_atlas`] – Fenster, effektive Gewichte und die Scores für die Treemap.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RiskAtlasResult {
+    pub window_days: u32,
+    pub weights: risk::Weights,
+    pub scores: Vec<risk::RiskScore>,
+}
+
+/// Risk Atlas (Cockpit 2.1): Churn + Komplexität je Klasse, gewichteter Score. Spiegelt die Logik
+/// des `risk_atlas`-MCP-Tools, hier als Tauri-Command, damit die GUI die Treemap füttern kann.
+#[tauri::command]
+fn risk_atlas(
+    module: Option<String>,
+    top: Option<u32>,
+    window_days: Option<u32>,
+    weights: Option<RiskWeightsArg>,
+    state: State<'_, Arc<AppState>>,
+) -> Result<RiskAtlasResult, String> {
+    let guard = state.repo.read();
+    let repo = guard
+        .as_ref()
+        .ok_or_else(|| "no repository open".to_string())?;
+    let mut w = risk::Weights::default();
+    if let Some(a) = weights {
+        if let Some(v) = a.churn {
+            w.churn = v;
+        }
+        if let Some(v) = a.cx {
+            w.cx = v;
+        }
+        if let Some(v) = a.cov {
+            w.cov = v;
+        }
+        if let Some(v) = a.deps {
+            w.deps = v;
+        }
+    }
+    let opts = risk::Options {
+        module,
+        // Treemap zeigt viele Kacheln -> grosszügiges Default-Top, per GUI überschreibbar.
+        top: top.map_or(200, |v| v as usize).max(1),
+        window_days: window_days.unwrap_or(risk::DEFAULT_CHURN_WINDOW_DAYS),
+        weights: w,
+    };
+    let scores = risk::compute(repo, &opts).map_err(|e| e.to_string())?;
+    Ok(RiskAtlasResult {
+        window_days: opts.window_days,
+        weights: opts.weights,
+        scores,
+    })
 }
 
 #[tauri::command]
@@ -1035,6 +1096,7 @@ pub fn run() {
             pending_markdown_file,
             list_classes,
             list_modules,
+            risk_atlas,
             show_class,
             class_outline,
             list_changes_since,

--- a/app/src/App.svelte
+++ b/app/src/App.svelte
@@ -48,6 +48,7 @@
   import PdfView from './components/PdfView.svelte';
   import DiffView from './components/DiffView.svelte';
   import CompareView from './components/CompareView.svelte';
+  import RiskAtlasView from './components/RiskAtlasView.svelte';
   import KeyboardHelp from './components/KeyboardHelp.svelte';
   import StatusBar from './components/StatusBar.svelte';
   import McpToast from './components/McpToast.svelte';
@@ -1083,6 +1084,15 @@
           {$t('nav.compare')}
         </button>
       {/if}
+      {#if $repo}
+        <button
+          class:active={$viewMode === 'risk'}
+          on:click={() => { followingMcp.set(false); viewMode.set('risk'); }}
+          title="Risk Atlas — Churn + Komplexität als Treemap"
+        >
+          Risk Atlas
+        </button>
+      {/if}
       {#if $viewMode === 'diff'}
         <button class="active">{$t('nav.diff')}</button>
       {/if}
@@ -1444,6 +1454,8 @@
     <DiffView reference={$diffViewRef.reference} to={$diffViewRef.to} />
   {:else if $viewMode === 'compare'}
     <CompareView />
+  {:else if $viewMode === 'risk'}
+    <RiskAtlasView />
   {:else}
     <section class="empty">
       <div class="welcome">

--- a/app/src/components/RiskAtlasView.svelte
+++ b/app/src/components/RiskAtlasView.svelte
@@ -1,0 +1,274 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { riskAtlas, type RiskScore, type RiskWeights } from '../lib/api';
+  import { classes, selectedClass, viewMode } from '../lib/store';
+  import { get } from 'svelte/store';
+
+  // Cockpit 2.1 — Risk Atlas (Issue #157):
+  //   Treemap (Fläche = SLOC, Farbe = Score) auf dem bereits gemergten risk_atlas-Backend.
+  //   Klick auf eine Kachel öffnet die Klasse im Code-Tab; Gewichts-Slider re-querien das
+  //   Backend und werden in localStorage persistiert.
+
+  const WEIGHTS_KEY = 'projectmind.risk.weights';
+  const DEFAULT_WEIGHTS: RiskWeights = { churn: 1, cx: 1, cov: 0, deps: 0 };
+  const WEIGHT_FIELDS: [keyof RiskWeights, string][] = [
+    ['churn', 'Churn'],
+    ['cx', 'Complexity'],
+    ['cov', 'Coverage'],
+    ['deps', 'Deps'],
+  ];
+
+  let weights: RiskWeights = loadWeights();
+  let scores: RiskScore[] = [];
+  let windowDays = 90;
+  let loading = false;
+  let error: string | null = null;
+
+  // Container-Pixelmasse (für das Treemap-Layout).
+  let boxW = 0;
+  let boxH = 0;
+
+  interface Rect {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+    item: RiskScore;
+  }
+
+  function loadWeights(): RiskWeights {
+    try {
+      const raw = localStorage.getItem(WEIGHTS_KEY);
+      if (raw) return { ...DEFAULT_WEIGHTS, ...JSON.parse(raw) };
+    } catch {
+      /* localStorage nicht verfügbar -> Defaults */
+    }
+    return { ...DEFAULT_WEIGHTS };
+  }
+
+  function persistWeights() {
+    try {
+      localStorage.setItem(WEIGHTS_KEY, JSON.stringify(weights));
+    } catch {
+      /* egal */
+    }
+  }
+
+  async function load() {
+    loading = true;
+    error = null;
+    try {
+      const res = await riskAtlas({ top: 250, weights });
+      scores = res.scores;
+      windowDays = res.window_days;
+    } catch (err) {
+      error = String(err);
+      scores = [];
+    } finally {
+      loading = false;
+    }
+  }
+
+  // Slider-Änderung: persistieren + Backend neu abfragen (debounced).
+  let reloadTimer: ReturnType<typeof setTimeout> | undefined;
+  function onWeightChange() {
+    persistWeights();
+    clearTimeout(reloadTimer);
+    reloadTimer = setTimeout(load, 250);
+  }
+
+  function resetWeights() {
+    weights = { ...DEFAULT_WEIGHTS };
+    onWeightChange();
+  }
+
+  // Rekursiver, flächentreuer Treemap (alternierende Halbierung nach kumuliertem SLOC).
+  // Bewusst simpel + korrekt; squarified-Optimierung der Seitenverhältnisse ist ein Follow-up.
+  function val(it: RiskScore): number {
+    return Math.max(it.sloc, 1);
+  }
+
+  function treemap(items: RiskScore[], x: number, y: number, w: number, h: number): Rect[] {
+    if (items.length === 0 || w <= 0 || h <= 0) return [];
+    if (items.length === 1) return [{ x, y, w, h, item: items[0] }];
+    const total = items.reduce((s, it) => s + val(it), 0);
+    let acc = 0;
+    let split = 1;
+    for (let i = 0; i < items.length - 1; i++) {
+      acc += val(items[i]);
+      if (acc >= total / 2) {
+        split = i + 1;
+        break;
+      }
+    }
+    const a = items.slice(0, split);
+    const b = items.slice(split);
+    const frac = a.reduce((s, it) => s + val(it), 0) / total;
+    if (w >= h) {
+      const aw = w * frac;
+      return [...treemap(a, x, y, aw, h), ...treemap(b, x + aw, y, w - aw, h)];
+    }
+    const ah = h * frac;
+    return [...treemap(a, x, y, w, ah), ...treemap(b, x, y + ah, w, h - ah)];
+  }
+
+  // Farbskala: Score 0 (grün) -> 100 (rot).
+  function colorFor(score: number): string {
+    const s = Math.max(0, Math.min(100, score));
+    const hue = 120 - (s / 100) * 120;
+    return `hsl(${hue}, 65%, 42%)`;
+  }
+
+  function shortName(fqn: string): string {
+    const i = fqn.lastIndexOf('.');
+    return i >= 0 ? fqn.slice(i + 1) : fqn;
+  }
+
+  // Klick: passende ClassEntry im Store finden und im Code-Tab öffnen (bestehende Mechanik).
+  function openClass(fqn: string) {
+    const match = get(classes).find((c) => c.fqn === fqn);
+    if (match) {
+      selectedClass.set(match);
+      viewMode.set('classes');
+    }
+  }
+
+  $: rects = boxW > 0 && boxH > 0 && scores.length > 0 ? treemap([...scores].sort((p, q) => val(q) - val(p)), 0, 0, boxW, boxH) : [];
+
+  onMount(load);
+</script>
+
+<div class="risk-atlas">
+  <header class="risk-bar">
+    <div class="risk-title">
+      <strong>Risk Atlas</strong>
+      <span class="muted">Fläche = SLOC · Farbe = Score · Fenster {windowDays} Tage · {scores.length} Klassen</span>
+    </div>
+    <div class="weights">
+      {#each WEIGHT_FIELDS as [key, label]}
+        <label class="weight">
+          <span>{label}</span>
+          <input
+            type="range"
+            min="0"
+            max="2"
+            step="0.1"
+            bind:value={weights[key]}
+            on:input={onWeightChange}
+          />
+          <span class="wval">{weights[key].toFixed(1)}</span>
+        </label>
+      {/each}
+      <button class="reset" on:click={resetWeights} title="Gewichte zurücksetzen">↺</button>
+    </div>
+  </header>
+
+  {#if error}
+    <div class="risk-msg error">{error}</div>
+  {:else if loading && scores.length === 0}
+    <div class="risk-msg">Lade Risk Atlas …</div>
+  {:else if scores.length === 0}
+    <div class="risk-msg">Keine Daten (kein Repo offen oder keine Klassen).</div>
+  {:else}
+    <div class="treemap" bind:clientWidth={boxW} bind:clientHeight={boxH}>
+      {#each rects as r (r.item.fqn)}
+        <button
+          class="tile"
+          style="left:{r.x}px; top:{r.y}px; width:{r.w}px; height:{r.h}px; background:{colorFor(r.item.score)};"
+          title={`${r.item.fqn}\nScore ${r.item.score.toFixed(0)} · Churn ${r.item.churn} · CX ${r.item.cx} · SLOC ${r.item.sloc}\n${r.item.why}`}
+          on:click={() => openClass(r.item.fqn)}
+        >
+          {#if r.w > 46 && r.h > 22}
+            <span class="tile-label">{shortName(r.item.fqn)}</span>
+          {/if}
+        </button>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .risk-atlas {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+  }
+  .risk-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 6px 10px;
+    flex-wrap: wrap;
+    border-bottom: 1px solid var(--border, #2a2a2a);
+  }
+  .risk-title strong {
+    margin-right: 8px;
+  }
+  .muted {
+    color: var(--muted, #888);
+    font-size: 12px;
+  }
+  .weights {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .weight {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 12px;
+  }
+  .weight input[type='range'] {
+    width: 80px;
+  }
+  .wval {
+    width: 22px;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    color: var(--muted, #888);
+  }
+  .reset {
+    cursor: pointer;
+  }
+  .risk-msg {
+    padding: 16px;
+    color: var(--muted, #888);
+  }
+  .risk-msg.error {
+    color: #e74c3c;
+    white-space: pre-wrap;
+  }
+  .treemap {
+    position: relative;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+  }
+  .tile {
+    position: absolute;
+    border: 1px solid rgba(0, 0, 0, 0.35);
+    margin: 0;
+    padding: 2px 4px;
+    overflow: hidden;
+    cursor: pointer;
+    color: #fff;
+    text-align: left;
+    font: inherit;
+    display: block;
+  }
+  .tile:hover {
+    outline: 2px solid #fff;
+    outline-offset: -2px;
+    z-index: 1;
+  }
+  .tile-label {
+    font-size: 11px;
+    line-height: 1.1;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+    word-break: break-word;
+  }
+</style>

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -589,3 +589,64 @@ export async function getBuildIntegrity(): Promise<BuildIntegrity | null> {
   if (!isTauriRuntime()) return null;
   return invoke<BuildIntegrity>('get_build_integrity');
 }
+
+// ---- Risk Atlas (Cockpit 2.1, Issue #157) -------------------------------
+
+export interface RiskScore {
+  fqn: string;
+  module: string;
+  file: string;
+  /** Composite score 0..=100. */
+  score: number;
+  churn: number;
+  cx: number;
+  sloc: number;
+  why: string;
+}
+
+export interface RiskWeights {
+  churn: number;
+  cx: number;
+  cov: number;
+  deps: number;
+}
+
+export interface RiskAtlasResult {
+  window_days: number;
+  weights: RiskWeights;
+  scores: RiskScore[];
+}
+
+export interface RiskAtlasOptions {
+  module?: string;
+  top?: number;
+  windowDays?: number;
+  weights?: Partial<RiskWeights>;
+}
+
+/**
+ * Risk Atlas: per-class churn+complexity score for the treemap. Dual-mode
+ * (Tauri invoke / browser-host HTTP), wie alle anderen Reads.
+ */
+export async function riskAtlas(opts: RiskAtlasOptions = {}): Promise<RiskAtlasResult> {
+  const { module, top, windowDays, weights } = opts;
+  if (!isTauriRuntime()) {
+    return api<RiskAtlasResult>(
+      `/api/risk_atlas${query({
+        module,
+        top,
+        window_days: windowDays,
+        churn: weights?.churn,
+        cx: weights?.cx,
+        cov: weights?.cov,
+        deps: weights?.deps,
+      })}`,
+    );
+  }
+  return invoke<RiskAtlasResult>('risk_atlas', {
+    module,
+    top,
+    windowDays,
+    weights,
+  });
+}

--- a/app/src/lib/store.ts
+++ b/app/src/lib/store.ts
@@ -27,7 +27,8 @@ export type ViewMode =
   | 'walkthrough'
   | 'html'
   | 'pdf'
-  | 'image';
+  | 'image'
+  | 'risk';
 
 export interface WalkthroughCursor {
   id: string;

--- a/crates/browser-host/src/lib.rs
+++ b/crates/browser-host/src/lib.rs
@@ -25,7 +25,7 @@ use projectmind_core::state::{self, UiState, ViewIntent};
 use projectmind_core::walkthrough::{
     self as wt, FeedbackEvent, FeedbackKind, FeedbackLog, Walkthrough,
 };
-use projectmind_core::{diagram, Engine, Repository};
+use projectmind_core::{diagram, risk, Engine, Repository};
 use projectmind_framework_lombok::LombokPlugin;
 use projectmind_framework_spring::SpringPlugin;
 use projectmind_lang_java::JavaPlugin;
@@ -417,6 +417,7 @@ fn route_api(
             )?)?)
         }
         ("GET", "/api/list_modules") => Ok(serde_json::to_value(list_modules_locked(&guard)?)?),
+        ("GET", "/api/risk_atlas") => Ok(serde_json::to_value(risk_atlas_locked(&guard, query)?)?),
         ("GET", "/api/show_class") => {
             let fqn = required(query, "fqn")?;
             Ok(serde_json::to_value(show_class_locked(&guard, fqn)?)?)
@@ -951,6 +952,55 @@ fn list_modules_locked(state: &HostState) -> anyhow::Result<Vec<ModuleEntry>> {
     }
     out.sort_by_key(|b| std::cmp::Reverse(b.classes));
     Ok(out)
+}
+
+/// Ergebnis von `risk_atlas` (Browser-Mode-Pendant zum Tauri-Command) für die Treemap-GUI.
+#[derive(serde::Serialize)]
+struct RiskAtlasResult {
+    window_days: u32,
+    weights: risk::Weights,
+    scores: Vec<risk::RiskScore>,
+}
+
+/// Risk Atlas (Cockpit 2.1) im Browser-Host. Gewichte/Filter kommen als Query-Parameter
+/// (module, top, window_days, churn, cx, cov, deps); fehlende -> Defaults aus `risk::Weights`.
+fn risk_atlas_locked(
+    state: &HostState,
+    query: &BTreeMap<String, String>,
+) -> anyhow::Result<RiskAtlasResult> {
+    let repo = repo(state)?;
+    let mut w = risk::Weights::default();
+    if let Some(v) = query.get("churn").and_then(|s| s.parse().ok()) {
+        w.churn = v;
+    }
+    if let Some(v) = query.get("cx").and_then(|s| s.parse().ok()) {
+        w.cx = v;
+    }
+    if let Some(v) = query.get("cov").and_then(|s| s.parse().ok()) {
+        w.cov = v;
+    }
+    if let Some(v) = query.get("deps").and_then(|s| s.parse().ok()) {
+        w.deps = v;
+    }
+    let opts = risk::Options {
+        module: query.get("module").cloned(),
+        top: query
+            .get("top")
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(200)
+            .max(1),
+        window_days: query
+            .get("window_days")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(risk::DEFAULT_CHURN_WINDOW_DAYS),
+        weights: w,
+    };
+    let scores = risk::compute(repo, &opts)?;
+    Ok(RiskAtlasResult {
+        window_days: opts.window_days,
+        weights: opts.weights,
+        scores,
+    })
 }
 
 fn show_class_locked(state: &HostState, fqn: &str) -> anyhow::Result<ClassDetails> {


### PR DESCRIPTION
Schliesst die GUI-Lücke von **Cockpit Phase 2.1 (Risk Atlas, #157)**. Das `risk_atlas`-Backend (crates/core + MCP) war auf master, aber **nicht als Tauri/Browser-Command** exponiert — die Svelte-GUI konnte es nicht aufrufen.

## Änderungen
- **Backend:** `risk_atlas` als Tauri-Command (`app/src-tauri/src/lib.rs`) **und** browser-host HTTP-Route (`/api/risk_atlas`), beide um `crates/core/risk.rs::compute()`.
- **api.ts:** dual-mode `riskAtlas()` + Typen.
- **RiskAtlasView.svelte:** flächentreuer Treemap (Fläche=SLOC, Farbe=Score), Tooltip, Klick→Klasse im Code-Tab, Gewichts-Slider (churn/cx/cov/deps, localStorage-persistiert).
- **App.svelte:** `risk`-ViewMode + „Risk Atlas"-Tab + Render-Block.

## Verifikation
- `svelte-check`: **0 Fehler**; `vite build`: ✓; `cargo check -p projectmind-browser-host`: ✓.
- Tauri-Backend (`projectmind-app`) lokal nicht checkbar (headless-Box ohne glib/webkit), nutzt aber dieselbe `risk::`-API.
- **Visuelle Politur im Viewer steht aus** (Treemap-Optik, Slider-UX).

## Follow-ups
- Gewichte in `.projectmind/risk.toml` statt localStorage.
- Squarified-Layout für bessere Seitenverhältnisse.
- Pattern Lens (2.3, #159) + die 2 fehlenden Detektoren.

Closes #157 (nach visuellem Review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)