### PR TITLE
Viz-Katalog V1.3/V1.4: renderer extraction + viewport store (foundation)

### DIFF
--- a/app/src/components/DiagramView.svelte
+++ b/app/src/components/DiagramView.svelte
@@ -22,6 +22,24 @@
     authorIdentity,
   } from '../lib/folderMapColors';
   import { wheelDelta } from '../lib/shiftWheelZoom';
+  import {
+    renderFolderMap,
+    type FolderMap,
+    type FolderMapNode,
+    type FillFor,
+  } from '../lib/diagrams/folderMap';
+  import { renderDocGraph, type DocGraph } from '../lib/diagrams/docGraph';
+  import { renderLanguageStats, type LanguageStats } from '../lib/diagrams/languageStats';
+  import {
+    renderArchitectureFlow,
+    type ArchitectureFlow,
+  } from '../lib/diagrams/architectureFlow';
+  import { renderModuleChord, type ModuleChord } from '../lib/diagrams/moduleChord';
+  import {
+    renderActivityHeatmap,
+    type ActivityHeatmap,
+  } from '../lib/diagrams/activityHeatmap';
+  import { createViewportStore } from '../lib/diagrams/viewport';
 
   export let kind: DiagramKind;
   export let folderLayout: 'hierarchy' | 'solar' | 'td' = 'solar';
@@ -30,148 +48,6 @@
   /// (target), and the toolbar's colour-by / diff-ref controls are hidden —
   /// they're driven by the embedding view instead.
   export let compareWith: string | null = null;
-
-  interface FolderMapNode {
-    id: string;
-    parent: string | null;
-    label: string;
-    path: string;
-    kind: 'root' | 'folder' | 'file';
-    depth: number;
-    weight: number;
-  }
-
-  interface FolderMap {
-    root: string;
-    max_depth: number;
-    truncated: boolean;
-    nodes: FolderMapNode[];
-  }
-
-  interface DocNode {
-    id: string;
-    abs: string;
-    rel: string;
-    title: string;
-    inbound: number;
-    outbound: number;
-    external: number;
-    orphan: boolean;
-  }
-
-  interface DocEdge {
-    from: string;
-    to: string;
-    label: string;
-    href: string;
-  }
-
-  interface DanglingDocLink {
-    from: string;
-    label: string;
-    href: string;
-    resolved: string;
-  }
-
-  interface DocGraph {
-    root: string;
-    nodes: DocNode[];
-    edges: DocEdge[];
-    dangling: DanglingDocLink[];
-    orphan_count: number;
-    dangling_count: number;
-    external_count: number;
-  }
-
-  interface LanguageBucket {
-    language: string;
-    extension: string | null;
-    files: number;
-    bytes: number;
-  }
-
-  interface LanguageStats {
-    root: string;
-    total_files: number;
-    total_bytes: number;
-    truncated: boolean;
-    buckets: LanguageBucket[];
-  }
-
-  interface FlowClass {
-    fqn: string;
-    name: string;
-    module: string;
-    stereotype: string | null;
-  }
-  interface FlowLayer {
-    id: string;
-    label: string;
-    description: string;
-    color: string;
-    classes: FlowClass[];
-    stereotypes: Record<string, number>;
-  }
-  interface FlowEdge {
-    from: string;
-    to: string;
-    count: number;
-  }
-  interface ArchitectureFlow {
-    root: string;
-    total_classes: number;
-    total_modules: number;
-    cross_module_edges: number;
-    layers: FlowLayer[];
-    edges: FlowEdge[];
-  }
-
-  interface ChordModule {
-    id: string;
-    label: string;
-    classes: number;
-    outgoing: number;
-    incoming: number;
-    internal: number;
-  }
-  interface ChordEdge {
-    from: string;
-    to: string;
-    count: number;
-  }
-  interface ModuleChord {
-    root: string;
-    modules: ChordModule[];
-    edges: ChordEdge[];
-    total_relations: number;
-  }
-
-  interface ActivityAuthorSlice {
-    name: string;
-    commits: number;
-  }
-  interface ActivityDay {
-    date: string;
-    commits: number;
-    top_authors: ActivityAuthorSlice[];
-  }
-  interface ActivityAuthorTotals {
-    name: string;
-    commits: number;
-  }
-  interface ActivityHeatmap {
-    root: string;
-    start_date: string;
-    end_date: string;
-    days: ActivityDay[];
-    total_commits: number;
-    distinct_authors: number;
-    top_authors: ActivityAuthorTotals[];
-    max_commits_per_day: number;
-    longest_streak_days: number;
-    truncated: boolean;
-    no_git: boolean;
-  }
 
   let stage: HTMLDivElement;
   let mermaidSource = '';
@@ -364,27 +240,31 @@
     await render(kind, folderLayout, docGraphLayout);
   }
 
-  // viewport state
-  let scale = 1;
-  let tx = 0;
-  let ty = 0;
+  // Viewport (pan / zoom) state now lives in a small per-instance Svelte
+  // store (`lib/diagrams/viewport.ts`) so the Mini-Map (#66) can read the
+  // viewport rectangle and drive pan/zoom through the same pure reducers the
+  // stage uses. `scale`/`tx`/`ty` are the live transform; `baseW`/`baseH`
+  // are the fit-to-stage SVG size at scale 1, stamped once per render.
+  //
+  // The base size still drives an explicit width/height on the SVG (see
+  // `applyBaseSize`) — the previous approach of mutating SVG width/height on
+  // every wheel tick was crisper at extreme zoom but unreliable under
+  // WKWebView (querySelector('svg') sometimes missed the freshly-attached
+  // node after HMR / async render, so the wrapper translated without the SVG
+  // scaling — "ganze Panel verschoben, aber nicht skaliert"). The CSS
+  // transform below always applies regardless of when the SVG mounts.
+  const viewport = createViewportStore();
+  $: scale = $viewport.scale;
+  $: tx = $viewport.tx;
+  $: ty = $viewport.ty;
+  $: baseW = $viewport.baseW;
+  $: baseH = $viewport.baseH;
+
   let dragging = false;
   let dragStartX = 0;
   let dragStartY = 0;
   let dragStartTx = 0;
   let dragStartTy = 0;
-
-  // SVG fit-to-stage size at scale=1. We still set width/height once during
-  // render() so the SVG occupies the stage sensibly; live zoom is then
-  // applied via a CSS transform on the wrapper (see `diagramTransform`
-  // below). The previous approach — mutating SVG width/height on every
-  // wheel tick — was crisper at extreme zoom but unreliable under WKWebView:
-  // querySelector('svg') sometimes missed the freshly-attached node after
-  // HMR / async render, so the wrapper translated without the SVG scaling
-  // ("ganze Panel verschoben, aber nicht skaliert"). CSS transform always
-  // applies regardless of when the SVG mounts.
-  let baseW = 0;
-  let baseH = 0;
 
   // Combined translate + scale for the .diagram wrapper. Reactive so any
   // tx/ty/scale update lands in one transform string.
@@ -438,9 +318,7 @@
   }
 
   function resetView() {
-    scale = 1;
-    tx = 0;
-    ty = 0;
+    viewport.reset();
   }
 
   function openFolderNode(path: string, nodeKind: string) {
@@ -519,14 +397,14 @@
         ) {
           selectedFolderNode = null;
         }
-        svg = renderFolderMap(folderMap, layout);
+        svg = renderFolderMap(folderMap, layout, buildFillFor(folderMap));
       } else if (k === 'doc-graph') {
         mermaidSource = '';
         docGraph = JSON.parse(payload) as DocGraph;
         if (selectedDocId && !docGraph.nodes.some((n) => n.id === selectedDocId)) {
           selectedDocId = null;
         }
-        svg = renderDocGraph(docGraph, docLayout);
+        svg = renderDocGraph(docGraph, docLayout, selectedDocId);
       } else if (k === 'architecture-layers') {
         mermaidSource = '';
         svg = '';
@@ -567,11 +445,9 @@
         const sh = stage?.clientHeight ?? 0;
         if (vbW > 0 && vbH > 0 && sw > 0 && sh > 0) {
           const fit = Math.min(sw / vbW, sh / vbH);
-          baseW = vbW * fit;
-          baseH = vbH * fit;
+          viewport.setBaseSize(vbW * fit, vbH * fit);
         } else {
-          baseW = sw;
-          baseH = sh;
+          viewport.setBaseSize(sw, sh);
         }
         node.style.display = 'block';
         applyBaseSize();
@@ -584,24 +460,11 @@
     }
   }
 
