### PR TITLE
Spec 25+30: NoStaticState is_final-Fix + ClassViewer Keyboard-Zoom

### DIFF
--- a/app/src/components/ClassViewer.svelte
+++ b/app/src/components/ClassViewer.svelte
@@ -30,10 +30,41 @@
   }
 
   // Shift + wheel zoom, persisted under the per-component key.
+  // Keyboard zoom (Cmd/Ctrl + + / − / 0) goes through the same store —
+  // `set()`/`update()` clamp + persist automatically.
+  const ZOOM_STEP = 0.1;
   const { zoom, action: zoomAction } = createShiftWheelZoom('projectmind.classviewer.zoom');
 
+  function zoomIn() {
+    zoom.update((z) => z + ZOOM_STEP);
+  }
+  function zoomOut() {
+    zoom.update((z) => z - ZOOM_STEP);
+  }
   function zoomReset() {
     zoom.set(1.0);
+  }
+
+  function onKey(ev: KeyboardEvent) {
+    // Only intercept while this view is on screen (mirrors FileView).
+    if (!rootEl || !rootEl.isConnected) return;
+
+    // Don't hijack the shortcuts while the user is typing in a field.
+    const tag = (ev.target as HTMLElement | null)?.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+
+    if (!(ev.metaKey || ev.ctrlKey)) return;
+    // `=` and `+` share a key on most keyboards. `-` is Minus, `0` is Digit0.
+    if (ev.key === '+' || ev.key === '=' || ev.code === 'Equal') {
+      ev.preventDefault();
+      zoomIn();
+    } else if (ev.key === '-' || ev.code === 'Minus') {
+      ev.preventDefault();
+      zoomOut();
+    } else if (ev.key === '0' || ev.code === 'Digit0') {
+      ev.preventDefault();
+      zoomReset();
+    }
   }
 
   // ----- Outline panel -----------------------------------------------------
@@ -53,6 +84,7 @@
   // gets in the way.
   let gutterOpen = readBoolPref(GUTTER_KEY, true);
   let sourceEl: HTMLPreElement | null = null;
+  let rootEl: HTMLDivElement | null = null;
   let lastFlash: number | null = null;
 
   function readBoolPref(key: string, defaultValue: boolean): boolean {
@@ -274,13 +306,15 @@
 
 
   onMount(() => {
+    window.addEventListener('keydown', onKey);
     return () => {
+      window.removeEventListener('keydown', onKey);
       if (lastFlash !== null) clearTimeout(lastFlash);
     };
   });
 </script>
 
-<div class="root" use:zoomAction style="font-size: {$zoom}em;">
+<div class="root" bind:this={rootEl} use:zoomAction style="font-size: {$zoom}em;">
   <div class="header">
     <div class="title-block">
       {#if outline && outline.super_types.length > 0}

--- a/crates/core/src/patterns.rs
+++ b/crates/core/src/patterns.rs
@@ -173,7 +173,7 @@ fn check_no_static_state(repo: &Repository, scope: &Scope) -> PatternResult {
         pattern: Pattern::NoStaticState,
         holds: holds_to_vec(holds),
         violations,
-        confidence: 0.9,
+        confidence: 0.85,
     }
 }
 
@@ -324,10 +324,14 @@ fn is_spring_controller(class: &Class) -> bool {
 }
 
 fn is_final_field(field: &projectmind_plugin_api::Field) -> bool {
-    field
-        .annotations
-        .iter()
-        .any(|a| a.is("Final") || a.is("Value") || a.is("ConfigurationProperty"))
+    // Primary signal: the parser extracted the `final` modifier. The
+    // type_text checks stay as a fallback for parsers that fold modifiers
+    // into the type text; `final` itself is a keyword, never an annotation.
+    field.is_final
+        || field
+            .annotations
+            .iter()
+            .any(|a| a.is("Value") || a.is("ConfigurationProperty"))
         || field.type_text.starts_with("final ")
         || field.type_text.contains(" final ")
 }
@@ -424,6 +428,28 @@ mod tests {
             type_text: "final int".into(),
             line: 11,
             is_static: true,
+            ..Default::default()
+        });
+        let repo = mk_repo(vec![make_module("m", vec![c])]);
+        let res = check(&repo, Pattern::NoStaticState, &Scope::default());
+        assert!(res.violations.is_empty());
+        assert_eq!(res.holds.len(), 1);
+        assert_eq!(res.holds[0].count, 1);
+    }
+
+    #[test]
+    fn no_static_state_ignores_static_final_via_is_final_flag() {
+        // Real Java-parser shape: `private static final Logger LOG = ...`
+        // yields type_text "Logger" (modifiers never land in type_text) and
+        // is_final: true. Must not be flagged.
+        let mut c = cls("a.b.Svc");
+        c.annotations.push(annot("Service"));
+        c.fields.push(Field {
+            name: "LOG".into(),
+            type_text: "Logger".into(),
+            line: 7,
+            is_static: true,
+            is_final: true,
             ..Default::default()
         });
         let repo = mk_repo(vec![make_module("m", vec![c])]);

--- a/crates/plugin-api/src/entity.rs
+++ b/crates/plugin-api/src/entity.rs
@@ -163,6 +163,11 @@ pub struct Field {
     pub annotations: Vec<Annotation>,
     /// Whether the field is static.
     pub is_static: bool,
+    /// Whether the field is final (Java `final` modifier). Languages without
+    /// the concept leave this `false`; `#[serde(default)]` keeps previously
+    /// serialized modules loadable.
+    #[serde(default)]
+    pub is_final: bool,
 }
 
 /// An annotation as written in source (`@Service`, `@Bean(name = "x")`, …).

--- a/plugins/framework-spring/src/lib.rs
+++ b/plugins/framework-spring/src/lib.rs
@@ -176,6 +176,7 @@ mod tests {
                 raw_args: None,
             }],
             is_static: false,
