### PR TITLE
Viz-Katalog V125: diagram-diff walkthrough target (backend for #125)

### DIFF
--- a/crates/core/src/tour_index.rs
+++ b/crates/core/src/tour_index.rs
@@ -478,6 +478,7 @@ fn target_locator(
         }
         WalkthroughTarget::Risk { fqn, .. } => (Some(fqn.clone()), None, None),
         WalkthroughTarget::Diff { .. }
+        | WalkthroughTarget::DiagramDiff { .. }
         | WalkthroughTarget::Artifact { .. }
         | WalkthroughTarget::Pattern { .. }
         | WalkthroughTarget::Atlas { .. }

--- a/crates/core/src/walkthrough.rs
+++ b/crates/core/src/walkthrough.rs
@@ -146,6 +146,22 @@ pub enum WalkthroughTarget {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         highlight_fqns: Vec<String>,
     },
+    /// A before/after snapshot of one diagram between two refs (#125).
+    /// The GUI renders the `from` and `to` states of `diagram` with
+    /// before / after / changed-only toggles; changed nodes pulse once.
+    /// Old tours never emit this variant, so their rendering is unchanged.
+    DiagramDiff {
+        /// Which diagram kind to snapshot (e.g. `folder-map`). Omitted
+        /// means the GUI's currently selected diagram.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        diagram: Option<String>,
+        /// Base ref for the "before" state (e.g. `HEAD~5`, a branch name).
+        from: String,
+        /// Optional target ref for the "after" state. `None` means the
+        /// current working tree.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        to: Option<String>,
+    },
     /// Pure narration; nothing rendered in the target pane.
     Note,
 }
@@ -534,6 +550,35 @@ mod tests {
         let target: WalkthroughTarget = serde_json::from_str(json).unwrap();
         match target {
             WalkthroughTarget::Artifact { id } => assert_eq!(id, "my-report"),
+            other => panic!("wrong target: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn diagram_diff_target_parses_diagram_from_and_to() {
+        let json = r#"{"kind":"diagram-diff","diagram":"folder-map","from":"HEAD~5","to":"HEAD"}"#;
+        let target: WalkthroughTarget = serde_json::from_str(json).unwrap();
+        match target {
+            WalkthroughTarget::DiagramDiff { diagram, from, to } => {
+                assert_eq!(diagram.as_deref(), Some("folder-map"));
+                assert_eq!(from, "HEAD~5");
+                assert_eq!(to.as_deref(), Some("HEAD"));
+            }
+            other => panic!("wrong target: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn diagram_diff_target_defaults_diagram_and_to() {
+        // A minimal `diagram-diff` step: only `from`. diagram/to default to None.
+        let json = r#"{"kind":"diagram-diff","from":"main"}"#;
+        let target: WalkthroughTarget = serde_json::from_str(json).unwrap();
+        match target {
+            WalkthroughTarget::DiagramDiff { diagram, from, to } => {
+                assert!(diagram.is_none());
+                assert_eq!(from, "main");
+                assert!(to.is_none());
+            }
             other => panic!("wrong target: {other:?}"),
         }
     }

--- a/crates/mcp-server/src/record.rs
+++ b/crates/mcp-server/src/record.rs
@@ -208,6 +208,13 @@ fn build_render_step(step: &WalkthroughStep, repo: Option<&Repository>) -> Rende
                 None => format!("diff {reference} → working tree"),
             };
         }
+        WalkthroughTarget::DiagramDiff { diagram, from, to } => {
+            let kind = diagram.as_deref().unwrap_or("diagram");
+            out.target = match to {
+                Some(t) => format!("{kind} diff {from}..{t}"),
+                None => format!("{kind} diff {from} → working tree"),
+            };
+        }
         WalkthroughTarget::Pattern { pattern, scope, .. } => {
             out.target = match scope {
                 Some(s) => format!("pattern {pattern} · {s}"),


### PR DESCRIPTION
Completes the #125 before/after tour step by adding the backend `DiagramDiff` variant to `WalkthroughTarget`.

## Why
The #193 frontend (target types, folder-map diff renderer, before/after/changed-only toggles) is merged, but `WalkthroughTarget` is a `#[serde(tag = "kind")]` union with no catch-all. An authored tour carrying `kind: "diagram-diff"` would be **rejected at deserialize time** (`current_walkthrough()` fails), so the step was unreachable end-to-end until this variant lands.

## Change (3 files, +53)
- `crates/core/src/walkthrough.rs` — new `DiagramDiff { diagram?, from, to? }` variant (kebab-case tag → `diagram-diff`), matching the frontend target shape. + two deserialize round-trip tests.
- `crates/core/src/tour_index.rs` — `target_locator` returns `(None, None, None)` for it (no concrete code location to index), grouped with Diff/Artifact/Pattern/Atlas/Note.
- `crates/mcp-server/src/record.rs` — presenter/recording describes it as `<kind> diff <from>..<to>`.

## Verified locally (cargo 1.96)
- `cargo build` core + browser-host + mcp ✓
- `cargo clippy -D warnings` (core/mcp/browser-host, all-targets) → **0 warnings** ✓
- `cargo test` → 2 new + 246 core-lib pass ✓
- app crate (`projectmind-app`) is macOS-CI-only (no local GTK) and has **no match on `WalkthroughTarget`**, so the added variant can't break its compile.

Addresses #125 (backend half; frontend was #193).