### PR TITLE
fix(mcp): advertise diagram-diff in the walkthrough step schema

### DIFF
--- a/crates/mcp-server/src/tools.rs
+++ b/crates/mcp-server/src/tools.rs
@@ -146,15 +146,17 @@ fn walkthrough_step_schema() -> Value {
             "narration": { "type": "string", "description": "Markdown shown alongside the target. Optional but strongly recommended — this is what the user reads." },
             "target": {
                 "type": "object",
-                "description": "What to render in the main pane. `kind` selects the viewer: class | file | diff | artifact | risk | pattern | atlas | note. The risk/pattern/atlas kinds (Cockpit 2.4) pull live signals from the Risk Atlas + Pattern Lens.",
+                "description": "What to render in the main pane. `kind` selects the viewer: class | file | diff | artifact | risk | pattern | atlas | diagram-diff | note. The risk/pattern/atlas kinds (Cockpit 2.4) pull live signals from the Risk Atlas + Pattern Lens. kind=diagram-diff renders a before/after architecture snapshot of one diagram between two git refs (`from`/`to`) with before / after / changed-only toggles.",
                 "properties": {
-                    "kind": { "type": "string", "enum": ["class", "file", "diff", "artifact", "risk", "pattern", "atlas", "note"] },
+                    "kind": { "type": "string", "enum": ["class", "file", "diff", "artifact", "risk", "pattern", "atlas", "diagram-diff", "note"] },
                     "fqn":  { "type": "string", "description": "Class FQN (kind=class or kind=risk)" },
                     "path": { "type": "string", "description": "Absolute file path (kind=file)" },
                     "anchor": { "type": "string", "description": "Heading slug (kind=file, markdown only)" },
                     "id":   { "type": "string", "description": "Artifact id from present_artifact (kind=artifact)" },
                     "ref":  { "type": "string", "description": "Base git ref (kind=diff)" },
-                    "to":   { "type": "string", "description": "Target git ref or omit for working tree (kind=diff)" },
+                    "diagram": { "type": "string", "enum": ["folder-map", "bean-graph-live"], "description": "Diagram kind to snapshot (kind=diagram-diff). Omit for the default `folder-map`; `bean-graph-live` renders an animated bean-graph morph." },
+                    "from": { "type": "string", "description": "Base git ref for the before state, e.g. `HEAD~5` or a branch name (kind=diagram-diff)." },
+                    "to":   { "type": "string", "description": "Target git ref or omit for working tree (kind=diff or kind=diagram-diff)" },
                     "show": {
                         "type": "array",
                         "description": "Risk signals to surface in the header bar (kind=risk). Empty = every signal with data.",
@@ -2221,6 +2223,53 @@ mod tests {
         assert!(props.get("highlight_fqns").is_some());
         assert!(props.get("show").is_some());
         assert!(props.get("pattern").is_some());
+    }
+
+    #[test]
+    fn walkthrough_step_schema_advertises_diagram_diff() {
+        // #125: the before/after architecture snapshot (`diagram-diff`) must be
+        // offered to the LLM in the step schema of BOTH authoring tools —
+        // walkthrough_start and walkthrough_append — or schema-faithful MCP
+        // clients can never emit it.
+        let v = list();
+        let tools = v["tools"].as_array().unwrap();
+        let start = tools
+            .iter()
+            .find(|t| t["name"] == "walkthrough_start")
+            .expect("walkthrough_start tool registered");
+        let append = tools
+            .iter()
+            .find(|t| t["name"] == "walkthrough_append")
+            .expect("walkthrough_append tool registered");
+        let targets = [
+            &start["inputSchema"]["properties"]["steps"]["items"]["properties"]["target"],
+            &append["inputSchema"]["properties"]["step"]["properties"]["target"],
+        ];
+        for target in targets {
+            let kinds: Vec<&str> = target["properties"]["kind"]["enum"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|v| v.as_str().unwrap())
+                .collect();
+            assert!(
+                kinds.contains(&"diagram-diff"),
+                "kind `diagram-diff` missing from {kinds:?}"
+            );
+            // The refs + diagram selector must be documented properties.
+            let props = &target["properties"];
+            assert!(props.get("diagram").is_some());
+            assert!(props.get("from").is_some());
+            assert!(props.get("to").is_some());
+            // Only the diagram kinds the GUI actually renders are offered.
+            let diagram_kinds: Vec<&str> = props["diagram"]["enum"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|v| v.as_str().unwrap())
+                .collect();
+            assert_eq!(diagram_kinds, ["folder-map", "bean-graph-live"]);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem (Fund F2, Verbesserungs-Sweep Runde 1)

Rust (`WalkthroughTarget::DiagramDiff { diagram, from, to }`, `crates/core/src/walkthrough.rs`) and the GUI (`DiagramDiffStep.svelte`, #125) fully support before/after architecture-snapshot tour steps — but the MCP step schema in `crates/mcp-server/src/tools.rs` never listed `diagram-diff` in the target `kind` enum. Schema-faithful MCP clients (including Claude) therefore could not author the V3 tour highlight at all.

## Fix

`walkthrough_step_schema()` is shared by `walkthrough_start` and `walkthrough_append`, so one change covers both tools:

- `"diagram-diff"` added to the `kind` enum (positioned to match the Rust enum order, before `note`)
- target description extended: kind list + one sentence explaining the before/after snapshot with `from`/`to` refs
- new properties documented:
  - `diagram` — enum `["folder-map", "bean-graph-live"]`, matching exactly what the GUI renders (`WalkthroughView.svelte` defaults omitted → `folder-map`)
  - `from` — base git ref for the before state (required by the Rust variant)
  - `to` — description updated to `kind=diff or kind=diagram-diff`

## Test

New regression test `walkthrough_step_schema_advertises_diagram_diff` asserts that **both** `walkthrough_start` and `walkthrough_append` advertise the kind, the `diagram`/`from`/`to` properties, and the exact diagram enum — alongside the existing `walkthrough_step_schema_advertises_cockpit_2_4_kinds` pattern.

## Gates (local)

- `cargo fmt --all --check` ✅
- `cargo clippy -p projectmind-mcp -p projectmind-core --all-targets -- -D warnings` ✅
- `cargo build -p projectmind-mcp -p projectmind-core` ✅ (full-workspace build fails on this box only because GTK/pkg-config is missing for the Tauri crate — pre-existing on clean master, unrelated)
- `cargo test -p projectmind-mcp -p projectmind-core` ✅ (330 tests, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJuL4nSq1EvgahTJe1hom1