### PR TITLE
feat(bean-graph-live): simulated request-flow mode (#200)

### DIFF
--- a/app/src/components/BeanGraphLive.svelte
+++ b/app/src/components/BeanGraphLive.svelte
@@ -24,6 +24,8 @@
   import type { BeanGraphElements } from '../lib/diagrams/beanGraphElements';
   import { classifyBeanGraphDiff } from '../lib/diagrams/beanGraphDiff';
   import { resolveOverlayMode, planBeanGraphMorph } from '../lib/diagrams/beanGraphMorph';
+  import { planBeanGraphFlow } from '../lib/diagrams/beanGraphFlow';
+  import type { FlowPlan } from '../lib/diagrams/beanGraphFlow';
   import { classes, selectedClass, viewMode } from '../lib/store';
   import { t } from '../lib/i18n';
 
@@ -69,6 +71,21 @@
   // turns it + `diffRef` into the active overlay state (off / diff / morph).
   let morphRequested = autoMorphRef !== '';
   $: overlayMode = resolveOverlayMode(!!diffRef, morphRequested);
+
+  // --- Flow mode (V4.1 / #200 fourth toolbar mode) ---------------------------
+  // A *simulated* request wave: BFS from the controller entry stereotypes along
+  // the directed edges towards the repositories. Frontier edges become
+  // marching-ants (`.flow-active`, an animated `line-dash-offset`), frontier
+  // nodes reuse the existing `.pulse`, already-travelled elements dim to
+  // `.flow-visited`; the plan loops until toggled off. It answers "how does a
+  // request topologically travel through this system" — the tooltip is explicit
+  // that this is topology order, not runtime traffic (honesty rule #61).
+  //
+  // Flow is NOT a since-ref overlay, so it lives in its own `flowActive` bool
+  // beside the off/diff/morph `overlayMode` (resolveOverlayMode stays untouched);
+  // it is mutually exclusive with the diff/morph overlay — turning one on clears
+  // the other.
+  let flowActive = false;
 
   // Stereotype fill/stroke/text — byte-parity with the Rust STEREOTYPE_STYLES
   // so the interactive graph reads like the Mermaid one.
@@ -213,6 +230,24 @@
             style: { opacity: 0.15, 'border-width': 0.5 },
           },
           { selector: 'edge.morph-enter', style: { opacity: 0.1, width: 0.5 } },
+          // --- Flow mode (V4.1 / #200) --------------------------------------
+          // Frontier edges: dashed marching-ants. The dash pattern is static;
+          // the rAF loop scrolls `line-dash-offset` to make the ants march. The
+          // accent blue matches the controller stereotype so the wave reads as
+          // "a request travelling out of the entry points".
+          {
+            selector: 'edge.flow-active',
+            style: {
+              'line-style': 'dashed',
+              'line-dash-pattern': [8, 4],
+              width: 3,
+              'line-color': '#79c0ff',
+              'target-arrow-color': '#79c0ff',
+            },
+          },
+          // Already-travelled nodes/edges hold a slightly dimmed accent so the
+          // path the wave took stays legible behind the live frontier.
+          { selector: '.flow-visited', style: { opacity: 0.85 } },
         ],
         // fcose-specific options aren't in the base cytoscape LayoutOptions
         // union (the extension ships no types), so cast through unknown.
@@ -274,6 +309,8 @@
       return;
     }
     if (!cy || !els) return;