-  function renderFolderMap(map: FolderMap, layout: 'hierarchy' | 'solar' | 'td'): string {
-    // Build the fill resolver once per render, then capture it in the
-    // closure. The three layout renderers below all consult `currentFillFor`
-    // when emitting circles.
-    currentFillFor = buildFillFor(map);
-    if (layout === 'solar') return renderFolderSolar(map);
-    if (layout === 'td') return renderFolderTopDown(map);
-    return renderFolderHierarchy(map);
-  }
-
-  // Captured by each layout renderer so we don't have to thread the resolver
-  // through three function signatures. Reset at the top of every render.
-  let currentFillFor: ((id: string, kind: 'root' | 'folder' | 'file') => string | null) =
-    () => null;
-
-  function buildFillFor(
-    map: FolderMap,
-  ): (id: string, kind: 'root' | 'folder' | 'file') => string | null {
+  /// Build the per-render fill resolver from the current colour-by state.
+  /// The pure `renderFolderMap` (in `lib/diagrams/folderMap.ts`) calls this
+  /// resolver per node; it lives here because it depends on the fetched git
+  /// facts / diff status the component owns.
+  function buildFillFor(map: FolderMap): FillFor {
     if (effectiveColorBy === 'diff') {
       return buildDiffFillFor(map);
     }
@@ -664,9 +527,7 @@
   /// so a tinted parent says "something interesting happened in here";
   /// untouched files / folders stay null and fall back to the structure
   /// palette.
-  function buildDiffFillFor(
-    map: FolderMap,
-  ): (id: string, kind: 'root' | 'folder' | 'file') => string | null {
+  function buildDiffFillFor(map: FolderMap): FillFor {
     if (!changesByPath || changesByPath.size === 0) {
       return () => null;
     }
@@ -746,331 +607,6 @@
     return `hsl(${h}, ${s}%, ${l}%)`;
   }
 
-  /// Helper used by all three folder-map layouts. Returns the `<circle>`
-  /// element string — without a fill override when colour-by is `structure`,
-  /// with an inline fill (and a tinted, lighter stroke) in `recency` mode.
-  function circleSvg(
-    n: FolderMapNode,
-    r: number,
-  ): string {
-    const fill = currentFillFor(n.id, n.kind);
-    if (fill === null) {
-      return `<circle r="${r}"/>`;
-    }
-    // Stroke is the same hue ~25% lighter so the rim still reads.
-    return `<circle r="${r}" style="fill:${fill};stroke:color-mix(in srgb, ${fill} 60%, white);"/>`;
-  }
-
-  function renderFolderHierarchy(map: FolderMap): string {
-    const nodes = [...map.nodes].sort((a, b) => a.depth - b.depth || a.id.localeCompare(b.id));
-    const byParent = groupByParent(nodes);
-    const rows: Array<{ n: FolderMapNode; x: number; y: number }> = [];
-    const nextY = { value: 70 };
-    const xGap = 210;
-    const yGap = 58;
-    function place(id: string, depth: number) {
-      const n = nodes.find((node) => node.id === id);
-      if (!n) return;
-      const children = byParent.get(id) ?? [];
-      if (children.length === 0) {
-        rows.push({ n, x: 80 + depth * xGap, y: nextY.value });
-        nextY.value += yGap;
-        return;
-      }
-      const before = nextY.value;
-      for (const child of children) place(child.id, depth + 1);
-      const after = nextY.value - yGap;
-      rows.push({ n, x: 80 + depth * xGap, y: (before + after) / 2 });
-    }
-    place('.', 0);
-    const byId = new Map(rows.map((r) => [r.n.id, r]));
-    const width = Math.max(900, Math.max(...rows.map((r) => r.x), 0) + 260);
-    const height = Math.max(520, nextY.value + 70);
-    const edges = rows
-      .filter((r) => r.n.parent)
-      .map((r) => {
-        const p = byId.get(r.n.parent ?? '');
-        if (!p) return '';
-        return `<path d="M${p.x + 70} ${p.y} C${p.x + 135} ${p.y}, ${r.x - 70} ${r.y}, ${r.x - 10} ${r.y}" class="edge"/>`;
-      })
-      .join('');
-    const body = rows
-      .map(({ n, x, y }) => {
-        const radius = nodeRadius(n);
-        return `<g class="node ${n.kind}" data-path="${esc(n.path)}" data-kind="${n.kind}" transform="translate(${x} ${y})">
-          ${circleSvg(n, radius)}
-          <text x="${radius + 8}" y="-3">${esc(shortLabel(n.label, 22))}</text>
-          <text x="${radius + 8}" y="13" class="meta">${n.kind} · ${n.weight}</text>
-        </g>`;
-      })
-      .join('');
-    return folderSvg(width, height, edges + body, map);
-  }
-
-  function renderFolderTopDown(map: FolderMap): string {
-    const nodes = [...map.nodes].sort((a, b) => a.depth - b.depth || a.id.localeCompare(b.id));
-    const byId = new Map(nodes.map((n) => [n.id, n]));
-    const byParent = groupByParent(nodes);
-    const placed = new Map<string, { n: FolderMapNode; x: number; y: number }>();
-    const leafX = { value: 95 };
-    const xGap = 120;
-    const yGap = 112;
-
-    function place(id: string, depth: number): number {
-      const n = byId.get(id);
-      if (!n) return leafX.value;
-      const children = byParent.get(id) ?? [];
-      let x: number;
-      if (children.length === 0) {
-        x = leafX.value;
-        leafX.value += xGap;
-      } else {
-        const childXs = children.map((child) => place(child.id, depth + 1));
-        x = (childXs[0] + childXs[childXs.length - 1]) / 2;
-      }
-      placed.set(id, { n, x, y: 70 + depth * yGap });
-      return x;
-    }
-
-    place('.', 0);
-    const rows = [...placed.values()];
-    const width = Math.max(900, leafX.value + 95);
-    const height = Math.max(520, Math.max(...rows.map((r) => r.y), 0) + 120);
-    const edges = rows
-      .filter((r) => r.n.parent)
-      .map((r) => {
-        const p = placed.get(r.n.parent ?? '');
-        if (!p) return '';
-        return `<path d="M${p.x} ${p.y + 32} C${p.x} ${p.y + 70}, ${r.x} ${r.y - 70}, ${r.x} ${r.y - 18}" class="edge"/>`;
-      })
-      .join('');
-    const body = rows
-      .map(({ n, x, y }) => {
-        const radius = nodeRadius(n);
-        return `<g class="node ${n.kind}" data-path="${esc(n.path)}" data-kind="${n.kind}" transform="translate(${x} ${y})">
-          ${circleSvg(n, radius)}
-          <text y="${radius + 17}" text-anchor="middle">${esc(shortLabel(n.label, 14))}</text>
-          <text y="${radius + 31}" class="meta" text-anchor="middle">${n.kind} · ${n.weight}</text>
-        </g>`;
-      })
-      .join('');
-    return folderSvg(width, height, edges + body, map);
-  }
-
-  function renderFolderSolar(map: FolderMap): string {
-    const nodes = map.nodes;
-    const byParent = groupByParent(nodes);
-    const width = 1400;
-    const height = 900;
-    const cx = width / 2;
-    const cy = height / 2;
-    const placed = new Map<string, { n: FolderMapNode; x: number; y: number }>();
-    placed.set('.', { n: nodes[0], x: cx, y: cy });
-    const maxDepth = Math.max(...nodes.map((n) => n.depth), 1);
-    const rings = Array.from({ length: maxDepth }, (_, i) => {
-      const r = 105 + i * 118;
-      return `<circle class="orbit" cx="${cx}" cy="${cy}" r="${r}"/>`;
-    }).join('');
-    for (let depth = 1; depth <= maxDepth; depth++) {
-      const level = nodes.filter((n) => n.depth === depth);
-      const radius = 105 + (depth - 1) * 118;
-      level.forEach((n, i) => {
-        const angle = -Math.PI / 2 + (i / Math.max(level.length, 1)) * Math.PI * 2;
-        placed.set(n.id, {
-          n,
-          x: cx + Math.cos(angle) * radius,
-          y: cy + Math.sin(angle) * radius,
-        });
-      });
-    }
-    const edges = nodes
-      .filter((n) => n.parent)
-      .map((n) => {
-        const a = placed.get(n.parent ?? '');
-        const b = placed.get(n.id);
-        if (!a || !b) return '';
-        return `<line class="edge" x1="${a.x}" y1="${a.y}" x2="${b.x}" y2="${b.y}"/>`;
-      })
-      .join('');
-    const body = [...placed.values()]
-      .map(({ n, x, y }) => {
-        const r = nodeRadius(n);
-        return `<g class="node ${n.kind}" data-path="${esc(n.path)}" data-kind="${n.kind}" transform="translate(${x} ${y})">
-          ${circleSvg(n, r)}
-          <text y="${r + 16}" text-anchor="middle">${esc(shortLabel(n.label, 18))}</text>
-        </g>`;
-      })
-      .join('');
-    return folderSvg(width, height, rings + edges + body, map);
-  }
-
-  function renderDocGraph(
-    graph: DocGraph,
-    layout: 'network' | 'radial' | 'orphans',
-  ): string {
-    if (graph.nodes.length === 0) return emptyDocGraphSvg();
-    const placed = placeDocNodes(graph, layout);
-    const width = 1400;
-    const height = 900;
-    const defs = `<defs>
-      <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-        <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b"/>
-      </marker>
-    </defs>`;
-    const edges = graph.edges
-      .map((e) => {
-        const from = placed.get(e.from);
-        const to = placed.get(e.to);
-        if (!from || !to) return '';
-        const dx = to.x - from.x;
-        const dy = to.y - from.y;
-        const len = Math.max(1, Math.sqrt(dx * dx + dy * dy));
-        const fromR = docNodeRadius(from.node) + 4;
-        const toR = docNodeRadius(to.node) + 10;
-        const x1 = from.x + (dx / len) * fromR;
-        const y1 = from.y + (dy / len) * fromR;
-        const x2 = to.x - (dx / len) * toR;
-        const y2 = to.y - (dy / len) * toR;
-        const curve = Math.min(80, Math.max(-80, (from.node.rel.localeCompare(to.node.rel) - 0.5) * 80));
-        const mx = (x1 + x2) / 2 - (dy / len) * curve;
-        const my = (y1 + y2) / 2 + (dx / len) * curve;
-        return `<path class="doc-edge" d="M${x1} ${y1} Q${mx} ${my} ${x2} ${y2}">
-          <title>${esc(e.from)} → ${esc(e.to)} (${esc(e.label)})</title>
-        </path>`;
-      })
-      .join('');
-    const nodes = [...placed.values()]
-      .map(({ node, x, y }) => {
-        const r = docNodeRadius(node);
-        const classes = ['node', 'doc-node'];
-        if (node.orphan) classes.push('orphan');
-        if (node.id === selectedDocId) classes.push('selected');
-        const subtitle = `${node.inbound} in · ${node.outbound} out · ${node.external} external`;
-        return `<g class="${classes.join(' ')}" data-id="${esc(node.id)}" transform="translate(${x} ${y})">
-          <circle r="${r}"/>
-          <text y="${r + 18}" text-anchor="middle">${esc(shortLabel(node.title || node.rel, 22))}</text>
-          <text y="${r + 33}" class="meta" text-anchor="middle">${esc(shortLabel(node.rel, 26))}</text>
-          <title>${esc(node.rel)}\n${esc(subtitle)}</title>
-        </g>`;
-      })
-      .join('');
-    const stats = `<g class="doc-stats" transform="translate(24 30)">
-      <text>docs ${graph.nodes.length}</text>
-      <text y="18">links ${graph.edges.length}</text>
-      <text y="36">orphans ${graph.orphan_count}</text>
-      <text y="54">dangling ${graph.dangling_count}</text>
-      <text y="72">external ${graph.external_count}</text>
-    </g>`;
-    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}">
-      ${defs}
-      <style>
-        .doc-edge{stroke:#64748b;stroke-width:1.6;fill:none;opacity:.58;marker-end:url(#arrow)}
-        .doc-node{cursor:pointer}
-        .doc-node circle{fill:#1f2937;stroke:#38bdf8;stroke-width:2;filter:drop-shadow(0 10px 18px rgba(0,0,0,.35))}
-        .doc-node.orphan circle{stroke:#f59e0b;stroke-dasharray:5 4}
-        .doc-node.selected circle{fill:#0f766e;stroke:#5eead4;stroke-width:4}
-        text{fill:#e5edf8;font:13px ui-sans-serif,system-ui,sans-serif;paint-order:stroke;stroke:#090d14;stroke-width:3px;stroke-linejoin:round}
-        .meta{fill:#9aa8ba;font-size:11px}
-        .doc-stats text{fill:#cbd5e1;font:12px ui-monospace,SFMono-Regular,Menlo,monospace;stroke:none}
-      </style>
-      <rect width="100%" height="100%" fill="#090d14"/>
-      ${edges}
-      ${nodes}
-      ${stats}
-    </svg>`;
-  }
-
-  function placeDocNodes(
-    graph: DocGraph,
-    layout: 'network' | 'radial' | 'orphans',
-  ): Map<string, { node: DocNode; x: number; y: number }> {
-    if (layout === 'orphans') return placeDocOrphans(graph);
-    if (layout === 'radial') return placeDocRadial(graph);
-    return placeDocNetwork(graph);
-  }
-
-  function placeDocNetwork(graph: DocGraph): Map<string, { node: DocNode; x: number; y: number }> {
-    const out = new Map<string, { node: DocNode; x: number; y: number }>();
-    const nodes = [...graph.nodes].sort(
-      (a, b) => b.inbound + b.outbound - (a.inbound + a.outbound) || a.rel.localeCompare(b.rel),
-    );
-    const cx = 700;
-    const cy = 450;
-    nodes.forEach((node, i) => {
-      if (i === 0) {
-        out.set(node.id, { node, x: cx, y: cy });
-        return;
-      }
-      const ring = Math.floor(Math.sqrt(i));
-      const inRingStart = ring * ring;
-      const inRingCount = Math.max(1, (ring + 1) * (ring + 1) - inRingStart);
-      const pos = i - inRingStart;
-      const angle = -Math.PI / 2 + (pos / inRingCount) * Math.PI * 2;
-      const radius = 120 + ring * 105;
-      out.set(node.id, {
-        node,
-        x: cx + Math.cos(angle) * radius,
-        y: cy + Math.sin(angle) * radius,
-      });
-    });
-    return out;
-  }
-
-  function placeDocRadial(graph: DocGraph): Map<string, { node: DocNode; x: number; y: number }> {
-    const out = new Map<string, { node: DocNode; x: number; y: number }>();
-    const root =
-      graph.nodes.find((n) => /^readme\.md$/i.test(n.rel)) ??
-      [...graph.nodes].sort((a, b) => b.outbound + b.inbound - (a.outbound + a.inbound))[0];
-    out.set(root.id, { node: root, x: 700, y: 450 });
-    const linked = new Set(graph.edges.filter((e) => e.from === root.id).map((e) => e.to));
-    const rings = [
-      graph.nodes.filter((n) => linked.has(n.id)),
-      graph.nodes.filter((n) => n.id !== root.id && !linked.has(n.id) && !n.orphan),
-      graph.nodes.filter((n) => n.id !== root.id && n.orphan),
-    ];
-    rings.forEach((ringNodes, ringIdx) => {
-      const radius = 150 + ringIdx * 180;
-      ringNodes
-        .sort((a, b) => a.rel.localeCompare(b.rel))
-        .forEach((node, i) => {
-          const angle = -Math.PI / 2 + (i / Math.max(1, ringNodes.length)) * Math.PI * 2;
-          out.set(node.id, {
-            node,
-            x: 700 + Math.cos(angle) * radius,
-            y: 450 + Math.sin(angle) * radius,
-          });
-        });
-    });
-    return out;
-  }
-
-  function placeDocOrphans(graph: DocGraph): Map<string, { node: DocNode; x: number; y: number }> {
-    const out = new Map<string, { node: DocNode; x: number; y: number }>();
-    const columns = [
-      graph.nodes.filter((n) => n.orphan).sort((a, b) => a.rel.localeCompare(b.rel)),
-      graph.nodes.filter((n) => !n.orphan).sort((a, b) => b.inbound - a.inbound || a.rel.localeCompare(b.rel)),
-    ];
-    columns.forEach((nodes, col) => {
-      const x = col === 0 ? 360 : 980;
-      const gap = Math.min(92, Math.max(44, 780 / Math.max(1, nodes.length)));
-      nodes.forEach((node, i) => {
-        out.set(node.id, { node, x, y: 80 + i * gap });
-      });
-    });
-    return out;
-  }
-
-  function docNodeRadius(n: DocNode): number {
-    return Math.min(46, 16 + Math.sqrt(n.inbound + n.outbound + n.external + 1) * 5);
-  }
-
-  function emptyDocGraphSvg(): string {
-    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 520">
-      <rect width="100%" height="100%" fill="#090d14"/>
-      <text x="450" y="260" text-anchor="middle" fill="#94a3b8" font-size="18" font-family="ui-sans-serif,system-ui">No markdown documents found</text>
-    </svg>`;
-  }
-
   function openDoc(path: string) {
     // The user is taking an explicit action; if we were mirroring an MCP
     // intent, stop doing so or applyState will clobber the view shortly.
@@ -1087,515 +623,6 @@
     selectedDocId = docId;
     const target = docGraph?.nodes.find((n) => n.id === docId);
     if (target) openDoc(target.abs);
-  }
-
-  function groupByParent(nodes: FolderMapNode[]): Map<string, FolderMapNode[]> {
-    const out = new Map<string, FolderMapNode[]>();
-    for (const n of nodes) {
-      if (!n.parent) continue;
-      const arr = out.get(n.parent) ?? [];
-      arr.push(n);
-      out.set(n.parent, arr);
-    }
-    for (const arr of out.values()) {
-      arr.sort((a, b) => folderRank(a) - folderRank(b) || a.label.localeCompare(b.label));
-    }
-    return out;
-  }
-
-  function folderRank(n: FolderMapNode): number {
-    return n.kind === 'root' ? 0 : n.kind === 'folder' ? 1 : 2;
-  }
-
-  function nodeRadius(n: FolderMapNode): number {
-    const base = n.kind === 'root' ? 30 : n.kind === 'folder' ? 18 : 7;
-    return Math.min(base + Math.sqrt(n.weight) * 2.5, n.kind === 'file' ? 13 : 46);
-  }
-
-  function folderSvg(width: number, height: number, body: string, map: FolderMap): string {
-    const note = map.truncated
-      ? `<text x="24" y="${height - 24}" class="caption">truncated at ${map.nodes.length} nodes / depth ${map.max_depth}</text>`
-      : '';
-    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}">
-      <style>
-        .edge{stroke:#3d4657;stroke-width:1.4;fill:none;opacity:.75}
-        .orbit{stroke:#2a3344;stroke-width:1;fill:none;stroke-dasharray:6 10}
-        .node circle{stroke-width:2;filter:drop-shadow(0 8px 14px rgba(0,0,0,.28))}
-        .node{cursor:default}
-        .node.file{cursor:pointer}
-        .node.root circle{fill:#4f46e5;stroke:#c4b5fd}
-        .node.folder circle{fill:#0f766e;stroke:#5eead4}
-        .node.file circle{fill:#334155;stroke:#94a3b8}
-        text{fill:#dce3f0;font:13px ui-sans-serif,system-ui,sans-serif}
-        .meta,.caption{fill:#8b98aa;font-size:11px}
-      </style>
-      <rect width="100%" height="100%" fill="#090d14"/>
-      ${body}
-      ${note}
-    </svg>`;
-  }
-
-  function shortLabel(label: string, max: number): string {
-    return label.length <= max ? label : `${label.slice(0, max - 1)}…`;
-  }
-
-  // ----- language-stats renderer ------------------------------------------
-  // Renders a horizontal-bar chart with the file count per language. Bars
-  // sorted by file count desc (already done server-side); the "Other"
-  // bucket sticks to the bottom. Bar width is proportional to file count
-  // relative to the largest bucket.
-  function renderLanguageStats(stats: LanguageStats): string {
-    if (stats.buckets.length === 0) {
-      return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 480">
-        <rect width="100%" height="100%" fill="#090d14"/>
-        <text x="450" y="240" text-anchor="middle" fill="#94a3b8" font-size="18" font-family="ui-sans-serif,system-ui">No files found</text>
-      </svg>`;
-    }
-    const PALETTE = [
-      '#3b82f6',
-      '#10b981',
-      '#f59e0b',
-      '#ef4444',
-      '#8b5cf6',
-      '#ec4899',
-      '#14b8a6',
-      '#f97316',
-      '#22d3ee',
-      '#a3e635',
-      '#eab308',
-      '#6366f1',
-    ];
-    const buckets = stats.buckets;
-    const maxFiles = Math.max(1, ...buckets.map((b) => b.files));
-    const totalFiles = Math.max(1, stats.total_files);
-    const ROW = 28;
-    const TOP = 60;
-    const LEFT_LABEL = 200;
-    const BAR_LEFT = LEFT_LABEL + 12;
-    const RIGHT_PADDING = 160;
-    const width = 960;
-    const barTrack = width - BAR_LEFT - RIGHT_PADDING;
-    const height = TOP + buckets.length * ROW + 40;
-    const truncatedNote = stats.truncated
-      ? `<text x="24" y="${height - 18}" class="caption">truncated at ${stats.total_files} files</text>`
-      : '';
-    const totalLine = formatBytes(stats.total_bytes);
-    const rows = buckets
-      .map((b, i) => {
-        const w = Math.max(2, Math.round((b.files / maxFiles) * barTrack));
-        const y = TOP + i * ROW;
-        const color = PALETTE[i % PALETTE.length];
-        const pct = ((b.files / totalFiles) * 100).toFixed(1);
-        const extLabel = b.extension ? `.${b.extension}` : '—';
-        return `<g class="row">
-          <text x="${LEFT_LABEL}" y="${y + 14}" class="lang" text-anchor="end">${esc(b.language)}</text>
-          <text x="${LEFT_LABEL - 8}" y="${y + 14}" class="ext" text-anchor="end" dx="-44">${esc(extLabel)}</text>
-          <rect x="${BAR_LEFT}" y="${y + 4}" width="${w}" height="${ROW - 10}" rx="3" fill="${color}" opacity="0.85"/>
-          <text x="${BAR_LEFT + w + 8}" y="${y + 14}" class="value">${b.files} · ${pct}% · ${formatBytes(b.bytes)}</text>
-        </g>`;
-      })
-      .join('');
-    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}">
-      <style>
-        text{fill:#dce3f0;font:13px ui-sans-serif,system-ui,sans-serif}
-        .title{font-size:18px;font-weight:600}
-        .caption{font-size:11px;fill:#94a3b8}
-        .lang{font-weight:600}
-        .ext{font-family:ui-monospace,monospace;font-size:11px;fill:#94a3b8}
-        .value{font-family:ui-monospace,monospace;font-size:11px;fill:#cbd5e1}
-        .ruler{stroke:#1f2937;stroke-width:1}
-      </style>
-      <rect width="100%" height="100%" fill="#090d14"/>
-      <text x="24" y="32" class="title">Sprachenverteilung</text>
-      <text x="24" y="50" class="caption">${stats.total_files} Dateien · ${totalLine} · ${buckets.length} Buckets</text>
-      <line x1="${BAR_LEFT}" y1="${TOP - 4}" x2="${BAR_LEFT}" y2="${TOP + buckets.length * ROW}" class="ruler"/>
-      ${rows}
-      ${truncatedNote}
-    </svg>`;
-  }
-
-  // ----- architecture-flow renderer ---------------------------------------
-  // Horizontal layer bands stacked top→bottom. Each band shows its name,
-  // class chips coloured by stereotype, a stereotype histogram, and an
-  // overall class count. Aggregated cross-layer edges become inter-band
-  // arrows whose stroke width encodes the underlying relation count.
-  function renderArchitectureFlow(flow: ArchitectureFlow): string {
-    const W = 1100;
-    const PAD_X = 40;
-    const PAD_TOP = 80;
-    const PAD_BETWEEN = 20;
-    const BAND_H = 150;
-    const CHIP_H = 26;
-    const CHIP_W = 132;
-    const CHIPS_PER_ROW = Math.max(1, Math.floor((W - 2 * PAD_X - 16) / (CHIP_W + 8)));
-
-    if (flow.total_classes === 0) {
-      const H = 320;
-      return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}">
-        <rect width="100%" height="100%" fill="#090d14"/>
-        <text x="${W / 2}" y="${H / 2}" text-anchor="middle" fill="#94a3b8" font-size="18" font-family="ui-sans-serif,system-ui">Keine Klassen erkannt — Architektur-Schichten benötigen geparsten Code.</text>
-      </svg>`;
-    }
-
-    type Band = { layer: FlowLayer; y: number; h: number; rows: number };
-    const bands: Band[] = [];
-    let cursor = PAD_TOP;
-    for (const layer of flow.layers) {
-      const rows = layer.classes.length === 0 ? 1 : Math.ceil(layer.classes.length / CHIPS_PER_ROW);
-      const h = Math.max(BAND_H, 56 + rows * (CHIP_H + 8));
-      bands.push({ layer, y: cursor, h, rows });
-      cursor += h + PAD_BETWEEN;
-    }
-    const H = cursor + 40;
-
-    const bandSvg = bands
-      .map(({ layer, y, h }) => {
-        const total = layer.classes.length;
-        const stripe = `<rect x="${PAD_X}" y="${y}" width="${W - 2 * PAD_X}" height="${h}" rx="14" ry="14" fill="${layer.color}" fill-opacity="0.08" stroke="${layer.color}" stroke-width="1.4"/>`;
-        const accent = `<rect x="${PAD_X}" y="${y}" width="6" height="${h}" rx="3" fill="${layer.color}"/>`;
-        const head = `
-          <text x="${PAD_X + 22}" y="${y + 28}" class="band-title" fill="${layer.color}">${esc(layer.label)}</text>
-          <text x="${PAD_X + 22}" y="${y + 48}" class="band-desc">${esc(layer.description)}</text>
-          <text x="${W - PAD_X - 16}" y="${y + 28}" text-anchor="end" class="band-count" fill="${layer.color}">${total} ${total === 1 ? 'Klasse' : 'Klassen'}</text>`;
-
-        const stereoEntries = Object.entries(layer.stereotypes).sort((a, b) => b[1] - a[1]);
-        const stereoBadges = stereoEntries
-          .slice(0, 4)
-          .map(([s, n], i) => {
-            const bx = W - PAD_X - 16 - (stereoEntries.length > 4 ? 110 : 0) - i * 86;
-            return `<g><rect x="${bx - 78}" y="${y + 36}" width="78" height="18" rx="9" fill="${layer.color}" fill-opacity="0.18" stroke="${layer.color}" stroke-opacity="0.5"/><text x="${bx - 39}" y="${y + 49}" text-anchor="middle" class="stereo">${esc(s)} · ${n}</text></g>`;
-          })
-          .join('');
-
-        const chips = layer.classes
-          .map((c, i) => {
-            const col = i % CHIPS_PER_ROW;
-            const row = Math.floor(i / CHIPS_PER_ROW);
-            const cx = PAD_X + 22 + col * (CHIP_W + 8);
-            const cy = y + 60 + row * (CHIP_H + 8);
-            const label = shortChipLabel(c.name);
-            return `<g class="chip"><rect x="${cx}" y="${cy}" width="${CHIP_W}" height="${CHIP_H}" rx="6" fill="${layer.color}" fill-opacity="0.18" stroke="${layer.color}" stroke-opacity="0.55"/><text x="${cx + 10}" y="${cy + 17}" class="chip-text">${esc(label)}</text><title>${esc(c.fqn)}\n${esc(c.module)}${c.stereotype ? `\n@${esc(c.stereotype)}` : ''}</title></g>`;
-          })
-          .join('');
-
-        const empty =
-          total === 0
-            ? `<text x="${PAD_X + 22}" y="${y + 80}" class="empty">— keine Klassen in dieser Schicht —</text>`
-            : '';
-
-        return `${stripe}${accent}${head}${stereoBadges}${chips}${empty}`;
-      })
-      .join('');
-
-    // Edges between bands. Stroke width scales with count, capped at 8px.
-    const layerY = new Map(bands.map((b) => [b.layer.id, b.y + b.h / 2]));
-    const layerColor = new Map(bands.map((b) => [b.layer.id, b.layer.color]));
-    const maxEdge = Math.max(1, ...flow.edges.map((e) => e.count));
-    const xCenter = W / 2;
-    const edgeSvg = flow.edges
-      .map((edge, i) => {
-        const yFrom = layerY.get(edge.from);
-        const yTo = layerY.get(edge.to);
-        if (yFrom === undefined || yTo === undefined) return '';
-        const width = Math.max(1.4, Math.min(8, (edge.count / maxEdge) * 7 + 1.4));
-        // Curve sideways so multiple edges don't overlap.
-        const offset = (i - flow.edges.length / 2) * 26;
-        const xMid = xCenter + offset;
-        const midY = (yFrom + yTo) / 2;
-        const arrow = yFrom < yTo ? '▼' : '▲';
-        const color = layerColor.get(edge.from) ?? '#9ca3af';
-        const path = `M ${xCenter} ${yFrom} C ${xMid} ${(yFrom + midY) / 2}, ${xMid} ${(midY + yTo) / 2}, ${xCenter} ${yTo}`;
-        return `<g class="edge"><path d="${path}" stroke="${color}" stroke-width="${width}" stroke-opacity="0.55" fill="none"/><text x="${xMid}" y="${midY + 4}" text-anchor="middle" class="edge-label">${arrow} ${edge.count}</text></g>`;
-      })
-      .join('');
-
-    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}">
-      <style>
-        text{fill:#dce3f0;font:13px ui-sans-serif,system-ui,sans-serif}
-        .title{font-size:20px;font-weight:600}
-        .subtitle{font-size:12px;fill:#94a3b8}
-        .band-title{font-size:16px;font-weight:700}
-        .band-desc{font-size:12px;fill:#94a3b8}
-        .band-count{font-size:12px;font-weight:600}
-        .stereo{font-size:10px;font-family:ui-monospace,monospace;fill:#cbd5e1}
-        .chip{cursor:default}
-        .chip-text{font-size:11px;font-family:ui-monospace,monospace}
-        .empty{font-size:12px;fill:#64748b;font-style:italic}
-        .edge-label{font-size:10px;fill:#cbd5e1;font-family:ui-monospace,monospace}
-      </style>
-      <rect width="100%" height="100%" fill="#090d14"/>
-      <text x="${PAD_X}" y="40" class="title">Architektur-Schichten</text>
-      <text x="${PAD_X}" y="60" class="subtitle">${flow.total_classes} Klassen · ${flow.total_modules} Module · ${flow.cross_module_edges} Cross-Module-Edges</text>
-      ${edgeSvg}
-      ${bandSvg}
-    </svg>`;
-  }
-
-  function shortChipLabel(name: string): string {
-    return name.length <= 16 ? name : `${name.slice(0, 15)}…`;
-  }
-
-  // ----- module-chord renderer --------------------------------------------
-  // Modules as arcs on a circle, edges as Bezier chords through the centre.
-  // Width of each chord encodes the underlying relation count. Self-edges
-  // are not drawn (the module's `internal` count is shown on the label).
-  function renderModuleChord(chord: ModuleChord): string {
-    const W = 900;
-    const H = 700;
-    const cx = W / 2;
-    const cy = H / 2 + 12;
-    const R = 270;
-    const innerR = R - 18;
-    const labelR = R + 28;
-
-    if (chord.modules.length === 0) {
-      return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}">
-        <rect width="100%" height="100%" fill="#090d14"/>
-        <text x="${cx}" y="${cy}" text-anchor="middle" fill="#94a3b8" font-size="18" font-family="ui-sans-serif,system-ui">Keine Module erkannt.</text>
-      </svg>`;
-    }
-
-    const PALETTE = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899', '#14b8a6', '#f97316', '#22d3ee', '#a3e635', '#eab308', '#6366f1'];
-
-    // Position each module on the rim with weight proportional to its
-    // class count (so big modules get a wider arc).
-    const totalWeight = chord.modules.reduce((s, m) => s + Math.max(1, m.classes), 0);
-    const arcs = new Map<string, { start: number; end: number; mid: number; color: string }>();
-    let theta = -Math.PI / 2; // start at top
-    chord.modules.forEach((m, i) => {
-      const w = Math.max(1, m.classes) / totalWeight;
-      const span = w * 2 * Math.PI * 0.94; // leave 6% gap total
-      const start = theta + 0.03 * (2 * Math.PI) / chord.modules.length;
-      const end = start + span;
-      arcs.set(m.id, { start, end, mid: (start + end) / 2, color: PALETTE[i % PALETTE.length] });
-      theta = end + 0.03 * (2 * Math.PI) / chord.modules.length;
-    });
-
-    const arcSvg = chord.modules
-      .map((m) => {
-        const a = arcs.get(m.id)!;
-        const x1 = cx + R * Math.cos(a.start);
-        const y1 = cy + R * Math.sin(a.start);
-        const x2 = cx + R * Math.cos(a.end);
-        const y2 = cy + R * Math.sin(a.end);
-        const x3 = cx + innerR * Math.cos(a.end);
-        const y3 = cy + innerR * Math.sin(a.end);
-        const x4 = cx + innerR * Math.cos(a.start);
-        const y4 = cy + innerR * Math.sin(a.start);
-        const large = a.end - a.start > Math.PI ? 1 : 0;
-        const path = `M ${x1} ${y1} A ${R} ${R} 0 ${large} 1 ${x2} ${y2} L ${x3} ${y3} A ${innerR} ${innerR} 0 ${large} 0 ${x4} ${y4} Z`;
-        const lx = cx + labelR * Math.cos(a.mid);
-        const ly = cy + labelR * Math.sin(a.mid);
-        const anchor = Math.cos(a.mid) > 0 ? 'start' : 'end';
-        const rotation = (a.mid * 180) / Math.PI;
-        const niceRot = rotation > 90 || rotation < -90 ? rotation + 180 : rotation;
-        const labelText = `${esc(m.label)} · ${m.classes}`;
-        return `<g class="rim"><path d="${path}" fill="${a.color}" fill-opacity="0.85" stroke="${a.color}" stroke-width="1"/><text x="${lx}" y="${ly}" text-anchor="${anchor}" transform="rotate(${niceRot.toFixed(1)} ${lx} ${ly})" class="rim-label">${labelText}</text><title>${esc(m.id)}\n${m.classes} Klassen · ↗ ${m.outgoing} · ↘ ${m.incoming} · ⤾ ${m.internal}</title></g>`;
-      })
-      .join('');
-
-    const maxEdge = Math.max(1, ...chord.edges.map((e) => e.count));
-    const chordSvg = chord.edges
-      .map((edge) => {
-        const a1 = arcs.get(edge.from);
-        const a2 = arcs.get(edge.to);
-        if (!a1 || !a2) return '';
-        // Tap each chord into a sub-portion of the arc proportional to
-        // edge weight relative to the module's total outgoing.
-        const x1 = cx + innerR * Math.cos(a1.mid);
-        const y1 = cy + innerR * Math.sin(a1.mid);
-        const x2 = cx + innerR * Math.cos(a2.mid);
-        const y2 = cy + innerR * Math.sin(a2.mid);
-        const w = Math.max(1, Math.min(6, (edge.count / maxEdge) * 5 + 1));
-        return `<path d="M ${x1} ${y1} Q ${cx} ${cy} ${x2} ${y2}" stroke="${a1.color}" stroke-width="${w}" stroke-opacity="0.45" fill="none"><title>${esc(edge.from)} → ${esc(edge.to)}: ${edge.count}</title></path>`;
-      })
-      .join('');
-
-    const top = chord.edges.slice(0, 6);
-    const topList = top
-      .map(
-        (e, i) =>
-          `<text x="24" y="${600 + i * 16}" class="top-line">${i + 1}. ${esc(e.from)} → ${esc(e.to)} · ${e.count}</text>`,
-      )
-      .join('');
-
-    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}">
-      <style>
-        text{fill:#dce3f0;font:13px ui-sans-serif,system-ui,sans-serif}
-        .title{font-size:20px;font-weight:600}
-        .subtitle{font-size:12px;fill:#94a3b8}
-        .rim-label{font-size:11px;font-family:ui-monospace,monospace}
-        .top-title{font-size:12px;font-weight:600;fill:#cbd5e1}
-        .top-line{font-size:11px;font-family:ui-monospace,monospace;fill:#94a3b8}
-      </style>
-      <rect width="100%" height="100%" fill="#090d14"/>
-      <text x="24" y="34" class="title">Modul-Kopplung</text>
-      <text x="24" y="52" class="subtitle">${chord.modules.length} Module · ${chord.edges.length} Cross-Module-Edges · ${chord.total_relations} Beziehungen gesamt</text>
-      ${chordSvg}
-      ${arcSvg}
-      ${top.length > 0 ? `<text x="24" y="584" class="top-title">Top Cross-Module-Kanten</text>${topList}` : ''}
-    </svg>`;
-  }
-
-  // ----- activity-heatmap renderer ----------------------------------------
-  // GitHub-style 7×N calendar grid. Each column is one week, each row a
-  // weekday (Mo top). Colour ramps linearly with commits-per-day relative
-  // to the busiest day. The side panel lists totals + top-10 authors.
-  function renderActivityHeatmap(heat: ActivityHeatmap): string {
-    const CELL = 13;
-    const GAP = 3;
-    const LEFT = 60;
-    const TOP = 90;
-    const PANEL = 240;
-
-    // Layout: bucket days into 7-row columns starting on the first
-    // ISO-Monday at or before the start_date.
-    const days = heat.days;
-    if (days.length === 0) {
-      return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 360">
-        <rect width="100%" height="100%" fill="#090d14"/>
-        <text x="550" y="180" text-anchor="middle" fill="#94a3b8" font-size="18">Keine Aktivität verfügbar.</text>
-      </svg>`;
-    }
-
-    // weekday(0=Mo … 6=So) for each day, derived from the date string.
-    function weekdayMondayBased(iso: string): number {
-      const d = new Date(iso + 'T00:00:00Z');
-      const w = d.getUTCDay(); // 0=Sun..6=Sat
-      return (w + 6) % 7; // 0=Mon..6=Sun
-    }
-
-    const first = days[0];
-    const firstW = weekdayMondayBased(first.date);
-    // Number of leading empty cells in column 0.
-    const totalCells = firstW + days.length;
-    const columns = Math.ceil(totalCells / 7);
-    const W = LEFT + columns * (CELL + GAP) + 16 + PANEL + 24;
-    const H = TOP + 7 * (CELL + GAP) + 80;
-
-    const max = Math.max(1, heat.max_commits_per_day);
-    const ramp = (n: number): string => {
-      if (n === 0) return '#1f2937';
-      const t = Math.min(1, n / max);
-      // 5 buckets, dark → bright green
-      if (t < 0.2) return '#0e3b27';
-      if (t < 0.45) return '#1c6c45';
-      if (t < 0.7) return '#2ea264';
-      if (t < 0.9) return '#3fcf83';
-      return '#7ee787';
-    };
-
-    const cells = days
-      .map((d, i) => {
-        const idx = firstW + i;
-        const col = Math.floor(idx / 7);
-        const row = idx % 7;
-        const x = LEFT + col * (CELL + GAP);
-        const y = TOP + row * (CELL + GAP);
-        const top = d.top_authors
-          .map((a) => `${a.name} · ${a.commits}`)
-          .join('\n');
-        const tip = `${d.date} — ${d.commits} ${d.commits === 1 ? 'Commit' : 'Commits'}${top ? `\n${top}` : ''}`;
-        return `<rect x="${x}" y="${y}" width="${CELL}" height="${CELL}" rx="2" fill="${ramp(d.commits)}"><title>${esc(tip)}</title></rect>`;
-      })
-      .join('');
-
-    // Weekday labels (Mo, Mi, Fr).
-    const weekdayLabels = ['Mo', '', 'Mi', '', 'Fr', '', 'So']
-      .map((lbl, i) => `<text x="${LEFT - 8}" y="${TOP + i * (CELL + GAP) + 11}" text-anchor="end" class="wd">${lbl}</text>`)
-      .join('');
-
-    // Month labels: one per first-Monday-of-month visible.
-    const monthLabels: string[] = [];
-    let lastMonth = '';
-    for (let i = 0; i < days.length; i += 1) {
-      const month = days[i].date.slice(0, 7);
-      if (month !== lastMonth) {
-        const idx = firstW + i;
-        const col = Math.floor(idx / 7);
-        const x = LEFT + col * (CELL + GAP);
-        const m = days[i].date.slice(5, 7);
-        const names = ['Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'];
-        monthLabels.push(`<text x="${x}" y="${TOP - 8}" class="mlbl">${names[parseInt(m, 10) - 1] ?? m}</text>`);
-        lastMonth = month;
-      }
-    }
-
-    // Side panel: stats + top authors.
-    const panelX = LEFT + columns * (CELL + GAP) + 24;
-    const noGit = heat.no_git
-      ? `<text x="${panelX}" y="${TOP + 16}" class="warn">Keine Git-Historie verfügbar.</text>`
-      : '';
-    const stats = !heat.no_git
-      ? `
-        <text x="${panelX}" y="${TOP}" class="panel-title">Übersicht</text>
-        <text x="${panelX}" y="${TOP + 22}" class="panel-line">Zeitraum: ${heat.start_date} – ${heat.end_date}</text>
-        <text x="${panelX}" y="${TOP + 40}" class="panel-line">Commits gesamt: ${heat.total_commits}</text>
-        <text x="${panelX}" y="${TOP + 58}" class="panel-line">Aktivste Tage: max. ${heat.max_commits_per_day}</text>
-        <text x="${panelX}" y="${TOP + 76}" class="panel-line">Längste Streak: ${heat.longest_streak_days} Tage</text>
-        <text x="${panelX}" y="${TOP + 94}" class="panel-line">Distincte Autoren: ${heat.distinct_authors}</text>
-        ${heat.truncated ? `<text x="${panelX}" y="${TOP + 112}" class="panel-warn">Walk bei ${heat.total_commits} Commits gestoppt.</text>` : ''}`
-      : '';
-    const authors = heat.top_authors
-      .map((a, i) => `<text x="${panelX}" y="${TOP + 140 + i * 16}" class="panel-line">${i + 1}. ${esc(a.name)} — ${a.commits}</text>`)
-      .join('');
-    const authorTitle = heat.top_authors.length > 0
-      ? `<text x="${panelX}" y="${TOP + 124}" class="panel-title">Top-Autoren</text>`
-      : '';
-
-    // Legend strip beneath the grid.
-    const legendY = TOP + 7 * (CELL + GAP) + 28;
-    const legend = ['#1f2937', '#0e3b27', '#1c6c45', '#2ea264', '#3fcf83', '#7ee787']
-      .map((c, i) => `<rect x="${LEFT + i * (CELL + GAP)}" y="${legendY}" width="${CELL}" height="${CELL}" rx="2" fill="${c}"/>`)
-      .join('');
-
-    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}">
-      <style>
-        text{fill:#dce3f0;font:13px ui-sans-serif,system-ui,sans-serif}
-        .title{font-size:20px;font-weight:600}
-        .subtitle{font-size:12px;fill:#94a3b8}
-        .wd{font-size:10px;font-family:ui-monospace,monospace;fill:#94a3b8}
-        .mlbl{font-size:10px;font-family:ui-monospace,monospace;fill:#94a3b8}
-        .panel-title{font-size:13px;font-weight:600;fill:#cbd5e1}
-        .panel-line{font-size:11px;font-family:ui-monospace,monospace;fill:#94a3b8}
-        .panel-warn{font-size:10px;font-family:ui-monospace,monospace;fill:#fbbf24}
-        .warn{font-size:13px;fill:#fbbf24}
-        .legend{font-size:10px;font-family:ui-monospace,monospace;fill:#94a3b8}
-      </style>
-      <rect width="100%" height="100%" fill="#090d14"/>
-      <text x="24" y="40" class="title">Commit-Aktivität</text>
-      <text x="24" y="60" class="subtitle">Letzte 12 Monate · ${heat.total_commits} Commits · ${heat.distinct_authors} Autoren</text>
-      ${monthLabels.join('')}
-      ${weekdayLabels}
-      ${cells}
-      <text x="${LEFT - 8}" y="${legendY + 11}" text-anchor="end" class="legend">weniger</text>
-      ${legend}
-      <text x="${LEFT + 6 * (CELL + GAP) + CELL + 8}" y="${legendY + 11}" class="legend">mehr</text>
-      ${noGit}
-      ${stats}
-      ${authorTitle}
-      ${authors}
-    </svg>`;
-  }
-
-  function formatBytes(n: number): string {
-    if (n < 1024) return `${n} B`;
-    if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`;
-    if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
-    return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`;
-  }
-
-  function esc(s: string): string {
-    return s.replace(/[&<>"']/g, (ch) => {
-      const map: Record<string, string> = {
-        '&': '&amp;',
-        '<': '&lt;',
-        '>': '&gt;',
-        '"': '&quot;',
-        "'": '&#39;',
-      };
-    return map[ch] ?? ch;
-    });
   }
 
   function onClick(e: MouseEvent) {
@@ -1631,12 +658,16 @@
   function applyBaseSize() {
     // Stamp the SVG at scale=1 once per render so it fills the stage; live
     // zoom then happens via `diagramTransform`. Safe to call multiple times
-    // — idempotent for a given baseW/baseH and current SVG node.
-    if (!stage || !baseW || !baseH) return;
+    // — idempotent for a given baseW/baseH and current SVG node. Reads the
+    // base size straight from the store (`get`) rather than the reactive
+    // `$:` locals, since this runs synchronously right after
+    // `viewport.setBaseSize()` — before Svelte flushes the reactive update.
+    const { baseW: bw, baseH: bh } = get(viewport);
+    if (!stage || !bw || !bh) return;
     const node = stage.querySelector('svg');
     if (!node) return;
-    node.setAttribute('width', String(baseW));
-    node.setAttribute('height', String(baseH));
+    node.setAttribute('width', String(bw));
+    node.setAttribute('height', String(bh));
   }
 
   function onWheel(e: WheelEvent) {
@@ -1655,13 +686,11 @@
     const cx = e.clientX - rect.left;
     const cy = e.clientY - rect.top;
     const factor = Math.exp(-delta * 0.0015);
-    const nextScale = Math.min(8, Math.max(0.2, scale * factor));
-    // Zoom toward cursor: keep the world-point under the cursor stable.
-    tx = cx - (cx - tx) * (nextScale / scale);
-    ty = cy - (cy - ty) * (nextScale / scale);
-    scale = nextScale;
-    // The `diagramTransform` reactive picks scale + tx + ty up in a single
+    // Zoom toward cursor: the store reducer keeps the world-point under the
+    // cursor stable and clamps scale to [MIN_SCALE, MAX_SCALE]. The
+    // `diagramTransform` reactive picks scale + tx + ty up in a single
     // transform string applied via inline style — no querySelector needed.
+    viewport.zoomAround(factor, cx, cy);
   }
 
   // Svelte's `on:wheel` registers a passive listener on browsers that
@@ -1697,8 +726,10 @@
 
   function onMouseMove(e: MouseEvent) {
     if (!dragging) return;
-    tx = dragStartTx + (e.clientX - dragStartX);
-    ty = dragStartTy + (e.clientY - dragStartY);
+    viewport.panTo(
+      dragStartTx + (e.clientX - dragStartX),
+      dragStartTy + (e.clientY - dragStartY),
+    );
   }
 
   function endDrag() {
@@ -1708,12 +739,8 @@
   function zoomBy(factor: number) {
     if (!stage) return;
     const rect = stage.getBoundingClientRect();
-    const cx = rect.width / 2;
-    const cy = rect.height / 2;
-    const nextScale = Math.min(8, Math.max(0.2, scale * factor));
-    tx = cx - (cx - tx) * (nextScale / scale);
-    ty = cy - (cy - ty) * (nextScale / scale);
-    scale = nextScale;
+    // Toolbar zoom anchors on the stage centre.
+    viewport.zoomAround(factor, rect.width / 2, rect.height / 2);
   }
 </script>
 

--- a/app/src/lib/diagrams/activityHeatmap.ts
+++ b/app/src/lib/diagrams/activityHeatmap.ts
@@ -1,0 +1,171 @@
+/// Activity-heatmap SVG renderer — extracted from `DiagramView.svelte`
+/// (Viz-Katalog V1.3, #61). GitHub-style 7×N calendar grid: one column per
+/// week, one row per weekday (Mo top). Cell colour ramps linearly with
+/// commits-per-day relative to the busiest day. A side panel lists totals +
+/// the top-10 authors. Pure.
+
+import { esc } from './common';
+
+export interface ActivityAuthorSlice {
+  name: string;
+  commits: number;
+}
+export interface ActivityDay {
+  date: string;
+  commits: number;
+  top_authors: ActivityAuthorSlice[];
+}
+export interface ActivityAuthorTotals {
+  name: string;
+  commits: number;
+}
+export interface ActivityHeatmap {
+  root: string;
+  start_date: string;
+  end_date: string;
+  days: ActivityDay[];
+  total_commits: number;
+  distinct_authors: number;
+  top_authors: ActivityAuthorTotals[];
+  max_commits_per_day: number;
+  longest_streak_days: number;
+  truncated: boolean;
+  no_git: boolean;
+}
+
+export function renderActivityHeatmap(heat: ActivityHeatmap): string {
+  const CELL = 13;
+  const GAP = 3;
+  const LEFT = 60;
+  const TOP = 90;
+  const PANEL = 240;
+
+  // Layout: bucket days into 7-row columns starting on the first
+  // ISO-Monday at or before the start_date.
+  const days = heat.days;
+  if (days.length === 0) {
+    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 360">
+        <rect width="100%" height="100%" fill="#090d14"/>
+        <text x="550" y="180" text-anchor="middle" fill="#94a3b8" font-size="18">Keine Aktivität verfügbar.</text>
+      </svg>`;
+  }
+
+  // weekday(0=Mo … 6=So) for each day, derived from the date string.
+  function weekdayMondayBased(iso: string): number {
+    const d = new Date(iso + 'T00:00:00Z');
+    const w = d.getUTCDay(); // 0=Sun..6=Sat
+    return (w + 6) % 7; // 0=Mon..6=Sun
+  }
+
+  const first = days[0];
+  const firstW = weekdayMondayBased(first.date);
+  // Number of leading empty cells in column 0.
+  const totalCells = firstW + days.length;
+  const columns = Math.ceil(totalCells / 7);
+  const W = LEFT + columns * (CELL + GAP) + 16 + PANEL + 24;
+  const H = TOP + 7 * (CELL + GAP) + 80;
+
+  const max = Math.max(1, heat.max_commits_per_day);
+  const ramp = (n: number): string => {
+    if (n === 0) return '#1f2937';
+    const t = Math.min(1, n / max);
+    // 5 buckets, dark → bright green
+    if (t < 0.2) return '#0e3b27';
+    if (t < 0.45) return '#1c6c45';
+    if (t < 0.7) return '#2ea264';
+    if (t < 0.9) return '#3fcf83';
+    return '#7ee787';
+  };
+
+  const cells = days
+    .map((d, i) => {
+      const idx = firstW + i;
+      const col = Math.floor(idx / 7);
+      const row = idx % 7;
+      const x = LEFT + col * (CELL + GAP);
+      const y = TOP + row * (CELL + GAP);
+      const top = d.top_authors
+        .map((a) => `${a.name} · ${a.commits}`)
+        .join('\n');
+      const tip = `${d.date} — ${d.commits} ${d.commits === 1 ? 'Commit' : 'Commits'}${top ? `\n${top}` : ''}`;
+      return `<rect x="${x}" y="${y}" width="${CELL}" height="${CELL}" rx="2" fill="${ramp(d.commits)}"><title>${esc(tip)}</title></rect>`;
+    })
+    .join('');
+
+  // Weekday labels (Mo, Mi, Fr).
+  const weekdayLabels = ['Mo', '', 'Mi', '', 'Fr', '', 'So']
+    .map((lbl, i) => `<text x="${LEFT - 8}" y="${TOP + i * (CELL + GAP) + 11}" text-anchor="end" class="wd">${lbl}</text>`)
+    .join('');
+
+  // Month labels: one per first-Monday-of-month visible.
+  const monthLabels: string[] = [];
+  let lastMonth = '';
+  for (let i = 0; i < days.length; i += 1) {
+    const month = days[i].date.slice(0, 7);
+    if (month !== lastMonth) {
+      const idx = firstW + i;
+      const col = Math.floor(idx / 7);
+      const x = LEFT + col * (CELL + GAP);
+      const m = days[i].date.slice(5, 7);
+      const names = ['Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'];
+      monthLabels.push(`<text x="${x}" y="${TOP - 8}" class="mlbl">${names[parseInt(m, 10) - 1] ?? m}</text>`);
+      lastMonth = month;
+    }
+  }
+
+  // Side panel: stats + top authors.
+  const panelX = LEFT + columns * (CELL + GAP) + 24;
+  const noGit = heat.no_git
+    ? `<text x="${panelX}" y="${TOP + 16}" class="warn">Keine Git-Historie verfügbar.</text>`
+    : '';
+  const stats = !heat.no_git
+    ? `
+        <text x="${panelX}" y="${TOP}" class="panel-title">Übersicht</text>
+        <text x="${panelX}" y="${TOP + 22}" class="panel-line">Zeitraum: ${heat.start_date} – ${heat.end_date}</text>
+        <text x="${panelX}" y="${TOP + 40}" class="panel-line">Commits gesamt: ${heat.total_commits}</text>
+        <text x="${panelX}" y="${TOP + 58}" class="panel-line">Aktivste Tage: max. ${heat.max_commits_per_day}</text>
+        <text x="${panelX}" y="${TOP + 76}" class="panel-line">Längste Streak: ${heat.longest_streak_days} Tage</text>
+        <text x="${panelX}" y="${TOP + 94}" class="panel-line">Distincte Autoren: ${heat.distinct_authors}</text>
+        ${heat.truncated ? `<text x="${panelX}" y="${TOP + 112}" class="panel-warn">Walk bei ${heat.total_commits} Commits gestoppt.</text>` : ''}`
+    : '';
+  const authors = heat.top_authors
+    .map((a, i) => `<text x="${panelX}" y="${TOP + 140 + i * 16}" class="panel-line">${i + 1}. ${esc(a.name)} — ${a.commits}</text>`)
+    .join('');
+  const authorTitle = heat.top_authors.length > 0
+    ? `<text x="${panelX}" y="${TOP + 124}" class="panel-title">Top-Autoren</text>`
+    : '';
+
+  // Legend strip beneath the grid.
+  const legendY = TOP + 7 * (CELL + GAP) + 28;
+  const legend = ['#1f2937', '#0e3b27', '#1c6c45', '#2ea264', '#3fcf83', '#7ee787']
+    .map((c, i) => `<rect x="${LEFT + i * (CELL + GAP)}" y="${legendY}" width="${CELL}" height="${CELL}" rx="2" fill="${c}"/>`)
+    .join('');
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}">
+      <style>
+        text{fill:#dce3f0;font:13px ui-sans-serif,system-ui,sans-serif}
+        .title{font-size:20px;font-weight:600}
+        .subtitle{font-size:12px;fill:#94a3b8}
+        .wd{font-size:10px;font-family:ui-monospace,monospace;fill:#94a3b8}
+        .mlbl{font-size:10px;font-family:ui-monospace,monospace;fill:#94a3b8}
+        .panel-title{font-size:13px;font-weight:600;fill:#cbd5e1}
+        .panel-line{font-size:11px;font-family:ui-monospace,monospace;fill:#94a3b8}
+        .panel-warn{font-size:10px;font-family:ui-monospace,monospace;fill:#fbbf24}
+        .warn{font-size:13px;fill:#fbbf24}
+        .legend{font-size:10px;font-family:ui-monospace,monospace;fill:#94a3b8}
+      </style>
+      <rect width="100%" height="100%" fill="#090d14"/>
+      <text x="24" y="40" class="title">Commit-Aktivität</text>
+      <text x="24" y="60" class="subtitle">Letzte 12 Monate · ${heat.total_commits} Commits · ${heat.distinct_authors} Autoren</text>
+      ${monthLabels.join('')}
+      ${weekdayLabels}
+      ${cells}
+      <text x="${LEFT - 8}" y="${legendY + 11}" text-anchor="end" class="legend">weniger</text>
+      ${legend}
+      <text x="${LEFT + 6 * (CELL + GAP) + CELL + 8}" y="${legendY + 11}" class="legend">mehr</text>
+      ${noGit}
+      ${stats}
+      ${authorTitle}
+      ${authors}
+    </svg>`;
+}

--- a/app/src/lib/diagrams/architectureFlow.ts
+++ b/app/src/lib/diagrams/architectureFlow.ts
@@ -1,0 +1,151 @@
+/// Architecture-flow SVG renderer — extracted from `DiagramView.svelte`
+/// (Viz-Katalog V1.3, #61). Horizontal layer bands stacked top→bottom; each
+/// band shows its name, class chips coloured by stereotype, a stereotype
+/// histogram and a class count. Aggregated cross-layer edges become
+/// inter-band arrows whose stroke width encodes the relation count. Pure.
+
+import { esc } from './common';
+
+export interface FlowClass {
+  fqn: string;
+  name: string;
+  module: string;
+  stereotype: string | null;
+}
+export interface FlowLayer {
+  id: string;
+  label: string;
+  description: string;
+  color: string;
+  classes: FlowClass[];
+  stereotypes: Record<string, number>;
+}
+export interface FlowEdge {
+  from: string;
+  to: string;
+  count: number;
+}
+export interface ArchitectureFlow {
+  root: string;
+  total_classes: number;
+  total_modules: number;
+  cross_module_edges: number;
+  layers: FlowLayer[];
+  edges: FlowEdge[];
+}
+
+export function renderArchitectureFlow(flow: ArchitectureFlow): string {
+  const W = 1100;
+  const PAD_X = 40;
+  const PAD_TOP = 80;
+  const PAD_BETWEEN = 20;
+  const BAND_H = 150;
+  const CHIP_H = 26;
+  const CHIP_W = 132;
+  const CHIPS_PER_ROW = Math.max(1, Math.floor((W - 2 * PAD_X - 16) / (CHIP_W + 8)));
+
+  if (flow.total_classes === 0) {
+    const H = 320;
+    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}">
+        <rect width="100%" height="100%" fill="#090d14"/>
+        <text x="${W / 2}" y="${H / 2}" text-anchor="middle" fill="#94a3b8" font-size="18" font-family="ui-sans-serif,system-ui">Keine Klassen erkannt — Architektur-Schichten benötigen geparsten Code.</text>
+      </svg>`;
+  }
+
+  type Band = { layer: FlowLayer; y: number; h: number; rows: number };
+  const bands: Band[] = [];
+  let cursor = PAD_TOP;
+  for (const layer of flow.layers) {
+    const rows = layer.classes.length === 0 ? 1 : Math.ceil(layer.classes.length / CHIPS_PER_ROW);
+    const h = Math.max(BAND_H, 56 + rows * (CHIP_H + 8));
+    bands.push({ layer, y: cursor, h, rows });
+    cursor += h + PAD_BETWEEN;
+  }
+  const H = cursor + 40;
+
+  const bandSvg = bands
+    .map(({ layer, y, h }) => {
+      const total = layer.classes.length;
+      const stripe = `<rect x="${PAD_X}" y="${y}" width="${W - 2 * PAD_X}" height="${h}" rx="14" ry="14" fill="${layer.color}" fill-opacity="0.08" stroke="${layer.color}" stroke-width="1.4"/>`;
+      const accent = `<rect x="${PAD_X}" y="${y}" width="6" height="${h}" rx="3" fill="${layer.color}"/>`;
+      const head = `
+          <text x="${PAD_X + 22}" y="${y + 28}" class="band-title" fill="${layer.color}">${esc(layer.label)}</text>
+          <text x="${PAD_X + 22}" y="${y + 48}" class="band-desc">${esc(layer.description)}</text>
+          <text x="${W - PAD_X - 16}" y="${y + 28}" text-anchor="end" class="band-count" fill="${layer.color}">${total} ${total === 1 ? 'Klasse' : 'Klassen'}</text>`;
+
+      const stereoEntries = Object.entries(layer.stereotypes).sort((a, b) => b[1] - a[1]);
+      const stereoBadges = stereoEntries
+        .slice(0, 4)
+        .map(([s, n], i) => {
+          const bx = W - PAD_X - 16 - (stereoEntries.length > 4 ? 110 : 0) - i * 86;
+          return `<g><rect x="${bx - 78}" y="${y + 36}" width="78" height="18" rx="9" fill="${layer.color}" fill-opacity="0.18" stroke="${layer.color}" stroke-opacity="0.5"/><text x="${bx - 39}" y="${y + 49}" text-anchor="middle" class="stereo">${esc(s)} · ${n}</text></g>`;
+        })
+        .join('');
+
+      const chips = layer.classes
+        .map((c, i) => {
+          const col = i % CHIPS_PER_ROW;
+          const row = Math.floor(i / CHIPS_PER_ROW);
+          const cx = PAD_X + 22 + col * (CHIP_W + 8);
+          const cy = y + 60 + row * (CHIP_H + 8);
+          const label = shortChipLabel(c.name);
+          return `<g class="chip"><rect x="${cx}" y="${cy}" width="${CHIP_W}" height="${CHIP_H}" rx="6" fill="${layer.color}" fill-opacity="0.18" stroke="${layer.color}" stroke-opacity="0.55"/><text x="${cx + 10}" y="${cy + 17}" class="chip-text">${esc(label)}</text><title>${esc(c.fqn)}\n${esc(c.module)}${c.stereotype ? `\n@${esc(c.stereotype)}` : ''}</title></g>`;
+        })
+        .join('');
+
+      const empty =
+        total === 0
+          ? `<text x="${PAD_X + 22}" y="${y + 80}" class="empty">— keine Klassen in dieser Schicht —</text>`
+          : '';
+
+      return `${stripe}${accent}${head}${stereoBadges}${chips}${empty}`;
+    })
+    .join('');
+
+  // Edges between bands. Stroke width scales with count, capped at 8px.
+  const layerY = new Map(bands.map((b) => [b.layer.id, b.y + b.h / 2]));
+  const layerColor = new Map(bands.map((b) => [b.layer.id, b.layer.color]));
+  const maxEdge = Math.max(1, ...flow.edges.map((e) => e.count));
+  const xCenter = W / 2;
+  const edgeSvg = flow.edges
+    .map((edge, i) => {
+      const yFrom = layerY.get(edge.from);
+      const yTo = layerY.get(edge.to);
+      if (yFrom === undefined || yTo === undefined) return '';
+      const width = Math.max(1.4, Math.min(8, (edge.count / maxEdge) * 7 + 1.4));
+      // Curve sideways so multiple edges don't overlap.
+      const offset = (i - flow.edges.length / 2) * 26;
+      const xMid = xCenter + offset;
+      const midY = (yFrom + yTo) / 2;
+      const arrow = yFrom < yTo ? '▼' : '▲';
+      const color = layerColor.get(edge.from) ?? '#9ca3af';
+      const path = `M ${xCenter} ${yFrom} C ${xMid} ${(yFrom + midY) / 2}, ${xMid} ${(midY + yTo) / 2}, ${xCenter} ${yTo}`;
+      return `<g class="edge"><path d="${path}" stroke="${color}" stroke-width="${width}" stroke-opacity="0.55" fill="none"/><text x="${xMid}" y="${midY + 4}" text-anchor="middle" class="edge-label">${arrow} ${edge.count}</text></g>`;
+    })
+    .join('');
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}">
+      <style>
+        text{fill:#dce3f0;font:13px ui-sans-serif,system-ui,sans-serif}
+        .title{font-size:20px;font-weight:600}
+        .subtitle{font-size:12px;fill:#94a3b8}
+        .band-title{font-size:16px;font-weight:700}
+        .band-desc{font-size:12px;fill:#94a3b8}
+        .band-count{font-size:12px;font-weight:600}
+        .stereo{font-size:10px;font-family:ui-monospace,monospace;fill:#cbd5e1}
+        .chip{cursor:default}
+        .chip-text{font-size:11px;font-family:ui-monospace,monospace}
+        .empty{font-size:12px;fill:#64748b;font-style:italic}
+        .edge-label{font-size:10px;fill:#cbd5e1;font-family:ui-monospace,monospace}
+      </style>
+      <rect width="100%" height="100%" fill="#090d14"/>
+      <text x="${PAD_X}" y="40" class="title">Architektur-Schichten</text>
+      <text x="${PAD_X}" y="60" class="subtitle">${flow.total_classes} Klassen · ${flow.total_modules} Module · ${flow.cross_module_edges} Cross-Module-Edges</text>
+      ${edgeSvg}
+      ${bandSvg}
+    </svg>`;
+}
+
+function shortChipLabel(name: string): string {
+  return name.length <= 16 ? name : `${name.slice(0, 15)}…`;
+}

--- a/app/src/lib/diagrams/charts.test.ts
+++ b/app/src/lib/diagrams/charts.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+import { esc, formatBytes, shortLabel } from './common';
+import { renderLanguageStats, type LanguageStats } from './languageStats';
+import { renderModuleChord, type ModuleChord } from './moduleChord';
+import { renderArchitectureFlow, type ArchitectureFlow } from './architectureFlow';
+import { renderActivityHeatmap, type ActivityHeatmap } from './activityHeatmap';
+
+describe('common helpers', () => {
+  it('esc escapes the five XML-significant characters', () => {
+    expect(esc(`<a href="x" data='y'>&`)).toBe(
+      '&lt;a href=&quot;x&quot; data=&#39;y&#39;&gt;&amp;',
+    );
+  });
+
+  it('formatBytes scales B / KB / MB / GB', () => {
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(2048)).toBe('2 KB');
+    expect(formatBytes(5 * 1024 * 1024)).toBe('5.0 MB');
+    expect(formatBytes(3 * 1024 * 1024 * 1024)).toBe('3.00 GB');
+  });
+
+  it('shortLabel truncates with an ellipsis past the limit', () => {
+    expect(shortLabel('short', 10)).toBe('short');
+    expect(shortLabel('abcdefghij', 5)).toBe('abcd…');
+  });
+});
+
+describe('renderLanguageStats', () => {
+  const stats: LanguageStats = {
+    root: '.',
+    total_files: 4,
+    total_bytes: 4096,
+    truncated: false,
+    buckets: [
+      { language: 'TypeScript', extension: 'ts', files: 3, bytes: 3072 },
+      { language: 'Rust', extension: 'rs', files: 1, bytes: 1024 },
+    ],
+  };
+
+  it('placeholders when there are no buckets', () => {
+    expect(renderLanguageStats({ ...stats, buckets: [] })).toContain('No files found');
+  });
+
+  it('renders one bar row per bucket with correct percentages', () => {
+    const svg = renderLanguageStats(stats);
+    expect((svg.match(/class="row"/g) ?? []).length).toBe(2);
+    // 3 of 4 files = 75.0%, 1 of 4 = 25.0%.
+    expect(svg).toContain('3 · 75.0%');
+    expect(svg).toContain('1 · 25.0%');
+  });
+
+  it('the longest bucket bar is widest (proportional to file count)', () => {
+    const svg = renderLanguageStats(stats);
+    const widths = [...svg.matchAll(/<rect x="212" y="\d+" width="(\d+)"/g)].map((m) =>
+      Number(m[1]),
+    );
+    expect(widths).toHaveLength(2);
+    expect(widths[0]).toBeGreaterThan(widths[1]);
+  });
+});
+
+describe('renderModuleChord', () => {
+  it('placeholders when there are no modules', () => {
+    const empty: ModuleChord = { root: '.', modules: [], edges: [], total_relations: 0 };
+    expect(renderModuleChord(empty)).toContain('Keine Module erkannt');
+  });
+
+  it('draws one rim arc per module and one chord per edge', () => {
+    const chord: ModuleChord = {
+      root: '.',
+      modules: [
+        { id: 'core', label: 'core', classes: 10, outgoing: 2, incoming: 1, internal: 5 },
+        { id: 'api', label: 'api', classes: 4, outgoing: 1, incoming: 2, internal: 1 },
+      ],
+      edges: [{ from: 'core', to: 'api', count: 3 }],
+      total_relations: 6,
+    };
+    const svg = renderModuleChord(chord);
+    expect((svg.match(/class="rim"/g) ?? []).length).toBe(2);
+    expect(svg).toContain('core → api: 3');
+  });
+});
+
+describe('renderArchitectureFlow', () => {
+  it('placeholders when no classes were parsed', () => {
+    const empty: ArchitectureFlow = {
+      root: '.',
+      total_classes: 0,
+      total_modules: 0,
+      cross_module_edges: 0,
+      layers: [],
+      edges: [],
+    };
+    expect(renderArchitectureFlow(empty)).toContain('Keine Klassen erkannt');
+  });
+
+  it('renders a chip per class and escapes fqns in tooltips', () => {
+    const flow: ArchitectureFlow = {
+      root: '.',
+      total_classes: 1,
+      total_modules: 1,
+      cross_module_edges: 0,
+      layers: [
+        {
+          id: 'web',
+          label: 'Web',
+          description: 'controllers',
+          color: '#3b82f6',
+          classes: [{ fqn: 'com.x.A<B>', name: 'A', module: 'm', stereotype: 'Controller' }],
+          stereotypes: { Controller: 1 },
+        },
+      ],
+      edges: [],
+    };
+    const svg = renderArchitectureFlow(flow);
+    expect((svg.match(/class="chip"/g) ?? []).length).toBe(1);
+    expect(svg).toContain('com.x.A&lt;B&gt;');
+  });
+});
+
+describe('renderActivityHeatmap', () => {
+  it('placeholders when there are no days', () => {
+    const empty: ActivityHeatmap = {
+      root: '.',
+      start_date: '2024-01-01',
+      end_date: '2024-01-01',
+      days: [],
+      total_commits: 0,
+      distinct_authors: 0,
+      top_authors: [],
+      max_commits_per_day: 0,
+      longest_streak_days: 0,
+      truncated: false,
+      no_git: false,
+    };
+    expect(renderActivityHeatmap(empty)).toContain('Keine Aktivität verfügbar');
+  });
+
+  it('renders one cell per day and lists the top authors', () => {
+    const heat: ActivityHeatmap = {
+      root: '.',
+      start_date: '2024-01-01',
+      end_date: '2024-01-03',
+      days: [
+        { date: '2024-01-01', commits: 0, top_authors: [] },
+        { date: '2024-01-02', commits: 5, top_authors: [{ name: 'Ada', commits: 5 }] },
+        { date: '2024-01-03', commits: 2, top_authors: [{ name: 'Ada', commits: 2 }] },
+      ],
+      total_commits: 7,
+      distinct_authors: 1,
+      top_authors: [{ name: 'Ada', commits: 7 }],
+      max_commits_per_day: 5,
+      longest_streak_days: 2,
+      truncated: false,
+      no_git: false,
+    };
+    const svg = renderActivityHeatmap(heat);
+    // 3 day cells + 6 legend swatches = 9 rounded rects with rx="2".
+    expect((svg.match(/rx="2"/g) ?? []).length).toBe(3 + 6);
+    expect(svg).toContain('1. Ada — 7');
+  });
+
+  it('shows the no-git warning instead of stats', () => {
+    const heat: ActivityHeatmap = {
+      root: '.',
+      start_date: '2024-01-01',
+      end_date: '2024-01-01',
+      days: [{ date: '2024-01-01', commits: 0, top_authors: [] }],
+      total_commits: 0,
+      distinct_authors: 0,
+      top_authors: [],
+      max_commits_per_day: 0,
+      longest_streak_days: 0,
+      truncated: false,
+      no_git: true,
+    };
+    const svg = renderActivityHeatmap(heat);
+    expect(svg).toContain('Keine Git-Historie verfügbar');
+    expect(svg).not.toContain('Übersicht');
+  });
+});

--- a/app/src/lib/diagrams/common.ts
+++ b/app/src/lib/diagrams/common.ts
@@ -1,0 +1,39 @@
+/// Shared, dependency-free building blocks for the hand-rolled SVG diagram
+/// renderers extracted out of `DiagramView.svelte` (Viz-Katalog V1.3, #61).
+///
+/// Every renderer under `app/src/lib/diagrams/<kind>.ts` is a pure function
+/// `render(payload, opts): string` that returns an SVG string — no DOM, no
+/// Svelte, so the layout maths can be unit-tested in isolation the way
+/// `treemap.ts` already is. This module holds the primitives those renderers
+/// share (HTML escaping, byte formatting, label truncation).
+
+/// Escape the five XML-significant characters so untrusted repo strings
+/// (file names, author names, class fqns) are safe to inline into an SVG
+/// string. Kept byte-for-byte identical to the previous in-component `esc`
+/// so the extraction stays behaviour-preserving.
+export function esc(s: string): string {
+  return s.replace(/[&<>"']/g, (ch) => {
+    const map: Record<string, string> = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;',
+    };
+    return map[ch] ?? ch;
+  });
+}
+
+/// Human-readable byte size (B / KB / MB / GB). Used by the language-stats
+/// renderer for the per-bucket + total size read-outs.
+export function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+/// Truncate a label to `max` characters, appending an ellipsis when clipped.
+export function shortLabel(label: string, max: number): string {
+  return label.length <= max ? label : `${label.slice(0, max - 1)}…`;
+}

--- a/app/src/lib/diagrams/docGraph.test.ts
+++ b/app/src/lib/diagrams/docGraph.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import {
+  docNodeRadius,
+  placeDocNetwork,
+  placeDocOrphans,
+  placeDocRadial,
+  renderDocGraph,
+  type DocGraph,
+  type DocNode,
+} from './docGraph';
+
+function docNode(
+  id: string,
+  rel: string,
+  opts: Partial<DocNode> = {},
+): DocNode {
+  return {
+    id,
+    abs: `/abs/${rel}`,
+    rel,
+    title: rel,
+    inbound: 0,
+    outbound: 0,
+    external: 0,
+    orphan: false,
+    ...opts,
+  };
+}
+
+function graph(nodes: DocNode[], edges: DocGraph['edges'] = []): DocGraph {
+  return {
+    root: '.',
+    nodes,
+    edges,
+    dangling: [],
+    orphan_count: nodes.filter((n) => n.orphan).length,
+    dangling_count: 0,
+    external_count: 0,
+  };
+}
+
+describe('renderDocGraph', () => {
+  it('renders a placeholder when there are no docs', () => {
+    const svg = renderDocGraph(graph([]), 'network');
+    expect(svg).toContain('No markdown documents found');
+  });
+
+  it('emits one node group per doc and honours the selected id', () => {
+    const g = graph([docNode('a', 'a.md'), docNode('b', 'b.md')]);
+    const svg = renderDocGraph(g, 'network', 'b');
+    expect((svg.match(/class="node doc-node/g) ?? []).length).toBe(2);
+    // The selected node picks up the `selected` class.
+    expect(svg).toContain('doc-node selected');
+  });
+
+  it('marks orphan nodes with the orphan class', () => {
+    const g = graph([docNode('o', 'orphan.md', { orphan: true })]);
+    expect(renderDocGraph(g, 'network')).toContain('doc-node orphan');
+  });
+});
+
+describe('doc-graph placement', () => {
+  it('network layout puts the highest-degree node at the centre (700,450)', () => {
+    const g = graph([
+      docNode('hub', 'hub.md', { inbound: 5, outbound: 5 }),
+      docNode('leaf', 'leaf.md', { inbound: 1 }),
+    ]);
+    const placed = placeDocNetwork(g);
+    expect(placed.get('hub')).toMatchObject({ x: 700, y: 450 });
+  });
+
+  it('radial layout centres the README', () => {
+    const g = graph([
+      docNode('readme', 'README.md', { outbound: 1 }),
+      docNode('other', 'other.md'),
+    ]);
+    const placed = placeDocRadial(g);
+    expect(placed.get('readme')).toMatchObject({ x: 700, y: 450 });
+  });
+
+  it('orphans layout splits into orphan (left) and connected (right) columns', () => {
+    const g = graph([
+      docNode('orph', 'orph.md', { orphan: true }),
+      docNode('conn', 'conn.md', { inbound: 2 }),
+    ]);
+    const placed = placeDocOrphans(g);
+    expect(placed.get('orph')!.x).toBe(360);
+    expect(placed.get('conn')!.x).toBe(980);
+  });
+});
+
+describe('docNodeRadius', () => {
+  it('grows with degree and caps at 46', () => {
+    expect(docNodeRadius(docNode('a', 'a.md'))).toBeGreaterThan(0);
+    const huge = docNodeRadius(
+      docNode('a', 'a.md', { inbound: 1000, outbound: 1000, external: 1000 }),
+    );
+    expect(huge).toBe(46);
+  });
+});

--- a/app/src/lib/diagrams/docGraph.ts
+++ b/app/src/lib/diagrams/docGraph.ts
@@ -1,0 +1,219 @@
+/// Documentation-graph SVG renderer — extracted from `DiagramView.svelte`
+/// (Viz-Katalog V1.3, #61). Three placement strategies (network / radial /
+/// orphans) feed a single SVG emitter. Pure apart from the `selectedDocId`
+/// highlight, which the component passes in.
+
+import { esc, shortLabel } from './common';
+
+export interface DocNode {
+  id: string;
+  abs: string;
+  rel: string;
+  title: string;
+  inbound: number;
+  outbound: number;
+  external: number;
+  orphan: boolean;
+}
+
+export interface DocEdge {
+  from: string;
+  to: string;
+  label: string;
+  href: string;
+}
+
+export interface DanglingDocLink {
+  from: string;
+  label: string;
+  href: string;
+  resolved: string;
+}
+
+export interface DocGraph {
+  root: string;
+  nodes: DocNode[];
+  edges: DocEdge[];
+  dangling: DanglingDocLink[];
+  orphan_count: number;
+  dangling_count: number;
+  external_count: number;
+}
+
+export type DocGraphLayout = 'network' | 'radial' | 'orphans';
+
+export function renderDocGraph(
+  graph: DocGraph,
+  layout: DocGraphLayout,
+  selectedDocId: string | null = null,
+): string {
+  if (graph.nodes.length === 0) return emptyDocGraphSvg();
+  const placed = placeDocNodes(graph, layout);
+  const width = 1400;
+  const height = 900;
+  const defs = `<defs>
+      <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b"/>
+      </marker>
+    </defs>`;
+  const edges = graph.edges
+    .map((e) => {
+      const from = placed.get(e.from);
+      const to = placed.get(e.to);
+      if (!from || !to) return '';
+      const dx = to.x - from.x;
+      const dy = to.y - from.y;
+      const len = Math.max(1, Math.sqrt(dx * dx + dy * dy));
+      const fromR = docNodeRadius(from.node) + 4;
+      const toR = docNodeRadius(to.node) + 10;
+      const x1 = from.x + (dx / len) * fromR;
+      const y1 = from.y + (dy / len) * fromR;
+      const x2 = to.x - (dx / len) * toR;
+      const y2 = to.y - (dy / len) * toR;
+      const curve = Math.min(80, Math.max(-80, (from.node.rel.localeCompare(to.node.rel) - 0.5) * 80));
+      const mx = (x1 + x2) / 2 - (dy / len) * curve;
+      const my = (y1 + y2) / 2 + (dx / len) * curve;
+      return `<path class="doc-edge" d="M${x1} ${y1} Q${mx} ${my} ${x2} ${y2}">
+          <title>${esc(e.from)} → ${esc(e.to)} (${esc(e.label)})</title>
+        </path>`;
+    })
+    .join('');
+  const nodes = [...placed.values()]
+    .map(({ node, x, y }) => {
+      const r = docNodeRadius(node);
+      const classes = ['node', 'doc-node'];
+      if (node.orphan) classes.push('orphan');
+      if (node.id === selectedDocId) classes.push('selected');
+      const subtitle = `${node.inbound} in · ${node.outbound} out · ${node.external} external`;
+      return `<g class="${classes.join(' ')}" data-id="${esc(node.id)}" transform="translate(${x} ${y})">
+          <circle r="${r}"/>
+          <text y="${r + 18}" text-anchor="middle">${esc(shortLabel(node.title || node.rel, 22))}</text>
+          <text y="${r + 33}" class="meta" text-anchor="middle">${esc(shortLabel(node.rel, 26))}</text>
+          <title>${esc(node.rel)}\n${esc(subtitle)}</title>
+        </g>`;
+    })
+    .join('');
+  const stats = `<g class="doc-stats" transform="translate(24 30)">
+      <text>docs ${graph.nodes.length}</text>
+      <text y="18">links ${graph.edges.length}</text>
+      <text y="36">orphans ${graph.orphan_count}</text>
+      <text y="54">dangling ${graph.dangling_count}</text>
+      <text y="72">external ${graph.external_count}</text>
+    </g>`;
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}">
+      ${defs}
+      <style>
+        .doc-edge{stroke:#64748b;stroke-width:1.6;fill:none;opacity:.58;marker-end:url(#arrow)}
+        .doc-node{cursor:pointer}
+        .doc-node circle{fill:#1f2937;stroke:#38bdf8;stroke-width:2;filter:drop-shadow(0 10px 18px rgba(0,0,0,.35))}
+        .doc-node.orphan circle{stroke:#f59e0b;stroke-dasharray:5 4}
+        .doc-node.selected circle{fill:#0f766e;stroke:#5eead4;stroke-width:4}
+        text{fill:#e5edf8;font:13px ui-sans-serif,system-ui,sans-serif;paint-order:stroke;stroke:#090d14;stroke-width:3px;stroke-linejoin:round}
+        .meta{fill:#9aa8ba;font-size:11px}
+        .doc-stats text{fill:#cbd5e1;font:12px ui-monospace,SFMono-Regular,Menlo,monospace;stroke:none}
+      </style>
+      <rect width="100%" height="100%" fill="#090d14"/>
+      ${edges}
+      ${nodes}
+      ${stats}
+    </svg>`;
+}
+
+export function placeDocNodes(
+  graph: DocGraph,
+  layout: DocGraphLayout,
+): Map<string, { node: DocNode; x: number; y: number }> {
+  if (layout === 'orphans') return placeDocOrphans(graph);
+  if (layout === 'radial') return placeDocRadial(graph);
+  return placeDocNetwork(graph);
+}
+
+export function placeDocNetwork(
+  graph: DocGraph,
+): Map<string, { node: DocNode; x: number; y: number }> {
+  const out = new Map<string, { node: DocNode; x: number; y: number }>();
+  const nodes = [...graph.nodes].sort(
+    (a, b) => b.inbound + b.outbound - (a.inbound + a.outbound) || a.rel.localeCompare(b.rel),
+  );
+  const cx = 700;
+  const cy = 450;
+  nodes.forEach((node, i) => {
+    if (i === 0) {
+      out.set(node.id, { node, x: cx, y: cy });
+      return;
+    }
+    const ring = Math.floor(Math.sqrt(i));
+    const inRingStart = ring * ring;
+    const inRingCount = Math.max(1, (ring + 1) * (ring + 1) - inRingStart);
+    const pos = i - inRingStart;
+    const angle = -Math.PI / 2 + (pos / inRingCount) * Math.PI * 2;
+    const radius = 120 + ring * 105;
+    out.set(node.id, {
+      node,
+      x: cx + Math.cos(angle) * radius,
+      y: cy + Math.sin(angle) * radius,
+    });
+  });
+  return out;
+}
+
+export function placeDocRadial(
+  graph: DocGraph,
+): Map<string, { node: DocNode; x: number; y: number }> {
+  const out = new Map<string, { node: DocNode; x: number; y: number }>();
+  const root =
+    graph.nodes.find((n) => /^readme\.md$/i.test(n.rel)) ??
+    [...graph.nodes].sort((a, b) => b.outbound + b.inbound - (a.outbound + a.inbound))[0];
+  out.set(root.id, { node: root, x: 700, y: 450 });
+  const linked = new Set(graph.edges.filter((e) => e.from === root.id).map((e) => e.to));
+  const rings = [
+    graph.nodes.filter((n) => linked.has(n.id)),
+    graph.nodes.filter((n) => n.id !== root.id && !linked.has(n.id) && !n.orphan),
+    graph.nodes.filter((n) => n.id !== root.id && n.orphan),
+  ];
+  rings.forEach((ringNodes, ringIdx) => {
+    const radius = 150 + ringIdx * 180;
+    ringNodes
+      .sort((a, b) => a.rel.localeCompare(b.rel))
+      .forEach((node, i) => {
+        const angle = -Math.PI / 2 + (i / Math.max(1, ringNodes.length)) * Math.PI * 2;
+        out.set(node.id, {
+          node,
+          x: 700 + Math.cos(angle) * radius,
+          y: 450 + Math.sin(angle) * radius,
+        });
+      });
+  });
+  return out;
+}
+
+export function placeDocOrphans(
+  graph: DocGraph,
+): Map<string, { node: DocNode; x: number; y: number }> {
+  const out = new Map<string, { node: DocNode; x: number; y: number }>();
+  const columns = [
+    graph.nodes.filter((n) => n.orphan).sort((a, b) => a.rel.localeCompare(b.rel)),
+    graph.nodes
+      .filter((n) => !n.orphan)
+      .sort((a, b) => b.inbound - a.inbound || a.rel.localeCompare(b.rel)),
+  ];
+  columns.forEach((nodes, col) => {
+    const x = col === 0 ? 360 : 980;
+    const gap = Math.min(92, Math.max(44, 780 / Math.max(1, nodes.length)));
+    nodes.forEach((node, i) => {
+      out.set(node.id, { node, x, y: 80 + i * gap });
+    });
+  });
+  return out;
+}
+
+export function docNodeRadius(n: DocNode): number {
+  return Math.min(46, 16 + Math.sqrt(n.inbound + n.outbound + n.external + 1) * 5);
+}
+
+function emptyDocGraphSvg(): string {
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 520">
+      <rect width="100%" height="100%" fill="#090d14"/>
+      <text x="450" y="260" text-anchor="middle" fill="#94a3b8" font-size="18" font-family="ui-sans-serif,system-ui">No markdown documents found</text>
+    </svg>`;
+}

--- a/app/src/lib/diagrams/folderMap.test.ts
+++ b/app/src/lib/diagrams/folderMap.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import {
+  groupByParent,
+  nodeRadius,
+  renderFolderHierarchy,
+  renderFolderMap,
+  renderFolderSolar,
+  renderFolderTopDown,
+  type FolderMap,
+  type FolderMapNode,
+} from './folderMap';
+
+function node(
+  id: string,
+  parent: string | null,
+  kind: FolderMapNode['kind'],
+  depth: number,
+  weight = 1,
+  label = id,
+): FolderMapNode {
+  return { id, parent, label, path: id, kind, depth, weight };
+}
+
+/// Tiny tree:  .  →  src(folder) → a.ts, b.ts   and  test(folder) → t.ts
+function fixture(): FolderMap {
+  return {
+    root: '.',
+    max_depth: 2,
+    truncated: false,
+    nodes: [
+      node('.', null, 'root', 0, 3, 'repo'),
+      node('src', '.', 'folder', 1, 2),
+      node('test', '.', 'folder', 1, 1),
+      node('src/a.ts', 'src', 'file', 2, 1, 'a.ts'),
+      node('src/b.ts', 'src', 'file', 2, 1, 'b.ts'),
+      node('test/t.ts', 'test', 'file', 2, 1, 't.ts'),
+    ],
+  };
+}
+
+describe('groupByParent', () => {
+  it('buckets children by parent and sorts folders before files', () => {
+    const g = groupByParent(fixture().nodes);
+    expect(g.get('.')!.map((n) => n.id)).toEqual(['src', 'test']);
+    // src's children are both files, sorted by label.
+    expect(g.get('src')!.map((n) => n.id)).toEqual(['src/a.ts', 'src/b.ts']);
+    // Root node itself has no parent → never a key.
+    expect(g.has('')).toBe(false);
+  });
+});
+
+describe('nodeRadius', () => {
+  it('files are small and capped at 13; folders/roots grow with weight', () => {
+    expect(nodeRadius(node('f', '.', 'file', 2, 1))).toBeLessThanOrEqual(13);
+    expect(nodeRadius(node('f', '.', 'file', 2, 9999))).toBe(13); // clamp
+    const root = nodeRadius(node('.', null, 'root', 0, 4));
+    const folder = nodeRadius(node('d', '.', 'folder', 1, 1));
+    expect(root).toBeGreaterThan(folder);
+  });
+});
+
+describe('renderFolderMap dispatch', () => {
+  it('routes each layout to its renderer (all produce an <svg>)', () => {
+    const m = fixture();
+    for (const layout of ['solar', 'hierarchy', 'td'] as const) {
+      const svg = renderFolderMap(m, layout);
+      expect(svg.startsWith('<svg')).toBe(true);
+      // One <g class="node …"> per node.
+      expect((svg.match(/class="node /g) ?? []).length).toBe(m.nodes.length);
+    }
+  });
+
+  it('solar layout places the root at the canvas centre (700,450)', () => {
+    const svg = renderFolderSolar(fixture());
+    // root group carries data-path="." and a translate to the centre.
+    expect(svg).toContain('data-path="." data-kind="root" transform="translate(700 450)"');
+  });
+
+  it('hierarchy + top-down layouts emit edges for every non-root node', () => {
+    const m = fixture();
+    const edgesInHierarchy = (renderFolderHierarchy(m).match(/class="edge"/g) ?? []).length;
+    const edgesInTd = (renderFolderTopDown(m).match(/class="edge"/g) ?? []).length;
+    // 5 non-root nodes → 5 parent→child edges.
+    expect(edgesInHierarchy).toBe(5);
+    expect(edgesInTd).toBe(5);
+  });
+});
+
+describe('fillFor pass-through', () => {
+  it('applies an inline fill + mixed stroke when the resolver returns a colour', () => {
+    const svg = renderFolderSolar(fixture(), (id) =>
+      id === 'src/a.ts' ? 'hsl(10, 50%, 50%)' : null,
+    );
+    expect(svg).toContain('style="fill:hsl(10, 50%, 50%);stroke:color-mix');
+    // Only the one tinted node carries an inline style.
+    expect((svg.match(/style="fill:/g) ?? []).length).toBe(1);
+  });
+
+  it('emits plain circles (no inline fill) in structure mode', () => {
+    const svg = renderFolderSolar(fixture());
+    expect(svg).not.toContain('style="fill:');
+  });
+});
+
+describe('escaping + truncation notice', () => {
+  it('escapes angle brackets in labels', () => {
+    const m = fixture();
+    m.nodes[3].label = '<script>';
+    const svg = renderFolderSolar(m);
+    expect(svg).toContain('&lt;script&gt;');
+    expect(svg).not.toContain('<script>');
+  });
+
+  it('shows a truncation caption only when truncated', () => {
+    expect(renderFolderHierarchy(fixture())).not.toContain('truncated at');
+    const t = { ...fixture(), truncated: true };
+    expect(renderFolderHierarchy(t)).toContain('truncated at 6 nodes / depth 2');
+  });
+});

--- a/app/src/lib/diagrams/folderMap.ts
+++ b/app/src/lib/diagrams/folderMap.ts
@@ -1,0 +1,244 @@
+/// Folder-map SVG renderer — extracted from `DiagramView.svelte`
+/// (Viz-Katalog V1.3, #61). Three layouts (solar / hierarchy / top-down)
+/// share the node-radius, edge-grouping and chrome helpers below.
+///
+/// Colour-by overlays (recency / author / diff) stay in the component: they
+/// depend on fetched git facts. The component builds a `FillFor` resolver
+/// and passes it in, so this module stays a pure layout function that can be
+/// unit-tested without any git plumbing.
+
+import { esc, shortLabel } from './common';
+
+export interface FolderMapNode {
+  id: string;
+  parent: string | null;
+  label: string;
+  path: string;
+  kind: 'root' | 'folder' | 'file';
+  depth: number;
+  weight: number;
+}
+
+export interface FolderMap {
+  root: string;
+  max_depth: number;
+  truncated: boolean;
+  nodes: FolderMapNode[];
+}
+
+export type FolderLayout = 'hierarchy' | 'solar' | 'td';
+
+/// Resolve the inline fill for a node, or `null` to keep the structural
+/// per-kind palette. Supplied by the component from its colour-by state.
+export type FillFor = (id: string, kind: FolderMapNode['kind']) => string | null;
+
+const noFill: FillFor = () => null;
+
+export function renderFolderMap(
+  map: FolderMap,
+  layout: FolderLayout,
+  fillFor: FillFor = noFill,
+): string {
+  if (layout === 'solar') return renderFolderSolar(map, fillFor);
+  if (layout === 'td') return renderFolderTopDown(map, fillFor);
+  return renderFolderHierarchy(map, fillFor);
+}
+
+/// `<circle>` element string — plain in `structure` mode, or with an inline
+/// fill + a lighter, hue-matched stroke when a colour-by mode supplies one.
+function circleSvg(n: FolderMapNode, r: number, fillFor: FillFor): string {
+  const fill = fillFor(n.id, n.kind);
+  if (fill === null) {
+    return `<circle r="${r}"/>`;
+  }
+  return `<circle r="${r}" style="fill:${fill};stroke:color-mix(in srgb, ${fill} 60%, white);"/>`;
+}
+
+export function renderFolderHierarchy(map: FolderMap, fillFor: FillFor = noFill): string {
+  const nodes = [...map.nodes].sort((a, b) => a.depth - b.depth || a.id.localeCompare(b.id));
+  const byParent = groupByParent(nodes);
+  const rows: Array<{ n: FolderMapNode; x: number; y: number }> = [];
+  const nextY = { value: 70 };
+  const xGap = 210;
+  const yGap = 58;
+  function place(id: string, depth: number) {
+    const n = nodes.find((node) => node.id === id);
+    if (!n) return;
+    const children = byParent.get(id) ?? [];
+    if (children.length === 0) {
+      rows.push({ n, x: 80 + depth * xGap, y: nextY.value });
+      nextY.value += yGap;
+      return;
+    }
+    const before = nextY.value;
+    for (const child of children) place(child.id, depth + 1);
+    const after = nextY.value - yGap;
+    rows.push({ n, x: 80 + depth * xGap, y: (before + after) / 2 });
+  }
+  place('.', 0);
+  const byId = new Map(rows.map((r) => [r.n.id, r]));
+  const width = Math.max(900, Math.max(...rows.map((r) => r.x), 0) + 260);
+  const height = Math.max(520, nextY.value + 70);
+  const edges = rows
+    .filter((r) => r.n.parent)
+    .map((r) => {
+      const p = byId.get(r.n.parent ?? '');
+      if (!p) return '';
+      return `<path d="M${p.x + 70} ${p.y} C${p.x + 135} ${p.y}, ${r.x - 70} ${r.y}, ${r.x - 10} ${r.y}" class="edge"/>`;
+    })
+    .join('');
+  const body = rows
+    .map(({ n, x, y }) => {
+      const radius = nodeRadius(n);
+      return `<g class="node ${n.kind}" data-path="${esc(n.path)}" data-kind="${n.kind}" transform="translate(${x} ${y})">
+          ${circleSvg(n, radius, fillFor)}
+          <text x="${radius + 8}" y="-3">${esc(shortLabel(n.label, 22))}</text>
+          <text x="${radius + 8}" y="13" class="meta">${n.kind} · ${n.weight}</text>
+        </g>`;
+    })
+    .join('');
+  return folderSvg(width, height, edges + body, map);
+}
+
+export function renderFolderTopDown(map: FolderMap, fillFor: FillFor = noFill): string {
+  const nodes = [...map.nodes].sort((a, b) => a.depth - b.depth || a.id.localeCompare(b.id));
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+  const byParent = groupByParent(nodes);
+  const placed = new Map<string, { n: FolderMapNode; x: number; y: number }>();
+  const leafX = { value: 95 };
+  const xGap = 120;
+  const yGap = 112;
+
+  function place(id: string, depth: number): number {
+    const n = byId.get(id);
+    if (!n) return leafX.value;
+    const children = byParent.get(id) ?? [];
+    let x: number;
+    if (children.length === 0) {
+      x = leafX.value;
+      leafX.value += xGap;
+    } else {
+      const childXs = children.map((child) => place(child.id, depth + 1));
+      x = (childXs[0] + childXs[childXs.length - 1]) / 2;
+    }
+    placed.set(id, { n, x, y: 70 + depth * yGap });
+    return x;
+  }
+
+  place('.', 0);
+  const rows = [...placed.values()];
+  const width = Math.max(900, leafX.value + 95);
+  const height = Math.max(520, Math.max(...rows.map((r) => r.y), 0) + 120);
+  const edges = rows
+    .filter((r) => r.n.parent)
+    .map((r) => {
+      const p = placed.get(r.n.parent ?? '');
+      if (!p) return '';
+      return `<path d="M${p.x} ${p.y + 32} C${p.x} ${p.y + 70}, ${r.x} ${r.y - 70}, ${r.x} ${r.y - 18}" class="edge"/>`;
+    })
+    .join('');
+  const body = rows
+    .map(({ n, x, y }) => {
+      const radius = nodeRadius(n);
+      return `<g class="node ${n.kind}" data-path="${esc(n.path)}" data-kind="${n.kind}" transform="translate(${x} ${y})">
+          ${circleSvg(n, radius, fillFor)}
+          <text y="${radius + 17}" text-anchor="middle">${esc(shortLabel(n.label, 14))}</text>
+          <text y="${radius + 31}" class="meta" text-anchor="middle">${n.kind} · ${n.weight}</text>
+        </g>`;
+    })
+    .join('');
+  return folderSvg(width, height, edges + body, map);
+}
+
+export function renderFolderSolar(map: FolderMap, fillFor: FillFor = noFill): string {
+  const nodes = map.nodes;
+  const byParent = groupByParent(nodes);
+  const width = 1400;
+  const height = 900;
+  const cx = width / 2;
+  const cy = height / 2;
+  const placed = new Map<string, { n: FolderMapNode; x: number; y: number }>();
+  placed.set('.', { n: nodes[0], x: cx, y: cy });
+  const maxDepth = Math.max(...nodes.map((n) => n.depth), 1);
+  const rings = Array.from({ length: maxDepth }, (_, i) => {
+    const r = 105 + i * 118;
+    return `<circle class="orbit" cx="${cx}" cy="${cy}" r="${r}"/>`;
+  }).join('');
+  for (let depth = 1; depth <= maxDepth; depth++) {
+    const level = nodes.filter((n) => n.depth === depth);
+    const radius = 105 + (depth - 1) * 118;
+    level.forEach((n, i) => {
+      const angle = -Math.PI / 2 + (i / Math.max(level.length, 1)) * Math.PI * 2;
+      placed.set(n.id, {
+        n,
+        x: cx + Math.cos(angle) * radius,
+        y: cy + Math.sin(angle) * radius,
+      });
+    });
+  }
+  const edges = nodes
+    .filter((n) => n.parent)
+    .map((n) => {
+      const a = placed.get(n.parent ?? '');
+      const b = placed.get(n.id);
+      if (!a || !b) return '';
+      return `<line class="edge" x1="${a.x}" y1="${a.y}" x2="${b.x}" y2="${b.y}"/>`;
+    })
+    .join('');
+  const body = [...placed.values()]
+    .map(({ n, x, y }) => {
+      const r = nodeRadius(n);
+      return `<g class="node ${n.kind}" data-path="${esc(n.path)}" data-kind="${n.kind}" transform="translate(${x} ${y})">
+          ${circleSvg(n, r, fillFor)}
+          <text y="${r + 16}" text-anchor="middle">${esc(shortLabel(n.label, 18))}</text>
+        </g>`;
+    })
+    .join('');
+  return folderSvg(width, height, rings + edges + body, map);
+}
+
+export function groupByParent(nodes: FolderMapNode[]): Map<string, FolderMapNode[]> {
+  const out = new Map<string, FolderMapNode[]>();
+  for (const n of nodes) {
+    if (!n.parent) continue;
+    const arr = out.get(n.parent) ?? [];
+    arr.push(n);
+    out.set(n.parent, arr);
+  }
+  for (const arr of out.values()) {
+    arr.sort((a, b) => folderRank(a) - folderRank(b) || a.label.localeCompare(b.label));
+  }
+  return out;
+}
+
+function folderRank(n: FolderMapNode): number {
+  return n.kind === 'root' ? 0 : n.kind === 'folder' ? 1 : 2;
+}
+
+export function nodeRadius(n: FolderMapNode): number {
+  const base = n.kind === 'root' ? 30 : n.kind === 'folder' ? 18 : 7;
+  return Math.min(base + Math.sqrt(n.weight) * 2.5, n.kind === 'file' ? 13 : 46);
+}
+
+function folderSvg(width: number, height: number, body: string, map: FolderMap): string {
+  const note = map.truncated
+    ? `<text x="24" y="${height - 24}" class="caption">truncated at ${map.nodes.length} nodes / depth ${map.max_depth}</text>`
+    : '';
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}">
+      <style>
+        .edge{stroke:#3d4657;stroke-width:1.4;fill:none;opacity:.75}
+        .orbit{stroke:#2a3344;stroke-width:1;fill:none;stroke-dasharray:6 10}
+        .node circle{stroke-width:2;filter:drop-shadow(0 8px 14px rgba(0,0,0,.28))}
+        .node{cursor:default}
+        .node.file{cursor:pointer}
+        .node.root circle{fill:#4f46e5;stroke:#c4b5fd}
+        .node.folder circle{fill:#0f766e;stroke:#5eead4}
+        .node.file circle{fill:#334155;stroke:#94a3b8}
+        text{fill:#dce3f0;font:13px ui-sans-serif,system-ui,sans-serif}
+        .meta,.caption{fill:#8b98aa;font-size:11px}
+      </style>
+      <rect width="100%" height="100%" fill="#090d14"/>
+      ${body}
+      ${note}
+    </svg>`;
+}

--- a/app/src/lib/diagrams/languageStats.ts
+++ b/app/src/lib/diagrams/languageStats.ts
@@ -1,0 +1,91 @@
+/// Language-stats SVG renderer — extracted from `DiagramView.svelte`
+/// (Viz-Katalog V1.3, #61). Horizontal-bar chart of file count per language.
+/// Bars are sorted by file count desc (done server-side); bar width is
+/// proportional to file count relative to the largest bucket. Pure.
+
+import { esc, formatBytes } from './common';
+
+export interface LanguageBucket {
+  language: string;
+  extension: string | null;
+  files: number;
+  bytes: number;
+}
+
+export interface LanguageStats {
+  root: string;
+  total_files: number;
+  total_bytes: number;
+  truncated: boolean;
+  buckets: LanguageBucket[];
+}
+
+export function renderLanguageStats(stats: LanguageStats): string {
+  if (stats.buckets.length === 0) {
+    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 480">
+        <rect width="100%" height="100%" fill="#090d14"/>
+        <text x="450" y="240" text-anchor="middle" fill="#94a3b8" font-size="18" font-family="ui-sans-serif,system-ui">No files found</text>
+      </svg>`;
+  }
+  const PALETTE = [
+    '#3b82f6',
+    '#10b981',
+    '#f59e0b',
+    '#ef4444',
+    '#8b5cf6',
+    '#ec4899',
+    '#14b8a6',
+    '#f97316',
+    '#22d3ee',
+    '#a3e635',
+    '#eab308',
+    '#6366f1',
+  ];
+  const buckets = stats.buckets;
+  const maxFiles = Math.max(1, ...buckets.map((b) => b.files));
+  const totalFiles = Math.max(1, stats.total_files);
+  const ROW = 28;
+  const TOP = 60;
+  const LEFT_LABEL = 200;
+  const BAR_LEFT = LEFT_LABEL + 12;
+  const RIGHT_PADDING = 160;
+  const width = 960;
+  const barTrack = width - BAR_LEFT - RIGHT_PADDING;
+  const height = TOP + buckets.length * ROW + 40;
+  const truncatedNote = stats.truncated
+    ? `<text x="24" y="${height - 18}" class="caption">truncated at ${stats.total_files} files</text>`
+    : '';
+  const totalLine = formatBytes(stats.total_bytes);
+  const rows = buckets
+    .map((b, i) => {
+      const w = Math.max(2, Math.round((b.files / maxFiles) * barTrack));
+      const y = TOP + i * ROW;
+      const color = PALETTE[i % PALETTE.length];
+      const pct = ((b.files / totalFiles) * 100).toFixed(1);
+      const extLabel = b.extension ? `.${b.extension}` : '—';
+      return `<g class="row">
+          <text x="${LEFT_LABEL}" y="${y + 14}" class="lang" text-anchor="end">${esc(b.language)}</text>
+          <text x="${LEFT_LABEL - 8}" y="${y + 14}" class="ext" text-anchor="end" dx="-44">${esc(extLabel)}</text>
+          <rect x="${BAR_LEFT}" y="${y + 4}" width="${w}" height="${ROW - 10}" rx="3" fill="${color}" opacity="0.85"/>
+          <text x="${BAR_LEFT + w + 8}" y="${y + 14}" class="value">${b.files} · ${pct}% · ${formatBytes(b.bytes)}</text>
+        </g>`;
+    })
+    .join('');
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}">
+      <style>
+        text{fill:#dce3f0;font:13px ui-sans-serif,system-ui,sans-serif}
+        .title{font-size:18px;font-weight:600}
+        .caption{font-size:11px;fill:#94a3b8}
+        .lang{font-weight:600}
+        .ext{font-family:ui-monospace,monospace;font-size:11px;fill:#94a3b8}
+        .value{font-family:ui-monospace,monospace;font-size:11px;fill:#cbd5e1}
+        .ruler{stroke:#1f2937;stroke-width:1}
+      </style>
+      <rect width="100%" height="100%" fill="#090d14"/>
+      <text x="24" y="32" class="title">Sprachenverteilung</text>
+      <text x="24" y="50" class="caption">${stats.total_files} Dateien · ${totalLine} · ${buckets.length} Buckets</text>
+      <line x1="${BAR_LEFT}" y1="${TOP - 4}" x2="${BAR_LEFT}" y2="${TOP + buckets.length * ROW}" class="ruler"/>
+      ${rows}
+      ${truncatedNote}
+    </svg>`;
+}

--- a/app/src/lib/diagrams/moduleChord.ts
+++ b/app/src/lib/diagrams/moduleChord.ts
@@ -1,0 +1,125 @@
+/// Module-chord (dependency-wheel) SVG renderer — extracted from
+/// `DiagramView.svelte` (Viz-Katalog V1.3, #61). Modules become arcs on a
+/// circle, cross-module edges become Bezier chords through the centre; chord
+/// width encodes the relation count. Self-edges are not drawn (a module's
+/// `internal` count is shown on its label instead). Pure.
+
+import { esc } from './common';
+
+export interface ChordModule {
+  id: string;
+  label: string;
+  classes: number;
+  outgoing: number;
+  incoming: number;
+  internal: number;
+}
+export interface ChordEdge {
+  from: string;
+  to: string;
+  count: number;
+}
+export interface ModuleChord {
+  root: string;
+  modules: ChordModule[];
+  edges: ChordEdge[];
+  total_relations: number;
+}
+
+export function renderModuleChord(chord: ModuleChord): string {
+  const W = 900;
+  const H = 700;
+  const cx = W / 2;
+  const cy = H / 2 + 12;
+  const R = 270;
+  const innerR = R - 18;
+  const labelR = R + 28;
+
+  if (chord.modules.length === 0) {
+    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}">
+        <rect width="100%" height="100%" fill="#090d14"/>
+        <text x="${cx}" y="${cy}" text-anchor="middle" fill="#94a3b8" font-size="18" font-family="ui-sans-serif,system-ui">Keine Module erkannt.</text>
+      </svg>`;
+  }
+
+  const PALETTE = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899', '#14b8a6', '#f97316', '#22d3ee', '#a3e635', '#eab308', '#6366f1'];
+
+  // Position each module on the rim with weight proportional to its
+  // class count (so big modules get a wider arc).
+  const totalWeight = chord.modules.reduce((s, m) => s + Math.max(1, m.classes), 0);
+  const arcs = new Map<string, { start: number; end: number; mid: number; color: string }>();
+  let theta = -Math.PI / 2; // start at top
+  chord.modules.forEach((m, i) => {
+    const w = Math.max(1, m.classes) / totalWeight;
+    const span = w * 2 * Math.PI * 0.94; // leave 6% gap total
+    const start = theta + 0.03 * (2 * Math.PI) / chord.modules.length;
+    const end = start + span;
+    arcs.set(m.id, { start, end, mid: (start + end) / 2, color: PALETTE[i % PALETTE.length] });
+    theta = end + 0.03 * (2 * Math.PI) / chord.modules.length;
+  });
+
+  const arcSvg = chord.modules
+    .map((m) => {
+      const a = arcs.get(m.id)!;
+      const x1 = cx + R * Math.cos(a.start);
+      const y1 = cy + R * Math.sin(a.start);
+      const x2 = cx + R * Math.cos(a.end);
+      const y2 = cy + R * Math.sin(a.end);
+      const x3 = cx + innerR * Math.cos(a.end);
+      const y3 = cy + innerR * Math.sin(a.end);
+      const x4 = cx + innerR * Math.cos(a.start);
+      const y4 = cy + innerR * Math.sin(a.start);
+      const large = a.end - a.start > Math.PI ? 1 : 0;
+      const path = `M ${x1} ${y1} A ${R} ${R} 0 ${large} 1 ${x2} ${y2} L ${x3} ${y3} A ${innerR} ${innerR} 0 ${large} 0 ${x4} ${y4} Z`;
+      const lx = cx + labelR * Math.cos(a.mid);
+      const ly = cy + labelR * Math.sin(a.mid);
+      const anchor = Math.cos(a.mid) > 0 ? 'start' : 'end';
+      const rotation = (a.mid * 180) / Math.PI;
+      const niceRot = rotation > 90 || rotation < -90 ? rotation + 180 : rotation;
+      const labelText = `${esc(m.label)} · ${m.classes}`;
+      return `<g class="rim"><path d="${path}" fill="${a.color}" fill-opacity="0.85" stroke="${a.color}" stroke-width="1"/><text x="${lx}" y="${ly}" text-anchor="${anchor}" transform="rotate(${niceRot.toFixed(1)} ${lx} ${ly})" class="rim-label">${labelText}</text><title>${esc(m.id)}\n${m.classes} Klassen · ↗ ${m.outgoing} · ↘ ${m.incoming} · ⤾ ${m.internal}</title></g>`;
+    })
+    .join('');
+
+  const maxEdge = Math.max(1, ...chord.edges.map((e) => e.count));
+  const chordSvg = chord.edges
+    .map((edge) => {
+      const a1 = arcs.get(edge.from);
+      const a2 = arcs.get(edge.to);
+      if (!a1 || !a2) return '';
+      // Tap each chord into a sub-portion of the arc proportional to
+      // edge weight relative to the module's total outgoing.
+      const x1 = cx + innerR * Math.cos(a1.mid);
+      const y1 = cy + innerR * Math.sin(a1.mid);
+      const x2 = cx + innerR * Math.cos(a2.mid);
+      const y2 = cy + innerR * Math.sin(a2.mid);
+      const w = Math.max(1, Math.min(6, (edge.count / maxEdge) * 5 + 1));
+      return `<path d="M ${x1} ${y1} Q ${cx} ${cy} ${x2} ${y2}" stroke="${a1.color}" stroke-width="${w}" stroke-opacity="0.45" fill="none"><title>${esc(edge.from)} → ${esc(edge.to)}: ${edge.count}</title></path>`;
+    })
+    .join('');
+
+  const top = chord.edges.slice(0, 6);
+  const topList = top
+    .map(
+      (e, i) =>
+        `<text x="24" y="${600 + i * 16}" class="top-line">${i + 1}. ${esc(e.from)} → ${esc(e.to)} · ${e.count}</text>`,
+    )
+    .join('');
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}">
+      <style>
+        text{fill:#dce3f0;font:13px ui-sans-serif,system-ui,sans-serif}
+        .title{font-size:20px;font-weight:600}
+        .subtitle{font-size:12px;fill:#94a3b8}
+        .rim-label{font-size:11px;font-family:ui-monospace,monospace}
+        .top-title{font-size:12px;font-weight:600;fill:#cbd5e1}
+        .top-line{font-size:11px;font-family:ui-monospace,monospace;fill:#94a3b8}
+      </style>
+      <rect width="100%" height="100%" fill="#090d14"/>
+      <text x="24" y="34" class="title">Modul-Kopplung</text>
+      <text x="24" y="52" class="subtitle">${chord.modules.length} Module · ${chord.edges.length} Cross-Module-Edges · ${chord.total_relations} Beziehungen gesamt</text>
+      ${chordSvg}
+      ${arcSvg}
+      ${top.length > 0 ? `<text x="24" y="584" class="top-title">Top Cross-Module-Kanten</text>${topList}` : ''}
+    </svg>`;
+}

--- a/app/src/lib/diagrams/viewport.test.ts
+++ b/app/src/lib/diagrams/viewport.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  MAX_SCALE,
+  MIN_SCALE,
+  createViewportStore,
+  initialViewport,
+  panBy,
+  panTo,
+  reset,
+  setBaseSize,
+  zoomAround,
+} from './viewport';
+
+describe('viewport reducers', () => {
+  it('starts at the identity transform with no base size', () => {
+    expect(initialViewport()).toEqual({ scale: 1, tx: 0, ty: 0, baseW: 0, baseH: 0 });
+  });
+
+  it('reset() clears pan + zoom but keeps the base size', () => {
+    const v = { scale: 3, tx: 40, ty: -20, baseW: 800, baseH: 600 };
+    expect(reset(v)).toEqual({ scale: 1, tx: 0, ty: 0, baseW: 800, baseH: 600 });
+  });
+
+  it('panBy() accumulates screen-space deltas', () => {
+    const v = panBy(initialViewport(), 10, -5);
+    expect(v).toMatchObject({ tx: 10, ty: -5 });
+    expect(panBy(v, 3, 5)).toMatchObject({ tx: 13, ty: 0 });
+  });
+
+  it('panTo() sets an absolute offset', () => {
+    expect(panTo({ ...initialViewport(), tx: 99, ty: 99 }, 7, 8)).toMatchObject({
+      tx: 7,
+      ty: 8,
+    });
+  });
+
+  it('setBaseSize() leaves the live transform untouched', () => {
+    const v = { scale: 2, tx: 5, ty: 6, baseW: 0, baseH: 0 };
+    expect(setBaseSize(v, 320, 240)).toEqual({
+      scale: 2,
+      tx: 5,
+      ty: 6,
+      baseW: 320,
+      baseH: 240,
+    });
+  });
+
+  describe('zoomAround()', () => {
+    it('scales by the factor when unclamped', () => {
+      const v = zoomAround(initialViewport(), 2, 100, 100);
+      expect(v.scale).toBe(2);
+    });
+
+    it('keeps the anchor world-point fixed on zoom in', () => {
+      // At scale 1, tx/ty 0: the world-point under (100,100) is (100,100).
+      // After zooming in it must still map back to screen (100,100).
+      const v = zoomAround(initialViewport(), 2, 100, 100);
+      // world = (screen - tx) / scale
+      const worldX = (100 - v.tx) / v.scale;
+      const worldY = (100 - v.ty) / v.scale;
+      expect(worldX).toBeCloseTo(100, 6);
+      expect(worldY).toBeCloseTo(100, 6);
+    });
+
+    it('keeps the anchor fixed even from a panned + zoomed start', () => {
+      const start = { scale: 1.5, tx: 30, ty: -12, baseW: 0, baseH: 0 };
+      const anchorX = 220;
+      const anchorY = 80;
+      const worldBefore = {
+        x: (anchorX - start.tx) / start.scale,
+        y: (anchorY - start.ty) / start.scale,
+      };
+      const v = zoomAround(start, 1.3, anchorX, anchorY);
+      const worldAfter = {
+        x: (anchorX - v.tx) / v.scale,
+        y: (anchorY - v.ty) / v.scale,
+      };
+      expect(worldAfter.x).toBeCloseTo(worldBefore.x, 6);
+      expect(worldAfter.y).toBeCloseTo(worldBefore.y, 6);
+    });
+
+    it('clamps at MAX_SCALE and still pins the anchor', () => {
+      const start = { scale: MAX_SCALE, tx: 10, ty: 10, baseW: 0, baseH: 0 };
+      const v = zoomAround(start, 4, 50, 50);
+      expect(v.scale).toBe(MAX_SCALE);
+      // ratio is 1 → transform unchanged, anchor trivially fixed.
+      expect(v.tx).toBe(10);
+      expect(v.ty).toBe(10);
+    });
+
+    it('clamps at MIN_SCALE on aggressive zoom out', () => {
+      const v = zoomAround({ ...initialViewport(), scale: MIN_SCALE }, 0.1, 0, 0);
+      expect(v.scale).toBe(MIN_SCALE);
+    });
+  });
+});
+
+describe('createViewportStore', () => {
+  it('is a Svelte store starting from the initial viewport', () => {
+    const store = createViewportStore();
+    expect(get(store)).toEqual(initialViewport());
+  });
+
+  it('applies pan / zoom / reset / base-size through helpers', () => {
+    const store = createViewportStore();
+    store.setBaseSize(640, 480);
+    store.panBy(20, 10);
+    store.zoomAround(2, 0, 0);
+    let v = get(store);
+    expect(v.baseW).toBe(640);
+    expect(v.scale).toBe(2);
+    // panBy(20,10) then zoomAround factor 2 about origin: tx = 0 - (0-20)*2 = 40
+    expect(v.tx).toBe(40);
+    expect(v.ty).toBe(20);
+
+    store.reset();
+    v = get(store);
+    expect(v).toMatchObject({ scale: 1, tx: 0, ty: 0, baseW: 640, baseH: 480 });
+  });
+
+  it('panTo sets an absolute offset via the store', () => {
+    const store = createViewportStore();
+    store.panTo(11, 22);
+    expect(get(store)).toMatchObject({ tx: 11, ty: 22 });
+  });
+});

--- a/app/src/lib/diagrams/viewport.ts
+++ b/app/src/lib/diagrams/viewport.ts
@@ -1,0 +1,101 @@
+/// Viewport (pan / zoom) store for the Diagrams stage — hoisted out of
+/// `DiagramView.svelte` (Viz-Katalog V1.4, #66 Mini-Map prerequisite).
+///
+/// The diagram stage renders an SVG scaled to `baseW × baseH` at scale 1 and
+/// applies live zoom via a CSS `translate(tx, ty) scale(scale)` transform.
+/// Previously all of that lived as component-local `let`s, which meant the
+/// Mini-Map (#66) had nowhere to read the current viewport rectangle from.
+/// This module lifts that state into a small Svelte store whose transitions
+/// are expressed as **pure reducers** — so the pan/zoom/reset maths can be
+/// unit-tested without a DOM, and the Mini-Map can drive it by dispatching
+/// the same reducers the main stage uses.
+
+import { writable } from 'svelte/store';
+
+/// The whole viewport state. `scale`/`tx`/`ty` are the live transform;
+/// `baseW`/`baseH` are the fit-to-stage SVG size at scale 1, stamped once
+/// per render. The Mini-Map derives its viewport rectangle from all five.
+export interface Viewport {
+  scale: number;
+  tx: number;
+  ty: number;
+  baseW: number;
+  baseH: number;
+}
+
+/// Zoom is clamped to this range everywhere (wheel, toolbar buttons,
+/// mini-map). Kept as exported constants so the mini-map uses the same
+/// bounds as the stage.
+export const MIN_SCALE = 0.2;
+export const MAX_SCALE = 8;
+
+export function initialViewport(): Viewport {
+  return { scale: 1, tx: 0, ty: 0, baseW: 0, baseH: 0 };
+}
+
+function clampScale(s: number): number {
+  return Math.min(MAX_SCALE, Math.max(MIN_SCALE, s));
+}
+
+/// Reset pan + zoom to the identity transform, preserving the current base
+/// size (the SVG doesn't change size on a view reset).
+export function reset(v: Viewport): Viewport {
+  return { ...v, scale: 1, tx: 0, ty: 0 };
+}
+
+/// Pan by a screen-space delta (used while dragging).
+export function panBy(v: Viewport, dx: number, dy: number): Viewport {
+  return { ...v, tx: v.tx + dx, ty: v.ty + dy };
+}
+
+/// Set an absolute pan offset (used by drag, which tracks from a captured
+/// start offset, and by the mini-map when it re-centres the view).
+export function panTo(v: Viewport, tx: number, ty: number): Viewport {
+  return { ...v, tx, ty };
+}
+
+/// Zoom by `factor` while keeping the world-point under the anchor point
+/// `(ax, ay)` (in stage-local pixels) fixed. This is the shared kernel for
+/// wheel-zoom (anchor = cursor), toolbar zoom (anchor = stage centre) and
+/// mini-map wheel-zoom. Scale is clamped to [MIN_SCALE, MAX_SCALE]; when the
+/// clamp bites, tx/ty are recomputed against the *clamped* scale so the
+/// anchor stays put exactly.
+export function zoomAround(v: Viewport, factor: number, ax: number, ay: number): Viewport {
+  const nextScale = clampScale(v.scale * factor);
+  const ratio = nextScale / v.scale;
+  return {
+    ...v,
+    tx: ax - (ax - v.tx) * ratio,
+    ty: ay - (ay - v.ty) * ratio,
+    scale: nextScale,
+  };
+}
+
+/// Set the fit-to-stage base size (stamped once per render). Leaves the live
+/// transform untouched.
+export function setBaseSize(v: Viewport, baseW: number, baseH: number): Viewport {
+  return { ...v, baseW, baseH };
+}
+
+/// Store factory. Each `DiagramView` instance owns its own viewport store so
+/// two stages (e.g. the compare view's side-by-side maps) don't fight over a
+/// single global. The returned object exposes the Svelte-store contract plus
+/// typed helpers that apply the pure reducers above.
+export function createViewportStore() {
+  const store = writable<Viewport>(initialViewport());
+  const { subscribe, set, update } = store;
+  return {
+    subscribe,
+    set,
+    update,
+    reset: () => update(reset),
+    panBy: (dx: number, dy: number) => update((v) => panBy(v, dx, dy)),
+    panTo: (tx: number, ty: number) => update((v) => panTo(v, tx, ty)),
+    zoomAround: (factor: number, ax: number, ay: number) =>
+      update((v) => zoomAround(v, factor, ax, ay)),
+    setBaseSize: (baseW: number, baseH: number) =>
+      update((v) => setBaseSize(v, baseW, baseH)),
+  };
+}
+
+export type ViewportStore = ReturnType<typeof createViewportStore>;


### PR DESCRIPTION
## Fundament für Viz-Katalog V2 — verhaltens-erhaltender Refactor + Viewport-Store

**Kein Feature-Issue geschlossen.** Dies ist das P0-Fundament (Plan-Abschnitt 4, V1.3/V1.4) das die noch offenen V2-Katalog-Features *ermöglicht* — allen voran **#66 Mini-Map** (braucht den hier gehoisteten Viewport-Store), sowie Timeline River (#63.4), Before/After-Snapshots (#125) und C4-Context (#142), die alle auf `DiagramView.svelte` aufsetzen.

### Was passiert
`app/src/components/DiagramView.svelte` war mit **2216 Zeilen** der Engpass des ganzen Epics: 7 handgerollte SVG-Renderer + Mermaid-Pfad + draw.io-Pfad + Pan/Zoom + Farbmodi in *einer* Komponente. Dieser PR zieht die reine Render-/Layout-Logik in einzelne, testbare Module (Muster: das bereits extrahierte `treemap.ts`) und hebt den Viewport-State in einen kleinen Svelte-Store.

**Verhaltens-erhaltend: keine visuellen Änderungen, keine neuen Features.** Die Komponente lädt weiterhin Daten, baut den Fill-Resolver, wählt das Renderer-Modul und rendert — plus die DOM-nahen Teile (Klick-Drilldown, Pan/Zoom-Handler, Base-Size-Stamping, Toolbar).

### Extrahierte Renderer (`app/src/lib/diagrams/*`, alle pure `render(payload, opts): string`)
| Modul | Inhalt |
|---|---|
| `common.ts` | `esc` / `formatBytes` / `shortLabel` |
| `folderMap.ts` | Solar / Hierarchy / Top-Down (Colour-by-Fill wird als `FillFor`-Callback reingereicht — Git-State bleibt in der Komponente) |
| `docGraph.ts` | Network / Radial / Orphans |
| `languageStats.ts` | Sprachen-Balkenchart |
| `architectureFlow.ts` | Schicht-Bänder |
| `moduleChord.ts` | Dependency-Wheel |
| `activityHeatmap.ts` | Commit-Kalender |

### Viewport-Store (V1.4)
`app/src/lib/diagrams/viewport.ts` — Pan/Zoom/Reset als **pure Reducer** hinter einem kleinen per-Instanz Svelte-Store. `DiagramView` treibt ihn aus Wheel/Drag/Toolbar; die Mini-Map (#66) kann später das Viewport-Rechteck lesen und dieselben Reducer dispatchen. `zoomAround()` hält den Anker-Weltpunkt fix und clampt auf `[MIN_SCALE, MAX_SCALE]` (0.2–8, wie zuvor).

`DiagramView.svelte`: **2216 → 1243 Zeilen** (−1040).

### Tests (vitest, alle grün)
- Viewport-Reducer: pan / zoom / reset / Anker-Pinning / Clamp + Store-Helper
- Layout-/Escaping-/Empty-State-Tests für `folderMap`, `docGraph` und die vier Chart-Renderer
- Bestehende Diagramm-Tests + `i18nDiagramKeys.test.ts` bleiben grün (299→ inkl. 59 neue lokal; auf master-Basis 276 grün)

### Scope / Gates
- **Reines Frontend** — kein Rust/Tauri-Crate berührt.
- Gates grün: `svelte-check` (0 Fehler/0 Warnungen), `vitest` (alle grün), `pnpm build`.
- Disjunkt zum parallelen Tour-UX-Strang (compass/diffFocus nicht angefasst).

### Kein Folge-Schritt offen
Alle 7 SVG-Renderer wurden extrahiert (nicht nur die 3–4 größten) — die Komponente enthält keine Render-/Layout-Logik mehr außer der DOM-Verdrahtung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJuL4nSq1EvgahTJe1hom1