### PR TITLE
feat(walkthrough): Source-Pane scrollt automatisch zur ersten Highlight-Range

### DIFF
--- a/app/src/components/WalkthroughView.svelte
+++ b/app/src/components/WalkthroughView.svelte
@@ -35,6 +35,7 @@
   import { readZoom, writeZoom, clampZoom, wheelDelta } from '../lib/shiftWheelZoom';
   import { openUrl } from '../lib/openUrl';
   import { expandStepRefs, matchLineAnchor } from '../lib/walkthroughText';
+  import { firstHighlightRange } from '../lib/walkthroughHighlight';
   import { compassFor, compassIconFor } from '../lib/compass';
   import { isCorrect, scoreQuiz, type QuizAnswer } from '../lib/quiz';
 
@@ -152,7 +153,37 @@
     // the fresh `body` hasn't been flushed into `step` at all — so the
     // loader would see a stale (or, on a fresh mount, null) step, skip the
     // fetch, and leave the target pane empty (#171).
-    await loadTargetForStep(body?.steps[_step] ?? null);
+    const activeStep = body?.steps[_step] ?? null;
+    await loadTargetForStep(activeStep);
+    await scrollToFirstHighlight(activeStep);
+  }
+
+  /// #175: when a step opens, bring its FIRST highlight range into view —
+  /// without this the pane sits at line 1 (or wherever the previous step
+  /// left it) and highlights below the fold go unseen. Steps without
+  /// highlights — or whose ranges point outside the loaded content — reset
+  /// the pane to the top instead, so the previous step's scroll offset
+  /// doesn't leak into this step. Diff targets are excluded (DiffView owns
+  /// its own focus rail, #126), markdown files too (FileView scrolls to its
+  /// own anchor), and note/artifact targets have no source lines at all.
+  async function scrollToFirstHighlight(s: WalkthroughStep | null) {
+    await tick(); // wait for the freshly loaded target to reach the DOM
+    const t = s?.target;
+    if (!targetEl || !t) return;
+    if (t.kind !== 'class' && t.kind !== 'file') return;
+    if (t.kind === 'file' && isMarkdown(t.path)) return;
+
+    const first = firstHighlightRange(t.highlight);
+    if (first) {
+      const line = targetEl.querySelector<HTMLElement>(`[data-line-no="${first.from}"]`);
+      if (line) {
+        line.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        return;
+      }
+      // Range beyond the rendered content — fall through to the top.
+    }
+    const scroller = plainEl ?? targetEl.querySelector<HTMLElement>('pre.source');
+    if (scroller) scroller.scrollTop = 0;
   }
 
   async function loadTargetForStep(s: WalkthroughStep | null) {

--- a/app/src/lib/walkthroughHighlight.test.ts
+++ b/app/src/lib/walkthroughHighlight.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { firstHighlightRange } from './walkthroughHighlight';
+
+describe('firstHighlightRange (#175)', () => {
+  it('returns null when the step has no highlights', () => {
+    expect(firstHighlightRange(undefined)).toBeNull();
+    expect(firstHighlightRange(null)).toBeNull();
+    expect(firstHighlightRange([])).toBeNull();
+  });
+
+  it('returns the only range as-is', () => {
+    expect(firstHighlightRange([{ from: 58, to: 77 }])).toEqual({ from: 58, to: 77 });
+  });
+
+  it('picks the topmost range, not the first in array order', () => {
+    expect(
+      firstHighlightRange([
+        { from: 120, to: 130 },
+        { from: 12, to: 18 },
+        { from: 58, to: 77 },
+      ]),
+    ).toEqual({ from: 12, to: 18 });
+  });
+
+  it('keeps the first-encountered range on equal starts', () => {
+    expect(
+      firstHighlightRange([
+        { from: 40, to: 45 },
+        { from: 40, to: 60 },
+      ]),
+    ).toEqual({ from: 40, to: 45 });
+  });
+});

--- a/app/src/lib/walkthroughHighlight.ts
+++ b/app/src/lib/walkthroughHighlight.ts
@@ -1,0 +1,24 @@
+/// Auto-scroll target selection for walkthrough steps (#175).
+///
+/// Pure function: given a step's highlight ranges, pick the one the
+/// source pane should scroll to on step activation. Lifted out of
+/// `WalkthroughView.svelte` so vitest can pin the selection rule
+/// without booting the component (same pattern as `diffFocus.ts`).
+
+import type { LineRange } from './api';
+
+/// The range the pane auto-scrolls to: the one starting at the
+/// smallest line — authors don't always emit ranges sorted, and the
+/// reader expects to land on the topmost highlighted block. Returns
+/// `null` when the step carries no highlights (caller shows the
+/// target from the top instead).
+export function firstHighlightRange(
+  ranges: readonly LineRange[] | undefined | null,
+): LineRange | null {
+  if (!ranges || ranges.length === 0) return null;
+  let first = ranges[0];
+  for (const r of ranges) {
+    if (r.from < first.from) first = r;
+  }
+  return first;
+}


### PR DESCRIPTION
## Problem

Wenn ein Tour-Step eine Klasse/Datei mit `highlight`-Ranges anvisiert, öffnete die Source-Pane bei Zeile 1 — eine Range wie 58–77 lag unterhalb des sichtbaren Bereichs des inneren Scroll-Containers und musste manuell gesucht werden.

## Änderungen

- **`WalkthroughView.svelte`:** Neues `scrollToFirstHighlight()`, das nach `loadTargetForStep()` (also bei jeder Step-Aktivierung, inkl. Prev/Next und externem `walkthrough_set_step`) läuft: nach `tick()` wird die erste Highlight-Range über die vorhandenen `data-line-no`-Marker (ClassViewer wie Plain-File-Branch) per `scrollIntoView({ behavior: 'smooth', block: 'center' })` zentriert — gleiches Verhalten wie der Diff-Focus-Rail aus #126 und die bestehenden `#L42`-Narration-Links.
- **`lib/walkthroughHighlight.ts`:** `firstHighlightRange()` als pure Funktion herausgezogen (Muster von `diffFocus.ts`) — wählt die Range mit der kleinsten `from`-Zeile, da Ranges unsortiert ankommen können.

## Edge-Cases

- **Step ohne Highlights:** kein Scroll ins Leere — die Pane wird auf den Anfang zurückgesetzt, damit der Scroll-Offset des vorherigen Steps nicht in den neuen Step „leckt" (ClassViewer/`pre` werden von Svelte wiederverwendet).
- **Range ausserhalb des geladenen Inhalts:** `data-line-no`-Lookup schlägt fehl → Fallback auf Anfang statt Fehlverhalten.
- **Diff-Targets** (eigener Focus-Rail #126), **Markdown-Targets** (FileView scrollt zu seinem eigenen Anchor) sowie **Note/Artifact** (keine Quellzeilen) werden bewusst nicht angefasst.

## Test

- `vitest run`: 107/107 grün, davon 4 neue Tests für `firstHighlightRange` (leer/undefined, Einzel-Range, unsortierte Ranges, gleicher Start)
- `svelte-check`: 0 Errors / 0 Warnings
- `vite build` (wie CI): erfolgreich

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJuL4nSq1EvgahTJe1hom1