+    // Diff/morph and flow are mutually exclusive — applying a ref stops the flow.
+    if (flowActive) stopFlow();
     diffLoading = true;
     try {
       const changes = await listChangesSince(ref);
@@ -369,9 +406,144 @@
 
   /// Toggle the morph mode on/off. Flipping it while a ref is applied re-applies
   /// the overlay in the newly selected style (morph animates, plain diff snaps).
+  /// Turning morph on while the flow runs stops the flow (mutually exclusive).
   function toggleMorph() {
+    if (!morphRequested && flowActive) stopFlow();
     morphRequested = !morphRequested;
     if (diffRef) void applyDiff();
+  }
+
+  // --- Flow playback (V4.1 / #200) -------------------------------------------
+  // The wave plan is built once per activation; a recursive setTimeout advances
+  // the frontier every FLOW_WAVE_MS, and a single rAF loop scrolls the
+  // marching-ants offset on the active edges. When the last wave settles we hold
+  // for FLOW_LOOP_PAUSE_MS, reset every flow class, and replay from wave 0.
+  const FLOW_WAVE_MS = 450;
+  const FLOW_LOOP_PAUSE_MS = 1000;
+  let flowPlan: FlowPlan | null = null;
+  let flowWaveTimer: ReturnType<typeof setTimeout> | null = null;
+  let flowRaf: ReturnType<typeof requestAnimationFrame> | null = null;
+  let flowStart = 0;
+
+  /// Toggle the flow mode. Turning it on clears any diff/morph overlay first
+  /// (mutually exclusive), builds the plan, and starts the loop; turning it off
+  /// stops the loop and strips every flow class back to the plain graph.
+  function toggleFlow() {
+    if (flowActive) {
+      stopFlow();
+    } else {
+      startFlow();
+    }
+  }
+
+  function startFlow() {
+    if (!cy || !els) return;
+    // Flow and the since-ref overlay are exclusive — drop diff/morph first.
+    if (diffRef || morphRequested) {
+      morphRequested = false;
+      clearDiff();
+    }
+    flowActive = true;
+    flowPlan = planBeanGraphFlow(els);
+    if (!flowPlan.animate) {
+      // Empty graph — nothing to travel; leave flowActive so the toggle reads
+      // pressed, but there is no wave to play.
+      return;
+    }
+    startFlowRaf();
+    playWave(0);
+  }
+
+  /// The rAF loop: scroll `line-dash-offset` on the active edges so the dashes
+  /// march. One batched `.style()` call per frame over the (small) active set.
+  /// The pattern repeats every 12 px (8+4), so wrapping the offset there keeps
+  /// the number bounded while staying visually continuous.
+  function startFlowRaf() {
+    flowStart = performance.now();
+    const tick = () => {
+      if (!cy || !flowActive) {
+        flowRaf = null;
+        return;
+      }
+      const elapsed = performance.now() - flowStart;
+      cy.edges('.flow-active').style('line-dash-offset', -(elapsed / 16) % 12);
+      flowRaf = requestAnimationFrame(tick);
+    };
+    flowRaf = requestAnimationFrame(tick);
+  }
+
+  /// Play wave `k`: promote the previous frontier to `.flow-visited`, light the
+  /// new frontier's edges (`.flow-active`) + pulse its nodes, and fade every
+  /// node/edge the wave hasn't reached yet. Recurses via setTimeout until the
+  /// last wave, then pauses and loops.
+  function playWave(k: number) {
+    if (!cy || !flowActive || !flowPlan) return;
+    const plan = flowPlan;
+
+    if (k === 0) {
+      // Fresh pass: fade everything, then reveal the entry frontier.
+      cy.batch(() => {
+        cy.elements().removeClass('flow-active flow-visited pulse');
+        cy.elements().addClass('faded');
+        const entry = cy.nodes().filter((n: { id: () => string }) => plan.waves[0].nodeIds.includes(n.id()));
+        entry.removeClass('faded').addClass('flow-visited');
+      });
+      pulseNodes(cy.nodes().filter((n: { id: () => string }) => plan.waves[0].nodeIds.includes(n.id())));
+    } else {
+      const wave = plan.waves[k];
+      const nodeSet = new Set(wave.nodeIds);
+      const edgeSet = new Set(wave.edgeIds);
+      cy.batch(() => {
+        // Previous frontier's edges settle from active → visited.
+        cy.edges('.flow-active').removeClass('flow-active').addClass('flow-visited');
+        // This wave's carrying edges march; its nodes arrive.
+        cy.edges().forEach((e: { id: () => string; removeClass: (c: string) => void; addClass: (c: string) => void }) => {
+          if (edgeSet.has(e.id())) {
+            e.removeClass('faded');
+            e.addClass('flow-active');
+          }
+        });
+        cy.nodes().forEach((n: { id: () => string; removeClass: (c: string) => void; addClass: (c: string) => void }) => {
+          if (nodeSet.has(n.id())) {
+            n.removeClass('faded');
+            n.addClass('flow-visited');
+          }
+        });
+      });
+      pulseNodes(cy.nodes().filter((n: { id: () => string }) => nodeSet.has(n.id())));
+    }
+
+    const next = k + 1;
+    if (next < plan.waves.length) {
+      flowWaveTimer = setTimeout(() => playWave(next), FLOW_WAVE_MS);
+    } else {
+      // Last wave settled: hold, then replay from the top.
+      flowWaveTimer = setTimeout(() => {
+        if (!cy || !flowActive) return;
+        cy.batch(() => cy.elements().removeClass('flow-active flow-visited pulse faded'));
+        playWave(0);
+      }, FLOW_LOOP_PAUSE_MS);
+    }
+  }
+
+  /// Stop the flow: cancel the wave timer + rAF and strip every flow class so
+  /// the plain graph is restored (mirror of `clearMorphTimers`' cleanup role).
+  function stopFlow() {
+    flowActive = false;
+    flowPlan = null;
+    if (flowWaveTimer !== null) {
+      clearTimeout(flowWaveTimer);
+      flowWaveTimer = null;
+    }
+    if (flowRaf !== null) {
+      cancelAnimationFrame(flowRaf);
+      flowRaf = null;
+    }
+    if (pulseTimer) {
+      clearTimeout(pulseTimer);
+      pulseTimer = null;
+    }
+    cy?.elements().removeClass('flow-active flow-visited pulse faded');
   }
 
   /// Toggle the `changed` / `faded` classes and fire a one-shot pulse on the
@@ -392,17 +564,26 @@
     pulseChanged();
   }
 
