### PR TITLE
feat(tour-scaffold): auto-narrated tour MCP tool (V4.4)

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -40,6 +40,7 @@ pub mod state;
 pub mod tour_embed;
 pub mod tour_index;
 pub mod tour_pdf;
+pub mod tour_suggest;
 pub mod tts;
 pub mod walkthrough;
 

--- a/crates/core/src/tour_suggest.rs
+++ b/crates/core/src/tour_suggest.rs
@@ -1,0 +1,845 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Auto-narrated tour scaffolding (#201, V4.4).
+//!
+//! ProjectMind is an MCP *server*; the LLM is the *client*. There is no
+//! LLM-call path in this repo and this module does not add one. Instead it
+//! composes the existing importance heuristics into a machine-readable
+//! *scaffold*: a ranked list of the modules worth touring plus ready-made
+//! step targets. The client (Claude) turns the `facts` bullets into prose
+//! and drives the existing `walkthrough_start`; a server-side `materialize`
+//! mode (in the MCP layer) fills the narration from a template so an
+//! offline / TTS demo works without any client LLM.
+//!
+//! The ranking is a pure, deterministic function of three signals that are
+//! already computed elsewhere:
+//!
+//! - **coupling** — a module's cross-module edges (`incoming + outgoing`)
+//!   from [`crate::module_chord`]. Central modules earn a tour stop.
+//! - **size** — the module's class count. Bigger modules carry more of the
+//!   story.
+//! - **activity** — commits in the trailing 90-day window from
+//!   [`crate::git::commit_activity`]. Hot modules are where change happens.
+//!
+//! Each signal is min-max normalised across the modules, then combined with
+//! the weights in [`TourWeights`] (default `0.4 / 0.3 / 0.3`). The top class
+//! of each module is the highest-`fan_in` class from [`crate::risk::compute`]
+//! — the one the most other classes depend on.
+
+use projectmind_plugin_api::FrameworkPlugin;
+use serde::Serialize;
+
+use crate::git::{self, CommitActivity};
+use crate::module_chord::{self, ModuleChord};
+use crate::repository::Repository;
+use crate::risk::{self, Options as RiskOptions, RiskScore};
+
+/// Commits inside this trailing window count toward the "activity" signal.
+pub const ACTIVITY_WINDOW_DAYS: u64 = 90;
+
+/// Weight applied to the (normalised) cross-module coupling signal.
+pub const DEFAULT_WEIGHT_COUPLING: f64 = 0.4;
+/// Weight applied to the (normalised) class-count signal.
+pub const DEFAULT_WEIGHT_SIZE: f64 = 0.3;
+/// Weight applied to the (normalised) 90-day commit-activity signal.
+pub const DEFAULT_WEIGHT_ACTIVITY: f64 = 0.3;
+
+/// Weights blending the three module-ranking signals into a score.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct TourWeights {
+    /// Weight on cross-module coupling (`incoming + outgoing`).
+    pub coupling: f64,
+    /// Weight on class count.
+    pub size: f64,
+    /// Weight on 90-day commit activity.
+    pub activity: f64,
+}
+
+impl Default for TourWeights {
+    fn default() -> Self {
+        Self {
+            coupling: DEFAULT_WEIGHT_COUPLING,
+            size: DEFAULT_WEIGHT_SIZE,
+            activity: DEFAULT_WEIGHT_ACTIVITY,
+        }
+    }
+}
+
+/// Which audience the tour is pitched at. Only affects framing text today;
+/// the ranking is identical so the scaffold stays deterministic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Persona {
+    /// Someone new to the codebase — the default. Leads with orientation.
+    NewDev,
+    /// An architect — leads with coupling / hotspots.
+    Architect,
+}
+
+impl Persona {
+    /// Parse the wire value. Unknown strings fall back to [`Persona::NewDev`].
+    #[must_use]
+    pub fn parse(raw: &str) -> Self {
+        match raw {
+            "architect" => Self::Architect,
+            _ => Self::NewDev,
+        }
+    }
+
+    /// A one-line framing sentence for the opening `Overview` step.
+    const fn overview_hint(self) -> &'static str {
+        match self {
+            Self::NewDev => "Start here to get oriented before reading any source.",
+            Self::Architect => {
+                "The most-coupled and busiest modules first — where the design lives."
+            }
+        }
+    }
+}
+
+/// The top class of a module, with the numbers that made it the pick.
+#[derive(Debug, Clone, Serialize)]
+pub struct TopClass {
+    /// Fully-qualified class name.
+    pub fqn: String,
+    /// Composite 0..=100 risk score (from [`crate::risk`]).
+    pub risk_score: f64,
+    /// How many other classes reference it (fan-in) — the reason it's the pick.
+    pub fan_in: u32,
+    /// Short human-readable hint (`why` from the risk atlas, e.g. `hot+central`).
+    pub why: String,
+}
+
+/// One ranked module in the tour.
+#[derive(Debug, Clone, Serialize)]
+pub struct RankedModule {
+    /// Module id (matches `repo.modules` key).
+    pub module: String,
+    /// Blended 0..=1 ranking score (higher = more tour-worthy).
+    pub score: f64,
+    /// Number of classes parsed for the module.
+    pub classes: usize,
+    /// Inbound cross-module edges.
+    pub fan_in: usize,
+    /// Outbound cross-module edges.
+    pub fan_out: usize,
+    /// Commits touching the module in the last 90 days.
+    pub commits_90d: usize,
+    /// The module's most-depended-on class, or `None` when it has no classes.
+    pub top_class: Option<TopClass>,
+    /// Human-readable bullets the client can narrate verbatim or paraphrase.
+    pub facts: Vec<String>,
+}
+
+/// The target of a suggested step, mirroring the [`crate::walkthrough`]
+/// target kinds the viewers already understand. Kept as a small local enum
+/// so `tour_suggest` stays free of walkthrough IO; the MCP layer maps these
+/// onto real `WalkthroughTarget`s when materialising.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum StepTarget {
+    /// Narration-only intro (`WalkthroughTarget::Note`).
+    Note,
+    /// The Risk Atlas treemap, optionally ringing named hotspots.
+    Atlas {
+        /// Fully-qualified class names to ring as hotspots.
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        highlight: Vec<String>,
+    },
+    /// A single class in the open repo (`WalkthroughTarget::Class`).
+    Class {
+        /// Fully-qualified class name to open.
+        fqn: String,
+    },
+}
+
+/// One suggested tour step: a title, a ready-made target, and the facts the
+/// client should weave into narration.
+#[derive(Debug, Clone, Serialize)]
+pub struct SuggestedStep {
+    /// Short step title (sidebar entry).
+    pub title: String,
+    /// Where the step points.
+    pub target: StepTarget,
+    /// Facts to narrate. Empty is legal (a pure framing step).
+    pub facts: Vec<String>,
+}
+
+/// Repository-level headline numbers for the tour intro.
+#[derive(Debug, Clone, Serialize)]
+pub struct RepoHead {
+    /// Display title (the repo directory name).
+    pub title: String,
+    /// Total module count.
+    pub modules_total: usize,
+    /// Total class count.
+    pub classes_total: usize,
+}
+
+/// The full scaffold returned to the caller.
+#[derive(Debug, Clone, Serialize)]
+pub struct TourScaffold {
+    /// Repository headline numbers.
+    pub repo: RepoHead,
+    /// Ranked modules, highest score first, capped at the requested `top`.
+    pub ranking: Vec<RankedModule>,
+    /// Ready-made steps: an overview, one per ranked module, and a closing
+    /// "where change happens" atlas step.
+    pub suggested_steps: Vec<SuggestedStep>,
+}
+
+/// Build a tour scaffold for `repo` using `framework` for relations.
+///
+/// `top` caps the number of ranked modules (clamped to at least 1). `persona`
+/// only tweaks framing text, keeping the ranking deterministic. Reads git
+/// history for the activity signal; an empty or non-git repo degrades to a
+/// zero-activity ranking rather than erroring.
+///
+/// An empty repo yields an empty `ranking` and a lone `Overview` step — never
+/// an error.
+#[must_use]
+pub fn suggest_tour(
+    repo: &Repository,
+    framework: &dyn FrameworkPlugin,
+    top: usize,
+    persona: Persona,
+) -> TourScaffold {
+    suggest_tour_with(repo, framework, top, persona, TourWeights::default())
+}
+
+/// [`suggest_tour`] with explicit weights — the seam the unit tests drive.
+#[must_use]
+pub fn suggest_tour_with(
+    repo: &Repository,
+    framework: &dyn FrameworkPlugin,
+    top: usize,
+    persona: Persona,
+    weights: TourWeights,
+) -> TourScaffold {
+    let top = top.max(1);
+    let chord = module_chord::build(repo, framework);
+    let activity = git::commit_activity(&repo.root);
+    let relations = collect_relations(repo, framework);
+    let top_classes = top_class_per_module(repo, &relations);
+
+    let ranked = rank_modules(&chord, &activity, &top_classes, weights, top);
+    let steps = build_steps(&ranked, persona);
+
+    TourScaffold {
+        repo: RepoHead {
+            title: repo_title(repo),
+            modules_total: repo.modules.len(),
+            classes_total: repo.class_count(),
+        },
+        ranking: ranked,
+        suggested_steps: steps,
+    }
+}
+
+/// Flatten every framework relation across the repo (same shape the risk
+/// atlas feeds on). Kept local so core need not depend on the engine.
+fn collect_relations(
+    repo: &Repository,
+    framework: &dyn FrameworkPlugin,
+) -> Vec<projectmind_plugin_api::Relation> {
+    let mut out = Vec::new();
+    for module in repo.modules.values() {
+        out.extend(framework.relations(module));
+    }
+    out
+}
+
+/// Compute risk once over the whole repo, then keep the highest-`fan_in`
+/// class per module. One git-churn walk instead of one per module.
+fn top_class_per_module(
+    repo: &Repository,
+    relations: &[projectmind_plugin_api::Relation],
+) -> std::collections::HashMap<String, TopClass> {
+    let opts = RiskOptions {
+        module: None,
+        // Ask for every class so no module drops off the tail.
+        top: repo.class_count().max(1),
+        window_days: risk::DEFAULT_CHURN_WINDOW_DAYS,
+        weights: risk::Weights::default(),
+    };
+    // Coverage is optional and orthogonal to fan-in selection; skip it here so
+    // the scaffold never depends on a test run having happened. A non-git repo
+    // (or any risk error) degrades to "no top classes" rather than failing.
+    let Ok(scores) = risk::compute(repo, relations, None, &opts) else {
+        return std::collections::HashMap::new();
+    };
+
+    let mut best: std::collections::HashMap<String, RiskScore> = std::collections::HashMap::new();
+    for s in scores {
+        best.entry(s.module.clone())
+            .and_modify(|cur| {
+                if is_better_top(&s, cur) {
+                    *cur = s.clone();
+                }
+            })
+            .or_insert(s);
+    }
+
+    best.into_iter()
+        .map(|(module, s)| {
+            (
+                module,
+                TopClass {
+                    fqn: s.fqn,
+                    risk_score: s.score,
+                    fan_in: s.fan_in,
+                    why: s.why,
+                },
+            )
+        })
+        .collect()
+}
+
+/// A class beats the current pick when it has a higher fan-in, or an equal
+/// fan-in with a higher risk score. Ties break on fqn for determinism.
+fn is_better_top(candidate: &RiskScore, current: &RiskScore) -> bool {
+    match candidate.fan_in.cmp(&current.fan_in) {
+        std::cmp::Ordering::Greater => true,
+        std::cmp::Ordering::Less => false,
+        std::cmp::Ordering::Equal => match candidate
+            .score
+            .partial_cmp(&current.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+        {
+            std::cmp::Ordering::Greater => true,
+            std::cmp::Ordering::Less => false,
+            std::cmp::Ordering::Equal => candidate.fqn < current.fqn,
+        },
+    }
+}
+
+/// Count commits within the 90-day window for `module` from the (24-month)
+/// activity payload.
+fn commits_90d_for(activity: &CommitActivity, module: &str) -> usize {
+    let cutoff = ACTIVITY_WINDOW_DAYS * 86_400;
+    activity
+        .modules
+        .iter()
+        .find(|m| m.module == module)
+        .map_or(0, |m| {
+            m.commits.iter().filter(|c| c.secs_ago <= cutoff).count()
+        })
+}
+
+/// Min-max normalise `v` into 0..=1 given the observed `max`. A zero max
+/// (every module equal / empty) maps everything to 0 so the signal simply
+/// doesn't move the ranking.
+fn norm(v: f64, max: f64) -> f64 {
+    if max <= 0.0 {
+        0.0
+    } else {
+        v / max
+    }
+}
+
+/// Score and sort the modules, capping at `top`.
+fn rank_modules(
+    chord: &ModuleChord,
+    activity: &CommitActivity,
+    top_classes: &std::collections::HashMap<String, TopClass>,
+    weights: TourWeights,
+    top: usize,
+) -> Vec<RankedModule> {
+    struct Row {
+        module: String,
+        classes: usize,
+        fan_in: usize,
+        fan_out: usize,
+        coupling: usize,
+        commits_90d: usize,
+    }
+
+    let mut rows: Vec<Row> = chord
+        .modules
+        .iter()
+        .map(|m| {
+            let commits_90d = commits_90d_for(activity, &m.id);
+            Row {
+                module: m.id.clone(),
+                classes: m.classes,
+                fan_in: m.incoming,
+                fan_out: m.outgoing,
+                coupling: m.incoming + m.outgoing,
+                commits_90d,
+            }
+        })
+        .collect();
+
+    let max_coupling = rows.iter().map(|r| r.coupling).max().unwrap_or(0) as f64;
+    let max_classes = rows.iter().map(|r| r.classes).max().unwrap_or(0) as f64;
+    let max_commits = rows.iter().map(|r| r.commits_90d).max().unwrap_or(0) as f64;
+
+    let mut ranked: Vec<RankedModule> = rows
+        .drain(..)
+        .map(|r| {
+            let score = weights.coupling * norm(r.coupling as f64, max_coupling)
+                + weights.size * norm(r.classes as f64, max_classes)
+                + weights.activity * norm(r.commits_90d as f64, max_commits);
+            let top_class = top_classes.get(&r.module).cloned();
+            let facts = module_facts(
+                &r.module,
+                r.fan_in,
+                r.commits_90d,
+                r.classes,
+                top_class.as_ref(),
+            );
+            RankedModule {
+                module: r.module,
+                score: (score * 1000.0).round() / 1000.0,
+                classes: r.classes,
+                fan_in: r.fan_in,
+                fan_out: r.fan_out,
+                commits_90d: r.commits_90d,
+                top_class,
+                facts,
+            }
+        })
+        .collect();
+
+    // Highest score first; ties break on module id for a stable order.
+    ranked.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.module.cmp(&b.module))
+    });
+    ranked.truncate(top);
+    ranked
+}
+
+/// Human-readable bullets for one module.
+fn module_facts(
+    module: &str,
+    fan_in: usize,
+    commits_90d: usize,
+    classes: usize,
+    top_class: Option<&TopClass>,
+) -> Vec<String> {
+    let mut facts = vec![format!(
+        "`{module}` has {classes} class(es), {fan_in} module(s) depend on it, {commits_90d} commit(s) in 90d"
+    )];
+    if fan_in > 0 {
+        facts.push(format!("depended on by {fan_in} module(s) (fan-in)"));
+    }
+    if commits_90d > 0 {
+        facts.push(format!("busy: {commits_90d} commit(s) in the last 90 days"));
+    }
+    if let Some(tc) = top_class {
+        facts.push(format!(
+            "top class `{}` (risk {:.0}, {} class(es) depend on it, {})",
+            tc.fqn, tc.risk_score, tc.fan_in, tc.why
+        ));
+    }
+    facts
+}
+
+/// Build the suggested-step list: Overview → one Class step per ranked module
+/// → a closing "Where change happens" atlas step.
+fn build_steps(ranked: &[RankedModule], persona: Persona) -> Vec<SuggestedStep> {
+    let mut steps = Vec::with_capacity(ranked.len() + 2);
+
+    // Overview — narration-only orientation.
+    let mut overview_facts = vec![persona.overview_hint().to_string()];
+    if let Some(first) = ranked.first() {
+        overview_facts.push(format!(
+            "start with `{}`, the highest-ranked module",
+            first.module
+        ));
+    }
+    steps.push(SuggestedStep {
+        title: "Overview".to_string(),
+        target: StepTarget::Note,
+        facts: overview_facts,
+    });
+
+    // One step per ranked module, pointing at its top class when it has one.
+    for m in ranked {
+        if let Some(tc) = &m.top_class {
+            steps.push(SuggestedStep {
+                title: m.module.clone(),
+                target: StepTarget::Class {
+                    fqn: tc.fqn.clone(),
+                },
+                facts: m.facts.clone(),
+            });
+        } else {
+            steps.push(SuggestedStep {
+                title: m.module.clone(),
+                target: StepTarget::Note,
+                facts: m.facts.clone(),
+            });
+        }
+    }
+
+    // Closing step — the hotspots ringed on the Risk Atlas.
+    let hotspots: Vec<String> = ranked
+        .iter()
+        .filter_map(|m| m.top_class.as_ref().map(|tc| tc.fqn.clone()))
+        .collect();
+    let mut change_facts =
+        vec!["these are the highest-risk classes across the toured modules".to_string()];
+    if !hotspots.is_empty() {
+        change_facts.push(format!("{} hotspot class(es) ringed", hotspots.len()));
+    }
+    steps.push(SuggestedStep {
+        title: "Where change happens".to_string(),
+        target: StepTarget::Atlas {
+            highlight: hotspots,
+        },
+        facts: change_facts,
+    });
+
+    steps
+}
+
+/// Repo display title = the root directory's file name, falling back to the
+/// full path string when there's no file component.
+fn repo_title(repo: &Repository) -> String {
+    repo.root.file_name().map_or_else(
+        || repo.root.to_string_lossy().into_owned(),
+        |s| s.to_string_lossy().into_owned(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use projectmind_plugin_api::{
+        Annotation, Class, Module, PluginInfo, Relation, RelationKind, Result as PluginResult,
+    };
+    use std::path::PathBuf;
+
+    /// Minimal framework that echoes a fixed relation set per module.
+    struct DummyFw {
+        relations: Vec<(String, Vec<Relation>)>,
+    }
+    impl std::fmt::Debug for DummyFw {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str("DummyFw")
+        }
+    }
+    impl FrameworkPlugin for DummyFw {
+        fn info(&self) -> PluginInfo {
+            PluginInfo {
+                id: "t",
+                name: "t",
+                version: "0",
+            }
+        }
+        fn supported_languages(&self) -> &[&'static str] {
+            &["lang-test"]
+        }
+        fn enrich(&self, _: &mut Module) -> PluginResult<()> {
+            Ok(())
+        }
+        fn relations(&self, module: &Module) -> Vec<Relation> {
+            self.relations
+                .iter()
+                .find(|(m, _)| m == &module.id)
+                .map(|(_, r)| r.clone())
+                .unwrap_or_default()
+        }
+        fn provided_diagrams(&self) -> &[&'static str] {
+            &[]
+        }
+    }
+
+    fn klass(fqn: &str) -> Class {
+        Class {
+            name: fqn.rsplit('.').next().unwrap_or(fqn).to_string(),
+            fqn: fqn.to_string(),
+            file: PathBuf::from(format!("{fqn}.java")),
+            line_start: 1,
+            line_end: 1,
+            annotations: vec![Annotation {
+                name: "Marker".into(),
+                fqn: None,
+                raw_args: None,
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn mk_module(id: &str, classes: Vec<Class>) -> Module {
+        mk_module_at(id, PathBuf::from("/tmp/tour-suggest"), classes)
+    }
+
+    fn mk_module_at(id: &str, root: PathBuf, classes: Vec<Class>) -> Module {
+        let mut m = Module {
+            id: id.to_string(),
+            root,
+            ..Default::default()
+        };
+        for c in classes {
+            m.classes.insert(c.fqn.clone(), c);
+        }
+        m
+    }
+
+    fn repo_with(modules: Vec<Module>) -> Repository {
+        // Non-git path → commit_activity degrades to zero activity, no error.
+        let mut r = Repository::new(PathBuf::from("/tmp/tour-suggest-nonexistent"));
+        for m in modules {
+            r.insert_module(m);
+        }
+        r
+    }
+
+    /// A throwaway on-disk git repo. `risk::compute` walks git history, so the
+    /// top-class facts only populate on a real checkout — these tests build a
+    /// tiny one, commit the class files, and clean up on drop.
+    struct TempGitRepo {
+        dir: PathBuf,
+    }
+    impl Drop for TempGitRepo {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+    impl TempGitRepo {
+        fn new(name: &str) -> Self {
+            let dir = std::env::temp_dir().join(format!(
+                "projectmind-tour-{name}-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+            ));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).unwrap();
+            git2::Repository::init(&dir).unwrap();
+            Self { dir }
+        }
+
+        /// Write `<fqn>.java` for every class of every module, then commit.
+        fn commit_classes(&self, modules: &[Module]) {
+            let git = git2::Repository::open(&self.dir).unwrap();
+            let mut index = git.index().unwrap();
+            for m in modules {
+                for class in m.classes.values() {
+                    let path = &class.file;
+                    std::fs::write(
+                        self.dir.join(path),
+                        format!("class {} {{ void f(){{ if(x){{}} }} }}\n", class.name),
+                    )
+                    .unwrap();
+                    index.add_path(path).unwrap();
+                }
+            }
+            index.write().unwrap();
+            let tree_id = index.write_tree().unwrap();
+            let tree = git.find_tree(tree_id).unwrap();
+            let sig = git2::Signature::now("t", "t@t").unwrap();
+            git.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+                .unwrap();
+        }
+    }
+
+    #[test]
+    fn empty_repo_yields_empty_ranking_and_overview_only() {
+        let scaffold = suggest_tour(
+            &repo_with(vec![]),
+            &DummyFw { relations: vec![] },
+            5,
+            Persona::NewDev,
+        );
+        assert!(scaffold.ranking.is_empty());
+        assert_eq!(scaffold.repo.modules_total, 0);
+        assert_eq!(scaffold.repo.classes_total, 0);
+        // Overview + closing step, no per-module steps.
+        assert_eq!(scaffold.suggested_steps.len(), 2);
+        assert_eq!(scaffold.suggested_steps[0].title, "Overview");
+        assert_eq!(scaffold.suggested_steps[1].title, "Where change happens");
+    }
+
+    #[test]
+    fn coupled_module_outranks_isolated_one() {
+        // web → core (2 edges). core is depended on; web depends out.
+        let ctrl = klass("g:web.Ctrl");
+        let svc = klass("g:core.Svc");
+        let lonely = klass("g:util.Lonely");
+        let web = mk_module("g:web", vec![ctrl.clone()]);
+        let core = mk_module("g:core", vec![svc.clone()]);
+        let util = mk_module("g:util", vec![lonely]);
+        let fw = DummyFw {
+            relations: vec![
+                (
+                    "g:web".to_string(),
+                    vec![
+                        Relation {
+                            from: ctrl.fqn.clone(),
+                            to: svc.fqn.clone(),
+                            kind: RelationKind::Injects,
+                        },
+                        Relation {
+                            from: ctrl.fqn.clone(),
+                            to: svc.fqn.clone(),
+                            kind: RelationKind::Calls,
+                        },
+                    ],
+                ),
+                ("g:core".to_string(), vec![]),
+                ("g:util".to_string(), vec![]),
+            ],
+        };
+        let scaffold = suggest_tour(&repo_with(vec![web, core, util]), &fw, 5, Persona::NewDev);
+        // util is coupling-free → ranks last.
+        assert_eq!(scaffold.ranking.len(), 3);
+        assert_ne!(scaffold.ranking.last().unwrap().module, "g:core");
+        assert_eq!(scaffold.ranking.last().unwrap().module, "g:util");
+        // The coupled pair scores above the isolated module.
+        let util_score = scaffold
+            .ranking
+            .iter()
+            .find(|m| m.module == "g:util")
+            .unwrap()
+            .score;
+        let core_score = scaffold
+            .ranking
+            .iter()
+            .find(|m| m.module == "g:core")
+            .unwrap()
+            .score;
+        assert!(core_score > util_score);
+    }
+
+    #[test]
+    fn ranking_is_deterministic() {
+        let mods = || {
+            let a = klass("g:a.A");
+            let b = klass("g:b.B");
+            vec![mk_module("g:a", vec![a]), mk_module("g:b", vec![b])]
+        };
+        let fw = DummyFw { relations: vec![] };
+        let one = suggest_tour(&repo_with(mods()), &fw, 5, Persona::NewDev);
+        let two = suggest_tour(&repo_with(mods()), &fw, 5, Persona::NewDev);
+        let ids_one: Vec<_> = one.ranking.iter().map(|m| m.module.clone()).collect();
+        let ids_two: Vec<_> = two.ranking.iter().map(|m| m.module.clone()).collect();
+        assert_eq!(ids_one, ids_two);
+    }
+
+    #[test]
+    fn top_cap_is_honoured() {
+        let modules: Vec<Module> = (0..6)
+            .map(|i| mk_module(&format!("g:m{i}"), vec![klass(&format!("g:m{i}.C"))]))
+            .collect();
+        let fw = DummyFw { relations: vec![] };
+        let scaffold = suggest_tour(&repo_with(modules), &fw, 3, Persona::NewDev);
+        assert_eq!(scaffold.ranking.len(), 3);
+        // Overview + 3 module steps + closing = 5.
+        assert_eq!(scaffold.suggested_steps.len(), 5);
+    }
+
+    #[test]
+    fn top_zero_is_clamped_to_one() {
+        let fw = DummyFw { relations: vec![] };
+        let scaffold = suggest_tour(
+            &repo_with(vec![mk_module("g:a", vec![klass("g:a.A")])]),
+            &fw,
+            0,
+            Persona::NewDev,
+        );
+        assert_eq!(scaffold.ranking.len(), 1);
+    }
+
+    #[test]
+    fn top_class_is_highest_fan_in() {
+        // Two classes point at core.Hub → Hub has fan-in 2 and should be the
+        // module's top class. Needs a real git repo for risk::compute.
+        let git = TempGitRepo::new("fanin");
+        let hub = klass("g:core.Hub");
+        let leaf = klass("g:core.Leaf");
+        let a = klass("g:web.A");
+        let b = klass("g:web.B");
+        let core = mk_module_at("g:core", git.dir.clone(), vec![hub.clone(), leaf]);
+        let web = mk_module_at("g:web", git.dir.clone(), vec![a.clone(), b.clone()]);
+        git.commit_classes(&[core.clone(), web.clone()]);
+
+        let mut repo = Repository::new(git.dir.clone());
+        repo.insert_module(core);
+        repo.insert_module(web);
+        let fw = DummyFw {
+            relations: vec![(
+                "g:web".to_string(),
+                vec![
+                    Relation {
+                        from: a.fqn.clone(),
+                        to: hub.fqn.clone(),
+                        kind: RelationKind::Uses,
+                    },
+                    Relation {
+                        from: b.fqn.clone(),
+                        to: hub.fqn.clone(),
+                        kind: RelationKind::Uses,
+                    },
+                ],
+            )],
+        };
+        let scaffold = suggest_tour(&repo, &fw, 5, Persona::NewDev);
+        let core_rank = scaffold
+            .ranking
+            .iter()
+            .find(|m| m.module == "g:core")
+            .unwrap();
+        let top = core_rank.top_class.as_ref().expect("core has a top class");
+        assert_eq!(top.fqn, "g:core.Hub");
+        assert_eq!(top.fan_in, 2);
+    }
+
+    #[test]
+    fn persona_parse_falls_back_to_new_dev() {
+        assert_eq!(Persona::parse("architect"), Persona::Architect);
+        assert_eq!(Persona::parse("new-dev"), Persona::NewDev);
+        assert_eq!(Persona::parse("garbage"), Persona::NewDev);
+    }
+
+    #[test]
+    fn steps_point_class_targets_at_top_classes() {
+        let git = TempGitRepo::new("steps");
+        let hub = klass("g:core.Hub");
+        let a = klass("g:web.A");
+        let core = mk_module_at("g:core", git.dir.clone(), vec![hub.clone()]);
+        let web = mk_module_at("g:web", git.dir.clone(), vec![a.clone()]);
+        git.commit_classes(&[core.clone(), web.clone()]);
+
+        let mut repo = Repository::new(git.dir.clone());
+        repo.insert_module(core);
+        repo.insert_module(web);
+        let fw = DummyFw {
+            relations: vec![(
+                "g:web".to_string(),
+                vec![Relation {
+                    from: a.fqn.clone(),
+                    to: hub.fqn.clone(),
+                    kind: RelationKind::Uses,
+                }],
+            )],
+        };
+        let scaffold = suggest_tour(&repo, &fw, 5, Persona::Architect);
+        let core_step = scaffold
+            .suggested_steps
+            .iter()
+            .find(|s| s.title == "g:core")
+            .expect("core module step");
+        match &core_step.target {
+            StepTarget::Class { fqn } => assert_eq!(fqn, "g:core.Hub"),
+            other => panic!("expected class target, got {other:?}"),
+        }
+        // Closing atlas step rings the hotspot.
+        let closing = scaffold.suggested_steps.last().unwrap();
+        match &closing.target {
+            StepTarget::Atlas { highlight } => {
+                assert!(highlight.contains(&"g:core.Hub".to_string()));
+            }
+            other => panic!("expected atlas target, got {other:?}"),
+        }
+    }
+}

--- a/crates/mcp-server/src/tools.rs
+++ b/crates/mcp-server/src/tools.rs
@@ -15,7 +15,10 @@ use projectmind_core::patterns::{self as core_patterns, Pattern, Scope as Patter
 use projectmind_core::risk::{self, Options as RiskOptions, Weights as RiskWeights};
 use projectmind_core::session::{self, Since};
 use projectmind_core::state::{self, UiState, ViewIntent};
-use projectmind_core::walkthrough::{self as wt, QuizQuestion, Walkthrough, WalkthroughStep};
+use projectmind_core::tour_suggest::{self, Persona, StepTarget, SuggestedStep, TourScaffold};
+use projectmind_core::walkthrough::{
+    self as wt, QuizQuestion, Walkthrough, WalkthroughStep, WalkthroughTarget,
+};
 use projectmind_core::{diagram, git, html};
 use projectmind_framework_spring::SpringPlugin;
 use projectmind_plugin_api::FrameworkPlugin;
@@ -360,6 +363,31 @@ fn architect_briefing_schema() -> Value {
     })
 }
 
+fn tour_scaffold_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "top": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 5,
+                "description": "How many modules to rank (and turn into per-module steps). Clamped to at least 1."
+            },
+            "persona": {
+                "type": "string",
+                "enum": ["new-dev", "architect"],
+                "default": "new-dev",
+                "description": "Who the tour is pitched at. Only tweaks the Overview framing text — the ranking is identical (and deterministic) either way. Unknown values fall back to `new-dev`."
+            },
+            "materialize": {
+                "type": "boolean",
+                "default": false,
+                "description": "When false (default) the tool returns ONLY the scaffold — you write `narration` for each step in your own words and call `walkthrough_start` yourself. When true the server persists a walkthrough right away with template narration built from the facts bullets (EN), and returns its `walkthrough_id`; use this for an offline / TTS demo without a client LLM. The materialized steps are still editable via walkthrough_append / _set_step."
+            }
+        }
+    })
+}
+
 fn open_browser_repo_schema() -> Value {
     json!({
         "type": "object",
@@ -560,6 +588,11 @@ pub(crate) fn list() -> Value {
                 "inputSchema": architect_briefing_schema()
             },
             {
+                "name": "tour_scaffold",
+                "description": "Auto-narrated tour scaffold (#201) — the machine skeleton for a \"welcome to this repo\" walkthrough. ProjectMind is the MCP server and YOU are the narrator: this returns a ranked list of the modules worth touring plus ready-made step targets, and you turn the `facts` bullets into prose and call `walkthrough_start`. Ranking blends three signals normalised across modules: cross-module coupling (incoming+outgoing edges, weight 0.4), class count (0.3), and 90-day commit activity (0.3); each module's `top_class` is its highest-fan-in class from the risk atlas. Returns `repo` (title/modules_total/classes_total), `ranking` (top-N modules with score/classes/fan_in/fan_out/commits_90d/top_class/facts), and `suggested_steps` (an Overview note, one Class step per module pointing at its top class, and a closing \"Where change happens\" atlas step ringing the hotspots). Set `materialize: true` to have the server persist the walkthrough immediately with template narration from the facts (for an offline / TTS demo without a client LLM) — the response then also carries `walkthrough_id`. Call this FIRST when the user says \"walk me through this repo\" / \"give me a tour\" and you have no curated tour yet.",
+                "inputSchema": tour_scaffold_schema()
+            },
+            {
                 "name": "open_browser_repo",
                 "description": "Start the in-process browser host that serves the ProjectMind webapp at a tokenized URL, then surface that URL to the user verbatim — they will open it themselves; you cannot. Use after `open in browser` / `im Browser zeigen` / `show me on my iPad / phone / laptop`. Pass `lan: true` whenever the user mentions a remote device (iPad, phone, second machine on the same WLAN) — otherwise the URL is `http://127.0.0.1:...` and unreachable from anything but this machine. The bearer token in the URL fragment gates every API call regardless of bind address. Idempotent: calling again with a different `path` reopens the host on the existing port; call `browser_status` first to avoid restarting the host. Once the user has opened the URL, every subsequent `view_*` / `walkthrough_*` push will mirror to that browser tab in addition to the Desktop GUI.",
                 "inputSchema": open_browser_repo_schema()
@@ -621,6 +654,7 @@ pub(crate) async fn call(state: &Mutex<ServerState>, params: Value) -> DispatchR
         "risk_atlas" => risk_atlas(state, parsed.arguments).await,
         "pattern_check" => pattern_check(state, parsed.arguments).await,
         "architect_briefing" => architect_briefing(state, parsed.arguments).await,
+        "tour_scaffold" => tour_scaffold(state, parsed.arguments).await,
         "open_browser_repo" => open_browser_repo(state, parsed.arguments).await,
         "browser_status" => browser_status(),
         "stop_browser" => stop_browser(),
@@ -1756,6 +1790,136 @@ async fn architect_briefing(state: &Mutex<ServerState>, args: Value) -> Dispatch
     })
 }
 
+#[derive(Deserialize, Default)]
+struct TourScaffoldArgs {
+    #[serde(default)]
+    top: Option<u32>,
+    #[serde(default)]
+    persona: Option<String>,
+    #[serde(default)]
+    materialize: bool,
+}
+
+/// `tour_scaffold` (V4.4, #201): compose the importance heuristics into a
+/// ranked, ready-to-narrate tour skeleton.
+///
+/// `materialize: false` (default) returns only the scaffold — the client
+/// narrates and calls `walkthrough_start`. `materialize: true` persists a
+/// walkthrough right away with template narration built from the facts and
+/// returns its `walkthrough_id`, mirroring the `walkthrough_start` persistence
+/// path so an offline / TTS demo works without a client LLM.
+async fn tour_scaffold(state: &Mutex<ServerState>, args: Value) -> DispatchResult {
+    let args: TourScaffoldArgs = if args.is_null() {
+        TourScaffoldArgs::default()
+    } else {
+        serde_json::from_value(args)
+            .map_err(|e| DispatchError::invalid_params(format!("tour_scaffold: {e}")))?
+    };
+    let top = args.top.map_or(5, |v| v as usize).max(1);
+    let persona = args
+        .persona
+        .as_deref()
+        .map_or(Persona::NewDev, Persona::parse);
+    let materialize = args.materialize;
+
+    let state = state.lock().await;
+    with_repo(&state, |repo| {
+        let spring = SpringPlugin::new();
+        let scaffold = tour_suggest::suggest_tour(repo, &spring, top, persona);
+
+        if !materialize {
+            let body = serde_json::to_string_pretty(&scaffold).unwrap_or_else(|_| "{}".into());
+            return Ok(text_result(body));
+        }
+
+        // Build + persist a walkthrough from the scaffold, then point the
+        // viewers at step 0 — same path walkthrough_start takes.
+        let walkthrough = materialize_walkthrough(&scaffold);
+        let id = walkthrough.id.clone();
+        let step_count = walkthrough.steps.len();
+        if let Err(err) = wt::clear() {
+            tracing::warn!(error = %err, "tour_scaffold: failed to clear previous tour");
+        }
+        let written = wt::write_body(walkthrough)
+            .map_err(|e| DispatchError::internal(format!("tour_scaffold: {e}")))?;
+        let prev = state::read().ok().flatten().unwrap_or_default();
+        publish_state(UiState {
+            repo_root: prev.repo_root,
+            view: ViewIntent::Walkthrough {
+                id: id.clone(),
+                step: 0,
+            },
+            ..UiState::default()
+        });
+        let scaffold_json =
+            serde_json::to_value(&scaffold).unwrap_or_else(|_| json!({"error": "serialise"}));
+        let body = serde_json::to_string_pretty(&json!({
+            "materialized": true,
+            "walkthrough_id": written.id,
+            "total": step_count,
+            "scaffold": scaffold_json,
+        }))
+        .unwrap_or_else(|_| "{}".into());
+        Ok(text_result(body))
+    })
+}
+
+/// Turn a scaffold into a persistable [`Walkthrough`] with template narration
+/// built from each step's facts. English-only; steps stay editable via the
+/// walkthrough tools afterwards.
+fn materialize_walkthrough(scaffold: &TourScaffold) -> Walkthrough {
+    let title = format!("Tour: {}", scaffold.repo.title);
+    let summary = format!(
+        "Auto-generated tour of {} — {} module(s), {} class(es). \
+         Narration is template-generated; edit any step to refine it.",
+        scaffold.repo.title, scaffold.repo.modules_total, scaffold.repo.classes_total
+    );
+    let steps: Vec<WalkthroughStep> = scaffold
+        .suggested_steps
+        .iter()
+        .map(materialize_step)
+        .collect();
+    Walkthrough {
+        schema_version: wt::CURRENT_SCHEMA_VERSION,
+        id: wt::slugify_id(&title),
+        title,
+        summary,
+        steps,
+        quiz: Vec::new(),
+        updated_at: 0,
+    }
+}
+
+/// Map one [`SuggestedStep`] onto a [`WalkthroughStep`], joining its facts
+/// into a plain-markdown bullet list as the template narration.
+fn materialize_step(step: &SuggestedStep) -> WalkthroughStep {
+    let narration = if step.facts.is_empty() {
+        String::new()
+    } else {
+        step.facts
+            .iter()
+            .map(|f| format!("- {f}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    let target = match &step.target {
+        StepTarget::Note => WalkthroughTarget::Note,
+        StepTarget::Class { fqn } => WalkthroughTarget::Class {
+            fqn: fqn.clone(),
+            highlight: Vec::new(),
+        },
+        StepTarget::Atlas { highlight } => WalkthroughTarget::Atlas {
+            module: None,
+            highlight_fqns: highlight.clone(),
+        },
+    };
+    WalkthroughStep {
+        title: step.title.clone(),
+        narration,
+        target,
+    }
+}
+
 /// Web frontend embedded into the MCP binary at compile time.
 ///
 /// The `app/dist` directory must exist at build time — the workspace CI
@@ -1862,8 +2026,77 @@ mod tests {
         assert!(names.contains(&"risk_atlas"));
         assert!(names.contains(&"pattern_check"));
         assert!(names.contains(&"architect_briefing"));
+        assert!(names.contains(&"tour_scaffold"));
         assert!(names.contains(&"present_artifact"));
         assert!(names.contains(&"list_artifacts"));
+    }
+
+    #[test]
+    fn tour_scaffold_schema_documents_top_persona_materialize() {
+        let v = list();
+        let tools = v["tools"].as_array().unwrap();
+        let ts = tools
+            .iter()
+            .find(|t| t["name"] == "tour_scaffold")
+            .expect("tour_scaffold tool registered");
+        let schema = &ts["inputSchema"];
+        assert_eq!(schema["type"], "object");
+        let props = &schema["properties"];
+        assert!(props.get("top").is_some(), "top documented");
+        assert!(props.get("persona").is_some(), "persona documented");
+        assert!(props.get("materialize").is_some(), "materialize documented");
+        // Persona enum lists both audiences.
+        let enum_vals = props["persona"]["enum"].as_array().unwrap();
+        assert!(enum_vals.iter().any(|v| v == "new-dev"));
+        assert!(enum_vals.iter().any(|v| v == "architect"));
+        // Everything is optional.
+        assert!(schema.get("required").is_none());
+    }
+
+    #[test]
+    fn materialize_step_maps_targets_and_narration() {
+        // Class step → Class target with facts joined as a bullet list.
+        let class_step = SuggestedStep {
+            title: "core".into(),
+            target: StepTarget::Class {
+                fqn: "a.Hub".into(),
+            },
+            facts: vec!["fact one".into(), "fact two".into()],
+        };
+        let ws = materialize_step(&class_step);
+        assert_eq!(ws.title, "core");
+        assert!(matches!(ws.target, WalkthroughTarget::Class { .. }));
+        assert!(ws.narration.contains("- fact one"));
+        assert!(ws.narration.contains("- fact two"));
+
+        // Atlas step carries the hotspot fqns.
+        let atlas_step = SuggestedStep {
+            title: "Where change happens".into(),
+            target: StepTarget::Atlas {
+                highlight: vec!["a.Hub".into()],
+            },
+            facts: vec![],
+        };
+        let ws = materialize_step(&atlas_step);
+        match ws.target {
+            WalkthroughTarget::Atlas { highlight_fqns, .. } => {
+                assert_eq!(highlight_fqns, vec!["a.Hub".to_string()]);
+            }
+            other => panic!("expected atlas target, got {other:?}"),
+        }
+        // No facts → empty narration.
+        assert!(ws.narration.is_empty());
+
+        // Note step round-trips to a Note target.
+        let note_step = SuggestedStep {
+            title: "Overview".into(),
+            target: StepTarget::Note,
+            facts: vec!["orient first".into()],
+        };
+        assert!(matches!(
+            materialize_step(&note_step).target,
+            WalkthroughTarget::Note
+        ));
     }
 
     #[test]

--- a/docs/auto-tour.md
+++ b/docs/auto-tour.md
@@ -1,0 +1,107 @@
+# Auto-narrated Tour — `tour_scaffold`
+
+> **Status:** shipped in Viz V4.4 ([#201](https://github.com/Plaintext-Gmbh/projectmind/issues/201)). Part of the "living, wow" visualization track ([#66](https://github.com/Plaintext-Gmbh/projectmind/issues/66)).
+
+## Why a *scaffold*, not a tour generator
+
+ProjectMind is the MCP **server**; the LLM is the **client**. There is no
+LLM-call path inside the repo and V4.4 deliberately does **not** add one — that
+would be an architecture break. Instead, `tour_scaffold` returns the *machine
+skeleton* of a "welcome to this repo" walk-through:
+
+- a **ranking** of the modules worth touring, each with the raw numbers and a
+  set of human-readable **facts** bullets, and
+- ready-made **suggested steps** whose `target`s already point at the right
+  class / atlas view.
+
+**You (the client) write the narration** in your own words — one idea per step,
+in the asker's language, per the guidance in
+[`walkthrough-query.md`](./walkthrough-query.md) — and then call the existing
+`walkthrough_start`. The whole Cockpit stack (GUI, browser viewer, presenter,
+TTS, PDF export) renders the result with **no frontend change**.
+
+## The MCP tool
+
+```jsonc
+tour_scaffold({
+  top?: number,          // how many modules to rank (default 5, min 1)
+  persona?: "new-dev" | "architect",   // framing only; ranking is identical
+  materialize?: boolean  // default false — see "Materialize mode" below
+}) →
+{
+  repo: { title, modules_total, classes_total },
+  ranking: [{
+    module, score,               // score is the blended 0..1 rank
+    classes, fan_in, fan_out,    // module-level coupling + size
+    commits_90d,                 // activity signal
+    top_class: { fqn, risk_score, fan_in, why } | null,
+    facts: [string, …]           // narrate these verbatim or paraphrase
+  }, …],
+  suggested_steps: [
+    { title: "Overview",            target: { kind: "note" },  facts: […] },
+    { title: "<module>",            target: { kind: "class", fqn },  facts: […] },
+    …,
+    { title: "Where change happens", target: { kind: "atlas", highlight: [fqn…] }, facts: […] }
+  ]
+}
+```
+
+## The client flow
+
+1. `open_repo({ path })`.
+2. `tour_scaffold({ top: 5 })`.
+3. For each `suggested_steps[i]`, write a short `narration` from its `facts`
+   (one idea per step, the asker's words).
+4. `walkthrough_start({ title, summary, steps })` with your narrated steps,
+   translating each scaffold `target` into the matching `WalkthroughTarget`
+   (`note` → `Note`, `class` → `Class { fqn }`, `atlas` → `Atlas { highlight_fqns }`).
+
+You are free to drop, reorder, merge or add steps — the scaffold is a starting
+point, not a contract.
+
+## The ranking
+
+Each module gets a blended score from three signals, **min-max normalised
+across the repo's modules** so the numbers are comparable:
+
+| signal    | source                                              | default weight |
+|-----------|-----------------------------------------------------|:--------------:|
+| coupling  | cross-module edges `incoming + outgoing` ([`module_chord`](../crates/core/src/module_chord.rs)) | **0.4** |
+| size      | class count of the module                           | **0.3** |
+| activity  | commits in the trailing 90-day window ([`git::commit_activity`](../crates/core/src/git.rs)) | **0.3** |
+
+`score = 0.4·norm(coupling) + 0.3·norm(classes) + 0.3·norm(commits_90d)`
+
+Modules are sorted by score descending (ties broken on module id for a stable
+order) and truncated to `top`. Each module's `top_class` is its
+**highest-`fan_in`** class from the risk atlas ([`risk::compute`](../crates/core/src/risk.rs))
+— the one the most other classes depend on; ties break on risk score, then fqn.
+
+The ranking is a **pure, deterministic** function of the repo (see
+[`tour_suggest.rs`](../crates/core/src/tour_suggest.rs)) — the same repo always
+yields the same order. `persona` only changes the Overview framing sentence.
+
+An empty or non-git repo degrades gracefully: an empty `ranking` and a lone
+Overview + closing step, never an error.
+
+## Materialize mode (offline / TTS, no client LLM)
+
+Set `materialize: true` and the server builds the walkthrough itself, filling
+each step's narration from a **template** (the `facts` bullets joined as a
+markdown list), persists it exactly the way `walkthrough_start` does, points the
+viewers at step 0, and returns the generated `walkthrough_id`:
+
+```jsonc
+tour_scaffold({ top: 5, materialize: true }) →
+{
+  materialized: true,
+  walkthrough_id: "tour-projectmind-1720…",
+  total: 7,
+  scaffold: { … }               // the same scaffold, for reference
+}
+```
+
+Use this for a `projectmind` CLI demo or an offline TTS playback where no
+client LLM is available to write prose. The materialized steps are ordinary
+walk-through steps — refine any of them afterwards with `walkthrough_append` /
+`walkthrough_set_step`, or clear with `walkthrough_clear`.


### PR DESCRIPTION
## Summary

Adds `tour_scaffold` (Viz **V4.4**, #201) — the machine skeleton for a "welcome to this repo" walk-through. ProjectMind stays a pure MCP **server**: the tool ranks the modules worth touring and returns ready-made step targets + facts; the **client (Claude) writes the narration** and calls the existing `walkthrough_start`. **No LLM-call path is added.**

## Ranking (pure, deterministic — `crates/core/src/tour_suggest.rs`)

Module score, signals min-max normalised across modules:

`score = 0.4·norm(coupling) + 0.3·norm(classes) + 0.3·norm(commits_90d)`

- **coupling** = cross-module edges `incoming + outgoing` (from `module_chord`)
- **size** = class count
- **activity** = commits in the trailing 90-day window (from `git::commit_activity`)

Per-module **top class** = highest `fan_in` via `risk::compute` (ties → risk score → fqn).

`suggested_steps`: an Overview note, one class step per module (pointing at its top class), and a closing "Where change happens" atlas step ringing the hotspots. Empty / non-git repos degrade to an empty ranking — never an error.

## `materialize` mode

`materialize:false` (default) returns only the scaffold. `materialize:true` persists a walkthrough with **template narration** built from the facts bullets, points the viewers at step 0, and returns the generated `walkthrough_id` — an offline / TTS demo without a client LLM. Steps stay editable via `walkthrough_append` / `_set_step`.

## Files

- **NEW** `crates/core/src/tour_suggest.rs` (+ `lib.rs` export) — pure `suggest_tour(repo, framework, top, persona)` + 8 unit tests
- **EDIT** `crates/mcp-server/src/tools.rs` — schema + dispatch + async handler + `materialize_walkthrough` mapping; 2 new tests
- **NEW** `docs/auto-tour.md` — client flow, ranking, materialize mode

## Gates (all green locally)

- `cargo fmt --all --check` clean
- `cargo clippy -p projectmind-core -p projectmind-mcp --all-targets -- -D warnings` → 0 warnings
- `cargo build -p projectmind-core -p projectmind-mcp` ok (frontend `pnpm build` ran first for `include_dir!`)
- `cargo test`: core 260, mcp 23+13+28 — all pass

Closes #201. Refs #66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJuL4nSq1EvgahTJe1hom1