+            is_final: false,
         });
         module.classes.insert(consumer.fqn.clone(), consumer);
         SpringPlugin.enrich(&mut module).unwrap();

--- a/plugins/lang-java/src/parser.rs
+++ b/plugins/lang-java/src/parser.rs
@@ -150,6 +150,7 @@ fn build_fields(node: Node<'_>, bytes: &[u8]) -> Vec<Field> {
                     visibility: visibility_from(&modifiers),
                     annotations: annotations.clone(),
                     is_static: modifiers.iter().any(|m| m == "static"),
+                    is_final: modifiers.iter().any(|m| m == "final"),
                 });
             }
         }
@@ -345,6 +346,28 @@ mod tests {
         assert_eq!(class.methods.len(), 1);
         assert_eq!(class.methods[0].name, "greet");
         assert_eq!(class.methods[0].visibility, Visibility::Public);
+    }
+
+    #[test]
+    fn field_final_modifier_sets_is_final() {
+        let src = r"
+            package com.example;
+            public class Svc {
+                private static final Logger LOG = null;
+                private static int counter;
+            }
+        ";
+        let m = parse_one(src);
+        let c = m.classes.get("com.example.Svc").unwrap();
+        let log = c.fields.iter().find(|f| f.name == "LOG").unwrap();
+        assert!(log.is_static);
+        assert!(log.is_final);
+        // tree-sitter yields the bare type node — modifiers never leak into
+        // type_text, so `is_final` is the only reliable signal.
+        assert_eq!(log.type_text, "Logger");
+        let counter = c.fields.iter().find(|f| f.name == "counter").unwrap();
+        assert!(counter.is_static);
+        assert!(!counter.is_final);
     }
 
     #[test]

--- a/plugins/lang-rust/src/parser.rs
+++ b/plugins/lang-rust/src/parser.rs
@@ -147,6 +147,8 @@ fn collect_fields(node: Node<'_>, bytes: &[u8]) -> Vec<Field> {
             visibility: item_visibility(member, bytes),
             annotations: collect_outer_attributes(member, bytes),
             is_static: false,
+            // Rust has no `final` — struct fields are never final.
+            is_final: false,
         });
     }
     out


### PR DESCRIPTION
Zwei Specs, ein Commit pro Spec:

## Spec 25 — NoStaticState: false positives durch fehlendes `is_final` (672551c)

Der Detektor meldete jede `private static final Logger LOG = ...`-Konstante in Spring-Komponenten als Violation, weil `Field` kein `is_final` kannte und die Heuristik in `is_final_field()` nie griff (`@Final` ist keine Java-Annotation; tree-sitter liefert den type-Knoten ohne Modifier).

- `plugin-api`: `Field.is_final: bool` mit `#[serde(default)]` (kein Breaking Change)
- `lang-java`: `build_fields()` extrahiert `final` aus den Modifiers (analog `is_static`)
- `lang-rust` / `framework-spring`: Field-Literale ergänzt (`is_final: false`)
- `core/patterns`: `is_final_field()` prüft primär `field.is_final`; tote `a.is("Final")`-Prüfung entfernt, `type_text`-Fallback bleibt
- `confidence` 0.9 → 0.85 (passend zur Doku "v1 detectors are 0.85")
- Neue Tests: `field_final_modifier_sets_is_final` (echter Parser-Pfad) + `no_static_state_ignores_static_final_via_is_final_flag`

## Spec 30 — ClassViewer: Keyboard-Zoom Cmd/Ctrl + / − / 0 (d026128)

Keyboard-Help verspricht Zoom "in allen Viewern", ClassViewer konnte es nicht (Commit 8b0a9f5 brachte nur den Reset-Button). Jetzt analog FileView:

- `zoomIn()`/`zoomOut()` über den bestehenden `createShiftWheelZoom`-Store (klemmt + persistiert automatisch)
- `keydown` auf `window`: `Cmd/Ctrl + =/+` rein, `−` raus, `0` Reset; nur aktiv wenn der Viewer im DOM ist und kein `<input>`/`<textarea>` fokussiert ist
- Registrierung in `onMount`, Cleanup im Return (kein Leak)

## Verifikation

- `cargo fmt --check` + `cargo clippy -D warnings` + `cargo test` (Workspace ohne Tauri-App-Crate — lokale Box hat keine GTK-Libs; CI baut den vollen Workspace): alle grün, 156+ Tests
- Frontend: `svelte-check` 0 Fehler, `vitest` 103 passed, `pnpm build` ok
- Hinweis: `pnpm lint` schlägt lokal fehl (ESLint 9 ohne flat config) — vorbestehend, nicht Teil der CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJuL4nSq1EvgahTJe1hom1