### PR TITLE
feat(code-city): first-person walk mode with pointer lock (#66 stage 2)

### DIFF
--- a/app/src/components/CodeCity.svelte
+++ b/app/src/components/CodeCity.svelte
@@ -10,8 +10,11 @@
   /// `codeCityLayout.ts` — this component only maps the model onto
   /// InstancedMesh instances and wires orbit + picking.
   ///
-  /// Stage 1/3 of the #66 flythrough: orbit camera + click-drill only.
-  /// First-person walk (V4.6b) and tour waypoints (V4.6c) come on top.
+  /// Stage 2/3 of the #66 flythrough: orbit camera + click-drill, plus a
+  /// first-person walk mode (V4.6b) — PointerLockControls own the look,
+  /// the pure `cityWalk.ts` owns movement/collision/terrain, and a
+  /// crosshair raycast reuses the exact same drill codepath as orbit.
+  /// Tour waypoints (V4.6c) come on top.
   import { onDestroy, onMount } from 'svelte';
   import { get } from 'svelte/store';
   import { codeCityData } from '../lib/api';
@@ -22,6 +25,7 @@
     type CityBuilding,
     type CityModel,
   } from '../lib/diagrams/codeCityLayout';
+  import { groundHeightAt, stepMovement, WALK_DEFAULTS } from '../lib/diagrams/cityWalk';
   import { classes, fileView, followingMcp, repo, selectedClass, viewMode } from '../lib/store';
   import { t } from '../lib/i18n';
 
@@ -42,6 +46,8 @@
   // so they don't drag the chunk into the eager bundle.
   type Three = typeof import('three');
   type OrbitControlsT = import('three/examples/jsm/controls/OrbitControls.js').OrbitControls;
+  type PointerLockControlsT =
+    import('three/examples/jsm/controls/PointerLockControls.js').PointerLockControls;
 
   let three: Three | null = null;
   let model: CityModel | null = null;
@@ -53,6 +59,23 @@
   let raycaster: import('three').Raycaster | null = null;
   let disposables: { dispose(): void }[] = [];
   let resizeObserver: ResizeObserver | null = null;
+
+  // --- First-person walk state (V4.6b) --------------------------------------
+  let PointerLock:
+    | (new (camera: import('three').Camera, domElement: HTMLElement) => PointerLockControlsT)
+    | null = null;
+  let plc: PointerLockControlsT | null = null;
+  /// Walk toggle — orbit is the default; flipping back restores this pose.
+  let walkMode = false;
+  /// Orbit pose saved on walk entry, restored verbatim on exit.
+  let savedOrbit: { pos: [number, number, number]; target: [number, number, number] } | null =
+    null;
+  /// Building under the crosshair (walk-mode hover — same drill as orbit).
+  let walkTarget: CityBuilding | null = null;
+  /// Currently pressed movement keys (KeyboardEvent.code values).
+  const keys = new Set<string>();
+  /// Timestamp of the previous walk frame, for dt (ms, from setAnimationLoop).
+  let lastTick = 0;
 
   /// Warm accent the glow lightens towards — the "freshly built" read.
   const GLOW_COLOR = '#ffd666';
@@ -73,11 +96,13 @@
       empty = buildingCount === 0;
 
       // Dynamic imports — the whole three chunk lands only now.