-  /// One-shot pulse: add the `pulse` class to changed nodes, then strip it after
-  /// the transition settles so it plays once and never flickers.
+  /// One-shot pulse over a Cytoscape node collection: add the `pulse` class,
+  /// then strip it after the transition settles so it plays once and never
+  /// flickers. Shared by the morph (changed nodes) and the flow (each wave's
+  /// frontier nodes).
   let pulseTimer: ReturnType<typeof setTimeout> | null = null;
-  function pulseChanged() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function pulseNodes(nodes: any) {
     if (!cy) return;
     if (pulseTimer) clearTimeout(pulseTimer);
-    cy.nodes('.changed').addClass('pulse');
+    nodes.addClass('pulse');
     pulseTimer = setTimeout(() => {
       cy?.nodes('.pulse').removeClass('pulse');
       pulseTimer = null;
     }, 700);
+  }
+
+  /// One-shot pulse on the diff's changed nodes (morph accent).
+  function pulseChanged() {
+    if (!cy) return;
+    pulseNodes(cy.nodes('.changed'));
   }
 
   /// Remove the overlay: strip all diff classes, reset state.
@@ -434,6 +615,7 @@
   onDestroy(() => {
     if (pulseTimer) clearTimeout(pulseTimer);
     clearMorphTimers();
+    stopFlow();
     cy?.destroy();
     cy = null;
   });