-      const [threeModule, { OrbitControls }] = await Promise.all([
+      const [threeModule, { OrbitControls }, { PointerLockControls }] = await Promise.all([
         import('three'),
         import('three/examples/jsm/controls/OrbitControls.js'),
+        import('three/examples/jsm/controls/PointerLockControls.js'),
       ]);
       three = threeModule;
+      PointerLock = PointerLockControls;
 
       if (empty) {
         loading = false;
@@ -109,10 +134,12 @@
     renderer.setSize(container.clientWidth || 1, container.clientHeight || 1);
     container.appendChild(renderer.domElement);
 
+    // Near plane 0.1: at walking eye height the camera gets close to facades;
+    // 0.5 would clip them. Depth precision stays fine (plateau steps are 0.6).
     camera = new T.PerspectiveCamera(
       50,
       (container.clientWidth || 1) / (container.clientHeight || 1),
-      0.5,
+      0.1,
       m.world * 10,
     );
     controls = new OrbitControls(camera, renderer.domElement);
@@ -190,19 +217,162 @@
 
     // Continuous loop — damping needs per-frame control updates anyway;
     // torn down via setAnimationLoop(null) in onDestroy.
-    renderer.setAnimationLoop(() => {
-      controls?.update();
+    renderer.setAnimationLoop((time: number) => {
+      if (walkMode) stepWalkFrame(time);
+      else controls?.update();
       if (renderer && scene && camera) renderer.render(scene, camera);
     });
   }
 
   /// Fly the orbit camera back to the establishing shot.
   export function resetCamera() {
-    if (!camera || !controls || !model) return;
+    if (!camera || !controls || !model || walkMode) return;
     const fit = cameraFitFor(model);
     camera.position.set(...fit.position);
     controls.target.set(...fit.target);
     controls.update();
+  }
+
+  // --- First-person walk (V4.6b) ---------------------------------------------
+
+  function toggleWalk() {
+    if (walkMode) exitWalk();
+    else enterWalk();
+  }
+
+  /// Switch orbit → walk: freeze OrbitControls, remember their pose, drop
+  /// the camera to eye height (keeping the current heading, levelling the
+  /// gaze) and grab the pointer. Esc (= pointer-lock exit) leaves the mode.
+  function enterWalk() {
+    if (walkMode || !three || !camera || !controls || !renderer || !model || !PointerLock) return;
+    savedOrbit = {
+      pos: camera.position.toArray() as [number, number, number],
+      target: controls.target.toArray() as [number, number, number],
+    };
+    controls.enabled = false;
+
+    // Keep the orbit heading but level the gaze and clamp into the city —
+    // "drop down where you were looking". YXZ is the PointerLockControls
+    // euler order, so yaw survives the round-trip through the quaternion.
+    const e = new three.Euler(0, 0, 0, 'YXZ');
+    e.setFromQuaternion(camera.quaternion);
+    const x = Math.min(Math.max(camera.position.x, 0), model.world);
+    const z = Math.min(Math.max(camera.position.z, 0), model.world);
+    camera.position.set(x, groundHeightAt(model, x, z) + WALK_DEFAULTS.eyeHeight, z);
+    camera.rotation.set(0, e.y, 0, 'YXZ');
+
+    plc = new PointerLock(camera, renderer.domElement);
+    plc.addEventListener('unlock', onWalkUnlock);
+    hover = null;
+    walkTarget = null;
+    walkMode = true;
+    lastTick = 0;
+    document.addEventListener('keydown', onWalkKeyDown);
+    document.addEventListener('keyup', onWalkKeyUp);
+    renderer.domElement.addEventListener('mousedown', onWalkMouseDown);
+    plc.lock();
+  }
+
+  /// Switch walk → orbit: tear the pointer-lock plumbing down and restore
+  /// the exact orbit pose saved on entry.
+  function exitWalk() {
+    if (!walkMode) return;
+    walkMode = false;
+    walkTarget = null;
+    keys.clear();
+    document.removeEventListener('keydown', onWalkKeyDown);
+    document.removeEventListener('keyup', onWalkKeyUp);
+    renderer?.domElement.removeEventListener('mousedown', onWalkMouseDown);
+    if (plc) {
+      // Listener off first — plc.unlock() would re-dispatch into exitWalk.
+      plc.removeEventListener('unlock', onWalkUnlock);
+      plc.unlock();
+      plc.dispose();
+      plc = null;
+    }
+    if (camera && controls && savedOrbit) {
+      camera.position.set(...savedOrbit.pos);
+      controls.target.set(...savedOrbit.target);
+    }
+    savedOrbit = null;
+    if (controls) {
+      controls.enabled = true;
+      controls.update();
+    }
+  }
+
+  /// Pointer lock released (Esc or focus loss) → back to orbit.
+  function onWalkUnlock() {
+    exitWalk();
+  }
+
+  const MOVE_CODES = new Set([
+    'KeyW',
+    'KeyA',
+    'KeyS',
+    'KeyD',
+    'ArrowUp',
+    'ArrowDown',
+    'ArrowLeft',
+    'ArrowRight',
+    'ShiftLeft',
+    'ShiftRight',
+  ]);
+
+  function onWalkKeyDown(e: KeyboardEvent) {
+    if (!MOVE_CODES.has(e.code)) return;
+    e.preventDefault(); // arrows would scroll the pane
+    keys.add(e.code);
+  }
+
+  function onWalkKeyUp(e: KeyboardEvent) {
+    keys.delete(e.code);
+  }
+
+  /// Walk-mode drill: while locked, a click drills into the building under
+  /// the crosshair — the same `drillInto` codepath as the orbit click.
+  /// Unlocked (the browser can deny the grab, e.g. Chrome's cooldown right
+  /// after an Esc), a click on the stage re-requests the lock instead.
+  function onWalkMouseDown(e: MouseEvent) {
+    if (e.button !== 0 || !plc) return;
+    if (!plc.isLocked) {
+      plc.lock();
+      return;
+    }
+    if (walkTarget) drillInto(walkTarget);
+  }
+
+  /// One walk frame: WASD intent + camera yaw → pure `stepMovement`
+  /// (collision, terraces, bounds), result written back onto the camera;
+  /// then the crosshair pick for the HUD.
+  function stepWalkFrame(now: number) {
+    if (!three || !camera || !model) return;
+    const dt = lastTick === 0 ? 0 : Math.min((now - lastTick) / 1000, 0.1);
+    lastTick = now;
+    const e = new three.Euler(0, 0, 0, 'YXZ');
+    e.setFromQuaternion(camera.quaternion);
+    const pose = stepMovement(
+      model,
+      { x: camera.position.x, y: camera.position.y, z: camera.position.z, yaw: e.y },
+      {
+        forward:
+          (keys.has('KeyW') || keys.has('ArrowUp') ? 1 : 0) -
+          (keys.has('KeyS') || keys.has('ArrowDown') ? 1 : 0),
+        strafe:
+          (keys.has('KeyD') || keys.has('ArrowRight') ? 1 : 0) -
+          (keys.has('KeyA') || keys.has('ArrowLeft') ? 1 : 0),
+        sprint: keys.has('ShiftLeft') || keys.has('ShiftRight'),
+      },
+      dt,
+    );
+    camera.position.set(pose.x, pose.y, pose.z);
+
+    // Crosshair raycast from the screen centre.
+    if (!raycaster || !buildingsMesh) return;
+    raycaster.setFromCamera(new three.Vector2(0, 0), camera);
+    const hit = raycaster.intersectObject(buildingsMesh, false)[0];
+    const b = hit?.instanceId !== undefined ? (model.buildings[hit.instanceId] ?? null) : null;
+    if (b !== walkTarget) walkTarget = b;
   }
 
   // --- Picking ---------------------------------------------------------------
@@ -224,6 +394,7 @@
   }
 
   function onPointerMove(e: PointerEvent) {
+    if (walkMode) return; // pointer-lock coordinates are stale — crosshair picks instead
     hover = pick(e);
     if (renderer) renderer.domElement.style.cursor = hover ? 'pointer' : 'grab';
   }
@@ -235,10 +406,12 @@
   // Click vs orbit-drag: only a press that barely moved counts as a drill.
   let downAt: { x: number; y: number } | null = null;
   function onPointerDown(e: PointerEvent) {
+    if (walkMode) return; // walk clicks drill via onWalkMouseDown
     if (e.button === 0) downAt = { x: e.clientX, y: e.clientY };
   }
 
   function onPointerUp(e: PointerEvent) {
+    if (walkMode) return;
     if (!downAt || e.button !== 0) return;
     const moved = Math.hypot(e.clientX - downAt.x, e.clientY - downAt.y);
     downAt = null;
@@ -284,6 +457,9 @@
   });
 
   onDestroy(() => {
+    // A drill out of walk mode destroys this component while the pointer is
+    // still locked — release it (and the key listeners) first.
+    exitWalk();
     // WKWebView leaks GPU memory on every kind switch unless the renderer
     // and its GPU resources are torn down explicitly.
     if (renderer) {
@@ -312,6 +488,15 @@
 <div class="city-root">
   <div class="toolbar">
     <button type="button" on:click={resetCamera} title={$t('diagram.resetView')}>⌂</button>
+    <button
+      type="button"
+      class="walk-toggle"
+      class:active={walkMode}
+      aria-pressed={walkMode}
+      disabled={loading || !!error || empty}
+      on:click={toggleWalk}
+      title={$t('diagram.codeCity.walkHud')}
+    >{$t('diagram.codeCity.walk')}</button>
     <span class="summary">{buildingCount} · {districtCount}</span>
     <span class="divider"></span>
     <span class="legend">
@@ -362,6 +547,16 @@
         {/if}
       </div>
     {/if}
+    {#if walkMode}
+      <div class="crosshair" aria-hidden="true"></div>
+      {#if walkTarget}
+        <div class="walk-target">
+          <span class="tt-label">{walkTarget.label}</span>
+          <span class="tt-path">{walkTarget.id}</span>
+        </div>
+      {/if}
+      <div class="walk-hud">{$t('diagram.codeCity.walkHud')}</div>
+    {/if}
   </div>
 </div>
 
@@ -393,6 +588,19 @@
   }
   .toolbar button:hover {
     border-color: var(--accent-2);
+  }
+  .toolbar button.walk-toggle {
+    width: auto;
+    padding: 0 8px;
+    font-size: 11px;
+  }
+  .toolbar button.walk-toggle.active {
+    border-color: var(--accent-2);
+    color: var(--accent-2);
+  }
+  .toolbar button.walk-toggle:disabled {
+    opacity: 0.5;
+    cursor: default;
   }
   .summary {
     font-family: var(--mono);
@@ -469,6 +677,72 @@
     gap: 8px;
     margin-top: 2px;
     color: var(--fg-1, var(--fg-0));
+  }
+  /* --- Walk-mode HUD (V4.6b) --- */
+  .crosshair {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 14px;
+    height: 14px;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+    z-index: 9;
+  }
+  .crosshair::before,
+  .crosshair::after {
+    content: '';
+    position: absolute;
+    background: rgba(255, 255, 255, 0.75);
+  }
+  .crosshair::before {
+    left: 50%;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    transform: translateX(-50%);
+  }
+  .crosshair::after {
+    top: 50%;
+    left: 0;
+    right: 0;
+    height: 1px;
+    transform: translateY(-50%);
+  }
+  .walk-target {
+    position: absolute;
+    left: 50%;
+    top: calc(50% + 22px);
+    transform: translateX(-50%);
+    display: flex;
+    gap: 8px;
+    align-items: baseline;
+    max-width: 70%;
+    pointer-events: none;
+    z-index: 9;
+    background: color-mix(in srgb, var(--bg-1) 82%, black);
+    border: 1px solid var(--bg-3);
+    border-radius: 4px;
+    padding: 3px 8px;
+    font-size: 11px;
+    color: var(--fg-0);
+    white-space: nowrap;
+    overflow: hidden;
+  }
+  .walk-hud {
+    position: absolute;
+    left: 50%;
+    bottom: 12px;
+    transform: translateX(-50%);
+    pointer-events: none;
+    z-index: 9;
+    background: color-mix(in srgb, var(--bg-1) 75%, black);
+    border: 1px solid var(--bg-3);
+    border-radius: 12px;
+    padding: 4px 12px;
+    font-size: 11px;
+    color: var(--fg-2);
+    white-space: nowrap;
   }
   .placeholder,
   .error {

--- a/app/src/i18n/de.json
+++ b/app/src/i18n/de.json
@@ -94,6 +94,8 @@
   "diagram.codeCity.legendHeight": "Höhe = Zeilen/Größe",
   "diagram.codeCity.legendRisk": "Farbe = Risiko",
   "diagram.codeCity.legendGlow": "Glühen = Commits < 7d",
+  "diagram.codeCity.walk": "Begehen",
+  "diagram.codeCity.walkHud": "WASD bewegen · Maus umsehen · Shift rennen · Esc beendet",
   "diagram.drillHint": "Klicke auf einen Knoten, um hineinzuspringen",
   "diagram.colourBy": "einfärben nach",
   "diagram.colourBy.structure": "Nach Knotenart einfärben (Standard)",

--- a/app/src/i18n/en.json
+++ b/app/src/i18n/en.json
@@ -94,6 +94,8 @@
   "diagram.codeCity.legendHeight": "height = lines/size",
   "diagram.codeCity.legendRisk": "colour = risk",
   "diagram.codeCity.legendGlow": "glow = commits < 7d",
+  "diagram.codeCity.walk": "Walk",
+  "diagram.codeCity.walkHud": "WASD move · mouse look · Shift run · Esc exit",
   "diagram.drillHint": "Click a node to drill into it",
   "diagram.colourBy": "colour by",
   "diagram.colourBy.structure": "Colour by node kind (default)",

--- a/app/src/i18n/es.json
+++ b/app/src/i18n/es.json
@@ -106,6 +106,8 @@
   "diagram.codeCity.legendHeight": "altura = líneas/tamaño",
   "diagram.codeCity.legendRisk": "color = riesgo",
   "diagram.codeCity.legendGlow": "brillo = commits < 7d",
+  "diagram.codeCity.walk": "Caminar",
+  "diagram.codeCity.walkHud": "WASD moverse · ratón mirar · Mayús correr · Esc salir",
   "diagram.description.c4Container": "Vista de contenedores C4 — módulos como contenedores, dependencias entre módulos como aristas.",
   "diagram.description.architectureLayers": "Mapa de capas draw.io — contacto externo en el borde, lógica de negocio en el medio, persistencia de datos dentro.",
   "diagram.description.languageStats": "Distribucion de archivos por lenguaje — numero de archivos y bytes por bucket.",

--- a/app/src/i18n/fr.json
+++ b/app/src/i18n/fr.json
@@ -106,6 +106,8 @@
   "diagram.codeCity.legendHeight": "hauteur = lignes/taille",
   "diagram.codeCity.legendRisk": "couleur = risque",
   "diagram.codeCity.legendGlow": "lueur = commits < 7j",
+  "diagram.codeCity.walk": "Marcher",
+  "diagram.codeCity.walkHud": "WASD se déplacer · souris regarder · Maj courir · Échap quitter",
   "diagram.description.c4Container": "Vue conteneur C4 — modules en conteneurs, dépendances inter-modules en arêtes.",
   "diagram.description.architectureLayers": "Carte de couches draw.io — contact externe au bord, logique métier au milieu, persistance des données à l'intérieur.",
   "diagram.description.languageStats": "Distribution des fichiers par langage — nombre de fichiers et octets par bucket.",

--- a/app/src/i18n/it.json
+++ b/app/src/i18n/it.json
@@ -106,6 +106,8 @@
   "diagram.codeCity.legendHeight": "altezza = righe/dimensione",
   "diagram.codeCity.legendRisk": "colore = rischio",
   "diagram.codeCity.legendGlow": "bagliore = commit < 7g",
+  "diagram.codeCity.walk": "Cammina",
+  "diagram.codeCity.walkHud": "WASD muoversi · mouse guardare · Maiusc correre · Esc esce",
   "diagram.description.c4Container": "Vista contenitori C4 — moduli come contenitori, dipendenze tra moduli come archi.",
   "diagram.description.architectureLayers": "Mappa a layer draw.io — contatto esterno sul bordo, logica business al centro, persistenza dati all'interno.",
   "diagram.description.languageStats": "Distribuzione dei file per linguaggio — numero di file e byte per bucket.",

--- a/app/src/lib/diagrams/cityWalk.test.ts
+++ b/app/src/lib/diagrams/cityWalk.test.ts
@@ -1,0 +1,207 @@
+/// Tests for the pure first-person walk physics (V4.6b, #66). No DOM, no
+/// WebGL — vitest under happy-dom must stay green on the Linux CI runner,
+/// so nothing here (nor in cityWalk.ts) may import three.
+
+import { describe, expect, it } from 'vitest';
+import type { CityBuilding, CityDistrict, CityModel } from './codeCityLayout';
+import {
+  collides,
+  groundHeightAt,
+  resolveCollision,
+  stepMovement,
+  WALK_DEFAULTS,
+  type WalkInput,
+  type WalkPose,
+} from './cityWalk';
+
+function district(
+  partial: Partial<CityDistrict> & Pick<CityDistrict, 'id' | 'x' | 'z' | 'w' | 'd' | 'y'>,
+): CityDistrict {
+  return { label: partial.id, depth: 0, ...partial };
+}
+
+function building(
+  partial: Partial<CityBuilding> & Pick<CityBuilding, 'id' | 'x' | 'z' | 'w' | 'd'>,
+): CityBuilding {
+  return {
+    label: partial.id,
+    fqn: null,
+    module: null,
+    y: 0,
+    h: 10,
+    color: 'hsl(215, 15%, 40%)',
+    glow: 0,
+    score: null,
+    sloc: null,
+    bytes: 100,
+    ...partial,
+  };
+}
+
+/// City fixture: 100×100 root plateau at 0, nested districts terracing to
+/// 0.6 and 1.2, one 4×4 building at (30, 30) on the depth-1 plateau.
+const model: CityModel = {
+  world: 100,
+  truncated: false,
+  districts: [
+    district({ id: '.', x: 0, z: 0, w: 100, d: 100, y: 0, depth: 0 }),
+    district({ id: 'a', x: 10, z: 10, w: 40, d: 40, y: 0.6, depth: 1 }),
+    district({ id: 'a/b', x: 15, z: 15, w: 12, d: 12, y: 1.2, depth: 2 }),
+  ],
+  buildings: [building({ id: 'a/f.rs', x: 30, z: 30, w: 4, d: 4, y: 0.6 })],
+};
+
+const emptyModel: CityModel = { world: 100, truncated: false, districts: [], buildings: [] };
+
+const pose = (x: number, z: number, yaw = 0): WalkPose => ({
+  x,
+  y: groundHeightAt(model, x, z) + WALK_DEFAULTS.eyeHeight,
+  z,
+  yaw,
+});
+
+const input = (partial?: Partial<WalkInput>): WalkInput => ({
+  forward: 0,
+  strafe: 0,
+  sprint: false,
+  ...partial,
+});
+
+describe('groundHeightAt', () => {
+  it('returns the plateau top of the deepest containing district', () => {
+    expect(groundHeightAt(model, 5, 5)).toBe(0); // root only
+    expect(groundHeightAt(model, 12, 12)).toBe(0.6); // depth-1 terrace
+    expect(groundHeightAt(model, 20, 20)).toBe(1.2); // nested depth-2 terrace
+  });
+
+  it('returns the ground plane outside the city', () => {
+    expect(groundHeightAt(model, -5, 50)).toBe(0);
+    expect(groundHeightAt(model, 50, 130)).toBe(0);
+  });
+
+  it('handles an empty layout', () => {
+    expect(groundHeightAt(emptyModel, 50, 50)).toBe(0);
+  });
+});
+
+describe('collides / resolveCollision', () => {
+  it('detects the building footprint expanded by the radius', () => {
+    expect(collides(model, 32, 32, 0.35)).toBe(true); // inside
+    expect(collides(model, 29.8, 32, 0.35)).toBe(true); // within radius of the wall
+    expect(collides(model, 29.8, 32, 0)).toBe(false); // radius matters
+    expect(collides(model, 28, 32, 0.35)).toBe(false); // clear of it
+  });
+
+  it('blocks head-on movement into a wall', () => {
+    const r = resolveCollision(model, { x: 28, z: 32 }, { x: 31, z: 32 }, 0.35);
+    expect(r).toEqual({ x: 28, z: 32 });
+  });
+
+  it('slides along the wall on a diagonal approach', () => {
+    // Moving +x/+z into the south-west corner region: x passes (z is still
+    // clear of the footprint), z is then blocked → slide along the wall.
+    const r = resolveCollision(model, { x: 28, z: 28 }, { x: 31, z: 31 }, 0.35);
+    expect(r).toEqual({ x: 31, z: 28 });
+  });
+
+  it('moves freely when no building is in the way', () => {
+    const r = resolveCollision(model, { x: 5, z: 5 }, { x: 6, z: 7 }, 0.35);
+    expect(r).toEqual({ x: 6, z: 7 });
+  });
+
+  it('lets a walker spawned inside a building walk out (escape hatch)', () => {
+    const r = resolveCollision(model, { x: 32, z: 32 }, { x: 36, z: 32 }, 0.35);
+    expect(r).toEqual({ x: 36, z: 32 });
+  });
+});
+
+describe('stepMovement', () => {
+  it('moves along the yaw-projected forward axis', () => {
+    // yaw 0 looks down −z (three.js convention).
+    const a = stepMovement(model, pose(50, 90), input({ forward: 1 }), 0.5);
+    expect(a.x).toBeCloseTo(50, 9);
+    expect(a.z).toBeCloseTo(90 - WALK_DEFAULTS.speed * 0.5, 9);
+    // yaw π/2 looks down −x.
+    const b = stepMovement(model, pose(50, 90, Math.PI / 2), input({ forward: 1 }), 0.5);
+    expect(b.x).toBeCloseTo(50 - WALK_DEFAULTS.speed * 0.5, 9);
+    expect(b.z).toBeCloseTo(90, 9);
+    // strafe +1 at yaw 0 goes +x.
+    const c = stepMovement(model, pose(50, 90), input({ strafe: 1 }), 0.5);
+    expect(c.x).toBeCloseTo(50 + WALK_DEFAULTS.speed * 0.5, 9);
+    expect(c.z).toBeCloseTo(90, 9);
+  });
+
+  it('is dt-independent: two half steps equal one full step', () => {
+    const start = pose(50, 90, Math.PI / 5);
+    const inp = input({ forward: 1, strafe: -1 });
+    const full = stepMovement(model, start, inp, 1);
+    const half = stepMovement(model, stepMovement(model, start, inp, 0.5), inp, 0.5);
+    expect(half.x).toBeCloseTo(full.x, 9);
+    expect(half.z).toBeCloseTo(full.z, 9);
+    expect(half.y).toBeCloseTo(full.y, 9);
+  });
+
+  it('normalises diagonal input and applies the sprint factor', () => {
+    const start = pose(50, 90);
+    const diag = stepMovement(model, start, input({ forward: 1, strafe: 1 }), 1);
+    const moved = Math.hypot(diag.x - start.x, diag.z - start.z);
+    expect(moved).toBeCloseTo(WALK_DEFAULTS.speed, 9); // not ×√2
+    const sprint = stepMovement(model, start, input({ forward: 1, sprint: true }), 1);
+    expect(Math.abs(sprint.z - start.z)).toBeCloseTo(
+      WALK_DEFAULTS.speed * WALK_DEFAULTS.sprintFactor,
+      9,
+    );
+  });
+
+  it('clamps y onto the terraces while walking up and down', () => {
+    // Walk from the root plateau across the depth-1 edge at x = 10.
+    const onRoot = pose(5, 12);
+    expect(onRoot.y).toBeCloseTo(WALK_DEFAULTS.eyeHeight, 9);
+    const up = stepMovement(model, { ...onRoot, yaw: -Math.PI / 2 }, input({ forward: 1 }), 0.5);
+    expect(up.x).toBeGreaterThan(10);
+    expect(up.y).toBeCloseTo(0.6 + WALK_DEFAULTS.eyeHeight, 9);
+    const down = stepMovement(model, { ...up, yaw: Math.PI / 2 }, input({ forward: 1 }), 0.5);
+    expect(down.x).toBeLessThan(10);
+    expect(down.y).toBeCloseTo(WALK_DEFAULTS.eyeHeight, 9);
+  });
+
+  it('blocks at buildings and slides along their walls', () => {
+    // Head-on into the west face of the building at x = 30 (expanded to
+    // 30 − radius = 29.65): x stops short of the wall even though one
+    // frame's travel would overshoot the whole building (no tunnelling).
+    const blocked = stepMovement(model, pose(29, 32, -Math.PI / 2), input({ forward: 1 }), 1);
+    expect(blocked.x).toBeGreaterThanOrEqual(29);
+    expect(blocked.x).toBeLessThan(30 - WALK_DEFAULTS.radius);
+    expect(blocked.z).toBe(32);
+    // Diagonal into the same face: x stays blocked while z slides the full
+    // tangential distance along the wall (dt chosen so the walker stays
+    // within the wall's z-extent — a longer step would round the corner).
+    const slide = stepMovement(
+      model,
+      pose(29, 30, -Math.PI / 2),
+      input({ forward: 1, strafe: 1 }),
+      0.2,
+    );
+    expect(slide.x).toBeLessThan(30 - WALK_DEFAULTS.radius);
+    expect(slide.z).toBeCloseTo(30 + (WALK_DEFAULTS.speed * 0.2) / Math.SQRT2, 9);
+  });
+
+  it('clamps to the roam bounds around the city', () => {
+    const out = stepMovement(model, pose(50, 5), input({ forward: 1 }), 60);
+    expect(out.z).toBe(-WALK_DEFAULTS.margin);
+    expect(out.y).toBeCloseTo(WALK_DEFAULTS.eyeHeight, 9); // ground plane outside
+  });
+
+  it('keeps the pose still on zero input and works on an empty layout', () => {
+    const still = stepMovement(model, pose(20, 20), input(), 1);
+    expect(still).toEqual(pose(20, 20));
+    const empty = stepMovement(
+      emptyModel,
+      { x: 50, y: WALK_DEFAULTS.eyeHeight, z: 50, yaw: 0 },
+      input({ forward: 1 }),
+      0.25,
+    );
+    expect(empty.z).toBeCloseTo(50 - WALK_DEFAULTS.speed * 0.25, 9);
+    expect(empty.y).toBeCloseTo(WALK_DEFAULTS.eyeHeight, 9);
+  });
+});

--- a/app/src/lib/diagrams/cityWalk.ts
+++ b/app/src/lib/diagrams/cityWalk.ts
@@ -1,0 +1,169 @@
+/// First-person walk physics for the code city (V4.6b, #66) — pure math,
+/// no DOM, no WebGL, no three import (Linux CI runs vitest without WebGL).
+///
+/// `CodeCity.svelte` drives this from its animation loop: PointerLockControls
+/// owns the *look* (mouse → camera quaternion), this module owns the *move* —
+/// WASD intent + yaw in, a collision- and terrain-resolved pose out.
+///
+/// Model of the world (all data straight from `codeCityLayout`):
+/// - **Ground** = district plateaus. Districts nest, so the ground height at
+///   (x, z) is the plateau top of the *deepest* district containing the
+///   point; outside every district it is the ground plane at 0. Plateau
+///   edges are small (`plinth` per level), so the walker simply steps up and
+///   down — no jump, no gravity, `y` is clamped to ground + eye height.
+/// - **Obstacles** = buildings. Collision is a 2D axis-aligned test on the
+///   XZ footprint (building heights always exceed the step scale, so a pure
+///   2D check is enough). Blocked movement slides along the wall via the
+///   classic axis-separated resolve: try x first, then z.
+
+import type { CityModel } from './codeCityLayout';
+
+/// Walker pose. `y` is derived (ground + eye height) but kept in the pose so
+/// the caller can copy it straight onto the camera. `yaw` follows the
+/// three.js YXZ convention: 0 looks down −z, positive turns towards −x.
+export interface WalkPose {
+  x: number;
+  y: number;
+  z: number;
+  yaw: number;
+}
+
+/// Per-frame movement intent, already resolved from pressed keys:
+/// `forward` +1 = ahead / −1 = back, `strafe` +1 = right / −1 = left.
+export interface WalkInput {
+  forward: number;
+  strafe: number;
+  sprint: boolean;
+}
+
+export interface WalkOptions {
+  /// Walking speed in world units per second.
+  speed?: number;
+  /// Speed multiplier while sprinting (Shift).
+  sprintFactor?: number;
+  /// Collision radius around the walker. Must stay below the layout's
+  /// building gap (0.4 per side → 0.8 corridors) so alleys remain passable.
+  radius?: number;
+  /// Camera height above the plateau the walker stands on.
+  eyeHeight?: number;
+  /// How far beyond the city square ([0, world]²) the walker may roam.
+  margin?: number;
+}
+
+/// Defaults tuned to the codeCityLayout scale (world = 200, buildings
+/// 0.5–30 high, plateau steps of 0.6): eye height 1.7 reads as street level,
+/// 24 u/s crosses the city in ~8 s.
+export const WALK_DEFAULTS: Required<WalkOptions> = {
+  speed: 24,
+  sprintFactor: 2.5,
+  radius: 0.35,
+  eyeHeight: 1.7,
+  margin: 30,
+};
+
+/// Ground height at (x, z): plateau top of the deepest district containing
+/// the point, 0 outside the city (districts nest, so "deepest containing"
+/// equals the max plateau `y` over all hits).
+export function groundHeightAt(model: CityModel, x: number, z: number): number {
+  let ground = 0;
+  for (const d of model.districts) {
+    if (x >= d.x && x <= d.x + d.w && z >= d.z && z <= d.z + d.d && d.y > ground) {
+      ground = d.y;
+    }
+  }
+  return ground;
+}
+
+/// True when a walker disc of `radius` at (x, z) overlaps any building
+/// footprint. Pure 2D — see the module header for why height is ignored.
+export function collides(model: CityModel, x: number, z: number, radius: number): boolean {
+  for (const b of model.buildings) {
+    if (x > b.x - radius && x < b.x + b.w + radius && z > b.z - radius && z < b.z + b.d + radius) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// Resolve a move from → to against the building AABBs with wall slide:
+/// each axis is applied independently, so hitting a wall head-on stops that
+/// axis while the tangential axis keeps moving (classic slide-along-wall).
+/// Escape hatch: a walker that already starts inside a building (bad spawn)
+/// may move freely so it can walk out instead of being stuck.
+export function resolveCollision(
+  model: CityModel,
+  from: { x: number; z: number },
+  to: { x: number; z: number },
+  radius: number,
+): { x: number; z: number } {
+  if (collides(model, from.x, from.z, radius)) return { x: to.x, z: to.z };
+  const x = collides(model, to.x, from.z, radius) ? from.x : to.x;
+  const z = collides(model, x, to.z, radius) ? from.z : to.z;
+  return { x, z };
+}
+
+const clamp = (v: number, lo: number, hi: number): number => Math.min(Math.max(v, lo), hi);
+
+/// One integration step: input + yaw → world-space delta (scaled by `dt`
+/// seconds — pure linear motion, so N small steps equal one big step and the
+/// walker is framerate-independent), clamped to the roam bounds, resolved
+/// against buildings, then snapped onto the ground. Returns a new pose;
+/// never mutates its inputs.
+///
+/// The collision resolve is applied in substeps no longer than the walker
+/// radius: a single point test at the destination would tunnel straight
+/// through a building whenever one frame's travel exceeds its footprint
+/// (sprint + a slow frame is enough). Every building is at least 2·radius
+/// wide once expanded by the radius, so radius-length substeps cannot skip
+/// one. Free movement stays exactly linear, preserving dt-independence.
+export function stepMovement(
+  model: CityModel,
+  pose: WalkPose,
+  input: WalkInput,
+  dt: number,
+  opts?: WalkOptions,
+): WalkPose {
+  const o: Required<WalkOptions> = { ...WALK_DEFAULTS, ...opts };
+
+  // Normalise the intent so diagonals are not √2 faster.
+  let fwd = input.forward;
+  let strafe = input.strafe;
+  const len = Math.hypot(fwd, strafe);
+  if (len > 1) {
+    fwd /= len;
+    strafe /= len;
+  }
+
+  // Yaw → ground-projected forward (−sin, −cos) and right (cos, −sin),
+  // matching the three.js YXZ camera convention (yaw 0 looks down −z).
+  const dist = o.speed * (input.sprint ? o.sprintFactor : 1) * dt;
+  const sin = Math.sin(pose.yaw);
+  const cos = Math.cos(pose.yaw);
+  const lo = -o.margin;
+  const hi = model.world + o.margin;
+  // Clamp the target once; the roam box is convex, so every substep along
+  // the segment stays inside it as long as the pose already is.
+  const to = {
+    x: clamp(pose.x + (-sin * fwd + cos * strafe) * dist, lo, hi),
+    z: clamp(pose.z + (-cos * fwd - sin * strafe) * dist, lo, hi),
+  };
+
+  const travel = Math.hypot(to.x - pose.x, to.z - pose.z);
+  const steps = Math.max(1, Math.ceil(travel / o.radius));
+  let cur = { x: clamp(pose.x, lo, hi), z: clamp(pose.z, lo, hi) };
+  const dx = (to.x - pose.x) / steps;
+  const dz = (to.z - pose.z) / steps;
+  for (let i = 0; i < steps; i++) {
+    cur = resolveCollision(model, cur, { x: cur.x + dx, z: cur.z + dz }, o.radius);
+  }
+  // Substep accumulation drifts by a few ulps — re-clamp so the roam bounds
+  // hold exactly.
+  cur = { x: clamp(cur.x, lo, hi), z: clamp(cur.z, lo, hi) };
+
+  return {
+    x: cur.x,
+    y: groundHeightAt(model, cur.x, cur.z) + o.eyeHeight,
+    z: cur.z,
+    yaw: pose.yaw,
+  };
+}


### PR DESCRIPTION
Refs #66 — Stufe 2/3; Tour-Waypoints = c.

## Was

Umschalter **Orbit ↔ Walk** in der Code-City-Toolbar (aria-pressed, i18n in allen 5 Locales, Default bleibt Orbit). Im Walk-Modus:

- **PointerLockControls** aus `three/examples` (gleicher lazy `three`-Chunk, keine neue Dependency) für die Maus-Blicksteuerung; WASD + Pfeiltasten bewegen, Shift sprintet, **Esc verlässt den Modus** und stellt die Orbit-Kamera/Controls exakt wieder her.
- **HUD**: Fadenkreuz + dezenter Hinweis („WASD bewegen · Maus umsehen · Shift rennen · Esc beendet", i18n) + Caption des anvisierten Gebäudes.
- **Hover/Drill im Walk-Modus**: Raycast aus der Bildmitte; Klick drillt über denselben `drillInto`-Codepfad wie der Orbit-Klick (Klasse → ClassViewer, sonst FileView).

## Boden- & Kollisionsmodell (pure, getestet)

Neu `app/src/lib/diagrams/cityWalk.ts` — kein DOM, kein WebGL, kein three-Import:

- `groundHeightAt(model, x, z)`: Plateau-Oberkante des tiefsten Distrikts, der den Punkt enthält (Terrassen = Treppen, y wird geklemmt — kein Gravity/Jump); außerhalb der Stadt Grundebene 0.
- `collides` / `resolveCollision(model, from, to, radius)`: 2D-AABB gegen Gebäude-Footprints mit klassischem Achsen-Slide (x zuerst, dann z) + Escape-Hatch bei Spawn-im-Gebäude.
- `stepMovement(model, pose, input, dt)`: dt-basierte, yaw-projizierte Integration (framerate-unabhängig, Diagonalen normalisiert), Welt-Grenzen (`world` + Rand), **Substeps ≤ radius gegen Tunneling** (ein Frame-Schritt könnte sonst durch ein schmales Gebäude springen — im Test nachgewiesen).

Szenen-Skala: world = 200, Plateau-Stufe 0.6/Tiefe, Gebäude 0.5–30 hoch → **Augenhöhe 1.7**, Speed 24 u/s (Sprint ×2.5), Kollisionsradius 0.35 (< halbe Gebäude-Gasse 0.8). Near-Plane 0.5→0.1, damit Fassaden auf Augenhöhe nicht clippen.

## Tests (vitest, 15 neu — Repo-Muster: nur pure Logik, kein WebGL)

Verschachtelte Plateau-Höhen, außerhalb-der-Stadt, Gebäude-Block + Wand-Slide + No-Tunneling, Radius-Wirkung, Escape-Hatch, dt-Unabhängigkeit (2×0.5dt == 1×1dt), Diagonal-Normalisierung + Sprint, Terrassen-Klemme rauf/runter, Welt-Grenzen, Leer-Layout.

## Gates

- `svelte-check`: 858 Dateien, **0 Fehler / 0 Warnungen**
- `vitest`: **474 passed** (32 Files)
- `pnpm build`: grün; `three` bleibt eigener Lazy-Chunk (746 kB / 189 kB gz, unverändert — PointerLockControls war schon Teil des Chunks), keine neuen i18nDiagramKeys-Kinds

Pointer-Lock ist in happy-dom nicht testbar → Komponente bleibt (wie im Repo üblich) manuell zu verifizieren: Desktop (`./build 0`) und Browser-Viewer (WKWebView + Chromium).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJuL4nSq1EvgahTJe1hom1