@@ -487,6 +669,20 @@
       {#if diffError}
         <span class="diff-error" title={diffError}>⚠</span>
       {/if}
+    {/if}
+    <!-- Flow toggle (V4.1): a simulated request wave. Visible even when
+         embedded (a tour step can play the flow), default off. Not a since-ref
+         overlay, so it lives beside the off/diff/morph controls. -->
+    {#if !empty}
+      {#if embedded}<span class="divider"></span>{/if}
+      <button
+        type="button"
+        class="flow-toggle"
+        class:active={flowActive}
+        aria-pressed={flowActive}
+        on:click={toggleFlow}
+        title={$t('diagram.beanGraphLive.flowTitle')}
+      >{$t('diagram.beanGraphLive.flow')}</button>
     {/if}
     <span class="hint">{$t('diagram.drillHint')}</span>
   </div>
@@ -582,6 +778,16 @@
   .toolbar button.morph-toggle.active {
     border-color: #f0b429;
     color: #f0b429;
+  }
+  /* Flow toggle: text button that lights up (accent blue = the flow edge
+     colour) while the simulated request wave is running. */
+  .toolbar button.flow-toggle {
+    width: auto;
+    padding: 0 8px;
+  }
+  .toolbar button.flow-toggle.active {
+    border-color: #79c0ff;
+    color: #79c0ff;
   }
   .diff-summary {
     font-size: 11px;

--- a/app/src/i18n/de.json
+++ b/app/src/i18n/de.json
@@ -64,6 +64,8 @@
   "diagram.beanGraphLive.changedCount": "{count} geändert",
   "diagram.beanGraphLive.morph": "Morph",
   "diagram.beanGraphLive.morphTitle": "Die Änderung animiert einblenden: Die geänderten Klassen fahren ein und pulsen, während sich das Layout sanft neu ordnet — statt dass die Änderung einfach anspringt.",
+  "diagram.beanGraphLive.flow": "▶ Fluss",
+  "diagram.beanGraphLive.flowTitle": "Eine simulierte Anfrage-Welle abspielen: Von den Controllern läuft eine BFS entlang der gerichteten Kanten zu den Repositories, mit marschierenden Kanten und pulsierenden Knoten, in Schleife bis zum Ausschalten. Simulierter Fluss — Topologie-Reihenfolge, kein Laufzeit-Verkehr.",
   "diagram.packageTree": "Paketbaum",
   "diagram.folderMap": "Ordner-Karte",
   "diagram.inheritanceTree": "Vererbungsbaum",

--- a/app/src/i18n/en.json
+++ b/app/src/i18n/en.json
@@ -64,6 +64,8 @@
   "diagram.beanGraphLive.changedCount": "{count} changed",
   "diagram.beanGraphLive.morph": "Morph",
   "diagram.beanGraphLive.morphTitle": "Animate the change in: the changed classes ease in and pulse while the layout settles, instead of the change snapping on.",
+  "diagram.beanGraphLive.flow": "▶ Flow",
+  "diagram.beanGraphLive.flowTitle": "Play a simulated request wave: from the controllers a BFS travels along the directed edges towards the repositories, with marching-ants edges and pulsing nodes, looping until turned off. Simulated flow — topology order, not runtime traffic.",
   "diagram.packageTree": "Package tree",
   "diagram.folderMap": "Folder map",
   "diagram.inheritanceTree": "Inheritance tree",

--- a/app/src/i18n/es.json
+++ b/app/src/i18n/es.json
@@ -44,6 +44,8 @@
   "diagram.beanGraphLive.applyDiff": "Diff",
   "diagram.beanGraphLive.clearDiff": "Quitar la superposición de diff",
   "diagram.beanGraphLive.changedCount": "{count} cambiadas",
+  "diagram.beanGraphLive.flow": "▶ Flujo",
+  "diagram.beanGraphLive.flowTitle": "Reproduce una oleada de solicitudes simulada: desde los controladores, un BFS recorre las aristas dirigidas hacia los repositorios, con aristas de puntos animadas y nodos que laten, en bucle hasta apagarlo. Flujo simulado — orden topológico, no tráfico en tiempo de ejecución.",
   "diagram.packageTree": "Arbol de paquetes",
   "diagram.folderMap": "Mapa de carpetas",
   "diagram.inheritanceTree": "Arbol de herencia",

--- a/app/src/i18n/fr.json
+++ b/app/src/i18n/fr.json
@@ -44,6 +44,8 @@
   "diagram.beanGraphLive.applyDiff": "Diff",
   "diagram.beanGraphLive.clearDiff": "Effacer la superposition de diff",
   "diagram.beanGraphLive.changedCount": "{count} modifiés",
+  "diagram.beanGraphLive.flow": "▶ Flux",
+  "diagram.beanGraphLive.flowTitle": "Jouer une vague de requêtes simulée : depuis les contrôleurs, un parcours en largeur suit les arêtes dirigées vers les dépôts, avec des arêtes en pointillés animés et des nœuds qui pulsent, en boucle jusqu'à la désactivation. Flux simulé — ordre topologique, pas le trafic d'exécution.",
   "diagram.packageTree": "Arbre des paquets",
   "diagram.folderMap": "Carte des dossiers",
   "diagram.inheritanceTree": "Arbre d'héritage",

--- a/app/src/i18n/it.json
+++ b/app/src/i18n/it.json
@@ -44,6 +44,8 @@
   "diagram.beanGraphLive.applyDiff": "Diff",
   "diagram.beanGraphLive.clearDiff": "Rimuovi la sovrapposizione diff",
   "diagram.beanGraphLive.changedCount": "{count} modificate",
+  "diagram.beanGraphLive.flow": "▶ Flusso",
+  "diagram.beanGraphLive.flowTitle": "Riproduci un'ondata di richieste simulata: dai controller una BFS percorre gli archi diretti verso i repository, con archi tratteggiati animati e nodi pulsanti, in loop fino allo spegnimento. Flusso simulato — ordine topologico, non traffico di runtime.",
   "diagram.packageTree": "Albero pacchetti",
   "diagram.folderMap": "Mappa delle cartelle",
   "diagram.inheritanceTree": "Albero di ereditarietà",

--- a/app/src/lib/diagrams/beanGraphFlow.test.ts
+++ b/app/src/lib/diagrams/beanGraphFlow.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest';
+import { planBeanGraphFlow } from './beanGraphFlow';
+import { beanGraphElements } from './beanGraphElements';
+import type { BeanGraphData } from '../api';
+
+/// Build elements from a compact payload, reusing the real mapping so the plan
+/// is exercised against exactly the `{ nodes, edges }` shape the component
+/// feeds it (stereoClass derivation, edge ids `e0`/`e1`/…, dropped danglers).
+function els(payload: BeanGraphData) {
+  return beanGraphElements(payload);
+}
+
+/// A textbook Controller → Service → Repository chain, plus a second service the
+/// controller also calls, so a wave can have more than one node.
+///
+///   Ctrl ──► Svc ──► Repo
+///        └──► Svc2
+function layered(): BeanGraphData {
+  return {
+    nodes: [
+      { id: 'Ctrl', label: 'Ctrl', module: 'g:m', stereotype: 'rest-controller', path: 'Ctrl.java' },
+      { id: 'Svc', label: 'Svc', module: 'g:m', stereotype: 'service', path: 'Svc.java' },
+      { id: 'Svc2', label: 'Svc2', module: 'g:m', stereotype: 'service', path: 'Svc2.java' },
+      { id: 'Repo', label: 'Repo', module: 'g:m', stereotype: 'repository', path: 'Repo.java' },
+    ],
+    edges: [
+      { from: 'Ctrl', to: 'Svc', kind: 'injects' },
+      { from: 'Ctrl', to: 'Svc2', kind: 'injects' },
+      { from: 'Svc', to: 'Repo', kind: 'calls' },
+    ],
+  };
+}
+
+describe('planBeanGraphFlow — entry detection', () => {
+  it('seeds the flow from controller stereotypes', () => {
+    const plan = planBeanGraphFlow(els(layered()));
+    expect(plan.animate).toBe(true);
+    expect(plan.entryNodeIds).toEqual(['Ctrl']);
+    // Wave 0 = the controller frontier, no carrying edges.
+    expect(plan.waves[0]).toEqual({ nodeIds: ['Ctrl'], edgeIds: [] });
+  });
+
+  it('groups nodes into waves by BFS depth, controller → service → repo', () => {
+    const plan = planBeanGraphFlow(els(layered()));
+    expect(plan.waves.map((w) => w.nodeIds)).toEqual([
+      ['Ctrl'],
+      ['Svc', 'Svc2'],
+      ['Repo'],
+    ]);
+  });
+
+  it('picks up plain (non-rest) controllers too', () => {
+    const plan = planBeanGraphFlow(
+      els({
+        nodes: [
+          { id: 'C', label: 'C', module: 'g:m', stereotype: 'controller', path: 'C.java' },
+          { id: 'S', label: 'S', module: 'g:m', stereotype: 'service', path: 'S.java' },
+        ],
+        edges: [{ from: 'C', to: 'S', kind: 'injects' }],
+      }),
+    );
+    expect(plan.entryNodeIds).toEqual(['C']);
+  });
+});
+
+describe('planBeanGraphFlow — edge → wave assignment', () => {
+  it('assigns each edge to the wave in which its target is first reached', () => {
+    const plan = planBeanGraphFlow(els(layered()));
+    const elements = els(layered());
+    // Resolve ids for readability: which edge is Ctrl→Svc etc.
+    const idOf = (from: string, to: string) =>
+      elements.edges.find((e) => e.data.source === from && e.data.target === to)!.data.id;
+
+    // Wave 0 carries no edge (the entry frontier).
+    expect(plan.waves[0].edgeIds).toEqual([]);
+    // Wave 1 carries the two controller→service edges (Svc, Svc2 first reached).
+    expect(plan.waves[1].edgeIds.sort()).toEqual([idOf('Ctrl', 'Svc'), idOf('Ctrl', 'Svc2')].sort());
+    // Wave 2 carries the service→repo edge (Repo first reached).
+    expect(plan.waves[2].edgeIds).toEqual([idOf('Svc', 'Repo')]);
+  });
+
+  it('emits each reachable edge in at most one wave', () => {
+    const plan = planBeanGraphFlow(els(layered()));
+    const all = plan.waves.flatMap((w) => w.edgeIds);
+    expect(new Set(all).size).toBe(all.length);
+  });
+});
+
+describe('planBeanGraphFlow — fallbacks', () => {
+  it('falls back to fan-in-0 sources when there is no controller', () => {
+    // No controller stereotype anywhere; Root has no incoming edge → the source.
+    const plan = planBeanGraphFlow(
+      els({
+        nodes: [
+          { id: 'Root', label: 'Root', module: 'g:m', stereotype: 'service', path: 'Root.java' },
+          { id: 'Leaf', label: 'Leaf', module: 'g:m', stereotype: 'repository', path: 'Leaf.java' },
+        ],
+        edges: [{ from: 'Root', to: 'Leaf', kind: 'calls' }],
+      }),
+    );
+    expect(plan.entryNodeIds).toEqual(['Root']);
+    expect(plan.waves.map((w) => w.nodeIds)).toEqual([['Root'], ['Leaf']]);
+  });
+
+  it('falls back to the sorted-first node when every node is in a cycle', () => {
+    // A ↔ B ring: neither is a controller, both have an incoming edge, so the
+    // only tiebreaker left is sorted-first id.
+    const plan = planBeanGraphFlow(
+      els({
+        nodes: [
+          { id: 'B', label: 'B', module: 'g:m', stereotype: 'service', path: 'B.java' },
+          { id: 'A', label: 'A', module: 'g:m', stereotype: 'service', path: 'A.java' },
+        ],
+        edges: [
+          { from: 'A', to: 'B', kind: 'calls' },
+          { from: 'B', to: 'A', kind: 'calls' },
+        ],
+      }),
+    );
+    expect(plan.entryNodeIds).toEqual(['A']);
+  });
+});
+
+describe('planBeanGraphFlow — cycles & reachability', () => {
+  it('terminates on a cycle without revisiting nodes', () => {
+    // Ctrl → A → B → A (back-edge). BFS must not loop.
+    const plan = planBeanGraphFlow(
+      els({
+        nodes: [
+          { id: 'Ctrl', label: 'Ctrl', module: 'g:m', stereotype: 'controller', path: 'Ctrl.java' },
+          { id: 'A', label: 'A', module: 'g:m', stereotype: 'service', path: 'A.java' },
+          { id: 'B', label: 'B', module: 'g:m', stereotype: 'service', path: 'B.java' },
+        ],
+        edges: [
+          { from: 'Ctrl', to: 'A', kind: 'injects' },
+          { from: 'A', to: 'B', kind: 'calls' },
+          { from: 'B', to: 'A', kind: 'calls' }, // back-edge closes the cycle
+        ],
+      }),
+    );
+    // Every node visited exactly once, across the whole plan.
+    const visited = plan.waves.flatMap((w) => w.nodeIds);
+    expect(visited.sort()).toEqual(['A', 'B', 'Ctrl']);
+    expect(new Set(visited).size).toBe(visited.length);
+    // The back-edge B→A does not appear (A already reached) — each node's
+    // carrying edge is emitted once.
+    const edgeCount = plan.waves.flatMap((w) => w.edgeIds).length;
+    expect(edgeCount).toBe(2); // Ctrl→A and A→B only
+  });
+
+  it('leaves unreachable islands out of the plan', () => {
+    // Ctrl → Svc is one component; Island1 → Island2 is disconnected and has no
+    // controller, so it is never reached from the entry frontier.
+    const plan = planBeanGraphFlow(
+      els({
+        nodes: [
+          { id: 'Ctrl', label: 'Ctrl', module: 'g:m', stereotype: 'controller', path: 'Ctrl.java' },
+          { id: 'Svc', label: 'Svc', module: 'g:m', stereotype: 'service', path: 'Svc.java' },
+          { id: 'Island1', label: 'I1', module: 'g:m', stereotype: 'service', path: 'I1.java' },
+          { id: 'Island2', label: 'I2', module: 'g:m', stereotype: 'repository', path: 'I2.java' },
+        ],
+        edges: [
+          { from: 'Ctrl', to: 'Svc', kind: 'injects' },
+          { from: 'Island1', to: 'Island2', kind: 'calls' },
+        ],
+      }),
+    );
+    const reached = plan.waves.flatMap((w) => w.nodeIds);
+    expect(reached.sort()).toEqual(['Ctrl', 'Svc']);
+    expect(reached).not.toContain('Island1');
+    expect(reached).not.toContain('Island2');
+  });
+});
+
+describe('planBeanGraphFlow — degenerate graphs', () => {
+  it('an empty graph plans no animation', () => {
+    const plan = planBeanGraphFlow(els({ nodes: [], edges: [] }));
+    expect(plan.animate).toBe(false);
+    expect(plan.waves).toEqual([]);
+    expect(plan.entryNodeIds).toEqual([]);
+  });
+
+  it('a single isolated node is one wave and animates', () => {
+    const plan = planBeanGraphFlow(
+      els({
+        nodes: [{ id: 'Solo', label: 'Solo', module: 'g:m', stereotype: null, path: 'Solo.java' }],
+        edges: [],
+      }),
+    );
+    expect(plan.animate).toBe(true);
+    expect(plan.waves).toEqual([{ nodeIds: ['Solo'], edgeIds: [] }]);
+  });
+
+  it('does not mutate the elements it is handed', () => {
+    const elements = els(layered());
+    const nodesBefore = elements.nodes.length;
+    const edgesBefore = elements.edges.length;
+    planBeanGraphFlow(elements);
+    expect(elements.nodes.length).toBe(nodesBefore);
+    expect(elements.edges.length).toBe(edgesBefore);
+  });
+});

--- a/app/src/lib/diagrams/beanGraphFlow.ts
+++ b/app/src/lib/diagrams/beanGraphFlow.ts
@@ -1,0 +1,159 @@
+/// Pure BFS-wave planner for the bean-graph *flow* mode
+/// (`bean-graph-live`, V4.1 / #200 fourth toolbar mode). The stateful Cytoscape
+/// mount and the actual marching-ants / pulse animation live in
+/// `app/src/components/BeanGraphLive.svelte`; this module holds the part that
+/// can be unit-tested without a DOM: turning the graph elements into the ordered
+/// waves a simulated request travels through, so the component just plays them.
+///
+/// ## What "flow" means (honesty rule #61)
+///
+/// ProjectMind is a read-only current-state browser — there is no live request
+/// stream to animate. "Flow" is a *simulated* request wave: a BFS from the entry
+/// stereotypes (rest-controller / controller) along the directed relation edges
+/// towards the repositories, surfaced as marching-ants edges + node pulses. It
+/// answers "how does a request topologically travel through this system", not
+/// "what traffic is happening now" — the toolbar tooltip says exactly that.
+///
+/// ## Wave construction
+///
+/// - **Entry nodes** are the ones whose `stereoClass` is a controller
+///   (`stereo-rest-controller` / `stereo-controller`). If a graph has none
+///   (e.g. a non-Spring repo, or one where controllers weren't parsed), we fall
+///   back to the nodes with no incoming edge (the topological sources); if there
+///   are none of those either (every node is in a cycle), we fall back to the
+///   first node in sorted id order so the animation always has a start. An empty
+///   graph yields `{ waves: [], animate: false }`.
+/// - **BFS with a visited set** makes cycles (a `calls` edge can point back)
+///   terminate: every node is enqueued at most once, at the depth it is first
+///   reached. Waves are grouped by that depth — wave 0 is the entry frontier,
+///   wave `k` the nodes first reached at distance `k`.
+/// - **Edges belong to the wave in which their *target* is first reached** — the
+///   edge that "carries" the request into a node lights up together with that
+///   node's arrival. An edge into an already-visited node (a back-edge closing a
+///   cycle, or a second path to the same node) is not re-emitted, so each edge
+///   appears in at most one wave.
+/// - **Unreachable nodes** (no directed path from any entry) are left out of the
+///   plan entirely; the component fades them for the duration of the flow so the
+///   travelled path reads as the signal.
+///
+/// Kept dependency-free (no `cytoscape` import) so the plan stays a plain
+/// function the component feeds into `cy` animation calls — same pattern as
+/// `beanGraphMorph.ts` / `beanGraphDiff.ts`.
+
+import type { BeanGraphElements } from './beanGraphElements';
+
+/// The stereotype classes that seed the flow (a request enters the system at a
+/// controller). Mirrors the `stereoClass` values `beanGraphElements` emits.
+const ENTRY_STEREO_CLASSES = new Set(['stereo-rest-controller', 'stereo-controller']);
+
+/// One BFS frontier: the node ids first reached at this depth and the edge ids
+/// that carried the request into them. Both are ordered by first-encounter so a
+/// replay is deterministic (tests can pin the exact wave contents).
+export interface FlowWave {
+  nodeIds: string[];
+  edgeIds: string[];
+}
+
+/// The plan the component plays: the ordered waves, the entry frontier it seeded
+/// from (echoed for the toolbar / debugging), and whether there is anything to
+/// animate. `animate` is false only for an empty graph — any non-empty graph has
+/// at least one entry node and therefore at least one wave.
+export interface FlowPlan {
+  waves: FlowWave[];
+  entryNodeIds: string[];
+  animate: boolean;
+}
+
+/// Pick the entry frontier: controllers first, then topological sources (no
+/// incoming edge), then the single sorted-first node. Returns [] only for an
+/// empty node set.
+function pickEntryNodeIds(
+  els: BeanGraphElements,
+  hasIncoming: Set<string>,
+): string[] {
+  const controllers = els.nodes
+    .filter((n) => ENTRY_STEREO_CLASSES.has(n.data.stereoClass))
+    .map((n) => n.data.id);
+  if (controllers.length > 0) return controllers;
+
+  const sources = els.nodes
+    .filter((n) => !hasIncoming.has(n.data.id))
+    .map((n) => n.data.id);
+  if (sources.length > 0) return sources;
+
+  // Every node has an incoming edge (fully cyclic) — seed from the sorted-first
+  // node so the wave still has somewhere to start.
+  const ids = els.nodes.map((n) => n.data.id).sort();
+  return ids.length > 0 ? [ids[0]] : [];
+}
+
+/// Build the BFS flow plan from the graph elements. Pure: empty in → empty out,
+/// deterministic, never throws.
+///
+/// See the module header for the full contract (entry selection, cycle
+/// termination, edge→wave assignment, unreachable-node handling).
+export function planBeanGraphFlow(els: BeanGraphElements): FlowPlan {
+  if (els.nodes.length === 0) {
+    return { waves: [], entryNodeIds: [], animate: false };
+  }
+
+  // Adjacency + incoming-edge presence in one pass. `outgoing` maps a source id
+  // to its (target, edgeId) pairs, in element order so BFS is deterministic.
+  const outgoing = new Map<string, { target: string; edgeId: string }[]>();
+  const hasIncoming = new Set<string>();
+  const nodeIds = new Set(els.nodes.map((n) => n.data.id));
+  for (const e of els.edges) {
+    // Defensive: beanGraphElements already drops dangling edges, but guard so a
+    // stray endpoint can never seed a phantom node into a wave.
+    if (!nodeIds.has(e.data.source) || !nodeIds.has(e.data.target)) continue;
+    let list = outgoing.get(e.data.source);
+    if (!list) {
+      list = [];
+      outgoing.set(e.data.source, list);
+    }
+    list.push({ target: e.data.target, edgeId: e.data.id });
+    hasIncoming.add(e.data.target);
+  }
+
+  const entryNodeIds = pickEntryNodeIds(els, hasIncoming);
+
+  // Standard level-order BFS. `visited` guards against cycles and re-entry; a
+  // node is added to exactly the wave (depth) it is first reached at, and the
+  // edge that first reaches it is the one emitted for that wave.
+  const visited = new Set<string>();
+  const waves: FlowWave[] = [];
+
+  // Frontier of the current wave: node ids reached at this depth, plus the edge
+  // ids that carried the request into them. Entry nodes have no carrying edge.
+  let frontierNodes: string[] = [];
+  const seededEdges: string[] = [];
+  for (const id of entryNodeIds) {
+    if (!visited.has(id)) {
+      visited.add(id);
+      frontierNodes.push(id);
+    }
+  }
+  if (frontierNodes.length > 0) {
+    waves.push({ nodeIds: frontierNodes, edgeIds: seededEdges });
+  }
+
+  while (frontierNodes.length > 0) {
+    const nextNodes: string[] = [];
+    const nextEdges: string[] = [];
+    for (const src of frontierNodes) {
+      const outs = outgoing.get(src);
+      if (!outs) continue;
+      for (const { target, edgeId } of outs) {
+        if (visited.has(target)) continue; // cycle / already reached — skip
+        visited.add(target);
+        nextNodes.push(target);
+        nextEdges.push(edgeId);
+      }
+    }
+    if (nextNodes.length === 0) break;
+    waves.push({ nodeIds: nextNodes, edgeIds: nextEdges });
+    frontierNodes = nextNodes;
+  }
+
+  return { waves, entryNodeIds, animate: true };
+}

--- a/docs/sketches/claude-living-flow.md
+++ b/docs/sketches/claude-living-flow.md
@@ -1,0 +1,22 @@
+# Living bean-graph — simulated request flow (#66 „Living architecture")
+
+**Concept.** ProjectMind is a read-only current-state browser: there is no live
+request stream to animate. The honest "living" reading is a *simulated* request
+wave: BFS from the entry stereotypes (rest-controller/controller) along the
+directed relation edges towards the repositories, rendered as marching-ants
+edges + node pulses, looping. A second overlay maps real `commit_activity`
+onto module halos ("the parts of the system that are alive *in the repo*").
+
+**Question it answers.** "How does a request topologically travel through this
+system, and which parts are actually being worked on right now?"
+
+**Candidate library.** Cytoscape.js (already shipped) — `line-dash-offset`
+animation, no new dependency. Explicitly *not* a particle engine.
+
+**Mock.**
+  (Ctrl)●━ants━▶(Svc)○──▶(Repo)○      wave 0: controllers pulse
+  (Ctrl)●━ants━▶(Svc)○──▶(Repo)○      wave 1: services + edges
+                                       wave 2: repositories … loop
+
+**Honesty rule (#61).** The animation is labelled "simulated flow — topology
+order, not runtime traffic" in the toolbar tooltip.


### PR DESCRIPTION
## V4.1 — Living Flow mode in the bean graph

Adds a fourth toolbar mode **▶ Flow** to `bean-graph-live`: a *simulated* request wave that BFS-travels from the controller entry stereotypes (`stereo-rest-controller` / `stereo-controller`) along the directed relation edges towards the repositories, looping until toggled off. **Frontend-only, no new dependency** — Cytoscape animates `line-dash-offset` natively.

### How the flow animates (Cytoscape mechanics)
- **Marching-ants edges:** the frontier edges get `.flow-active` (`line-style: dashed`, `line-dash-pattern: [8,4]`, blue accent). A single `requestAnimationFrame` loop batches one `cy.edges('.flow-active').style('line-dash-offset', -(elapsed/16) % 12)` call per frame so the dashes scroll — no particle canvas.
- **Wave stepping:** a recursive `setTimeout` (~450 ms) advances the frontier. Each wave promotes the previous frontier's edges to `.flow-visited` (opacity 0.85), lights the new wave's carrying edges, and pulses its arriving nodes via the existing `.pulse` mechanic (generalised into `pulseNodes(ids)`). Everything not yet reached stays `.faded`. After the last wave: 1 s pause → reset → replay.
- **Plan is pure & tested:** `planBeanGraphFlow(els)` (new `app/src/lib/diagrams/beanGraphFlow.ts`, DOM-free, mirroring `beanGraphMorph.ts`) does the BFS with a visited-set (cycle-safe), grouping nodes by depth and assigning each edge to the wave in which its target is first reached. Unreachable islands stay out of the plan and fade during the flow. Entry selection: controllers → fan-in-0 sources → sorted-first node; empty graph → `{ waves: [], animate: false }`.

### Mutual exclusivity
Flow is **not** a since-ref overlay, so it lives in its own `flowActive` bool beside the off/diff/morph `overlayMode` — `resolveOverlayMode` is untouched. Turning Flow on clears the diff/morph overlay and vice-versa. Timers + rAF are torn down in `onDestroy` and on toggle-off (mirroring `clearMorphTimers`); all flow classes are stripped. The Flow button is visible when `embedded` too (a walkthrough step can play it), default off.

### Files
- **NEW** `app/src/lib/diagrams/beanGraphFlow.ts` — pure `planBeanGraphFlow`.
- **NEW** `app/src/lib/diagrams/beanGraphFlow.test.ts` — 12 tests (entry detection, both fallbacks, cycle termination, edge→wave assignment, unreachable island, empty-graph `animate:false`).
- **EDIT** `app/src/components/BeanGraphLive.svelte` — `.flow-active`/`.flow-visited` stylesheet, `▶ Flow` toggle button, wave playback + rAF loop, cleanup.
- **EDIT** `app/src/i18n/{en,de,fr,it,es}.json` — `diagram.beanGraphLive.flow` + `.flowTitle` (tooltip honest per #61: "simulated flow — topology order, not runtime traffic"). No new diagram kind → `i18nDiagramKeys.test.ts` untouched.
- **NEW** `docs/sketches/claude-living-flow.md` — sketch, per the #66 process.

### Gates
- `svelte-check`: **0 errors / 0 warnings**
- `vitest`: **406 passed** (28 files, incl. 12 new `beanGraphFlow` tests)
- `vite build`: **green** (cytoscape stays lazy; flow code adds a few KB to the main chunk, no new dependency)
- No Rust / Cargo touched. (`eslint` has no flat config in the repo — pre-existing/known, unrelated to this change.)

Closes #200
Refs #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJuL4nSq1EvgahTJe1hom1