### PR TITLE
chore(lint): ESLint 9 flat config, fix all findings, lint in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,13 @@ jobs:
         working-directory: app
         run: pnpm test
 
+      - name: Frontend lint (eslint 9) + svelte-check
+        if: runner.os == 'Linux'
+        working-directory: app
+        run: |
+          pnpm lint
+          pnpm check
+
       - name: Format + clippy
         env:
           PROJECTMIND_SKIP_TAURI_APP: ${{ runner.os == 'Linux' && '1' || '' }}

--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -1,0 +1,47 @@
+// ESLint 9 flat config for the Svelte 5 + TypeScript frontend.
+//
+// Layers:
+//   1. typescript-eslint flat/recommended — registers the TS parser + plugin
+//      and the recommended rule set (applied to *.ts and *.svelte).
+//   2. eslint-plugin-svelte flat/recommended — svelte-eslint-parser for
+//      *.svelte plus the recommended Svelte rules.
+//   3. A *.svelte override wiring @typescript-eslint/parser into the Svelte
+//      parser so <script lang="ts"> blocks get the TS rules too.
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+import svelte from 'eslint-plugin-svelte';
+
+export default [
+  {
+    // Build output and the Rust/Tauri shell are not lint targets.
+    ignores: ['dist/', 'src-tauri/'],
+  },
+  ...tsPlugin.configs['flat/recommended'],
+  ...svelte.configs['flat/recommended'],
+  {
+    files: ['**/*.svelte'],
+    languageOptions: {
+      parserOptions: {
+        // Parse <script lang="ts"> blocks with the TypeScript parser.
+        parser: tsParser,
+      },
+    },
+  },
+  {
+    rules: {
+      // `_`-prefixed bindings are the repo's deliberate placeholder
+      // convention (e.g. reactive-statement triggers, ignored tuple parts).
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+      // {@html} is the core rendering path of this app: the pure diagram
+      // renderers in src/lib/diagrams/*.ts return SVG strings (all dynamic
+      // text goes through their esc() helper) that the stage components
+      // mount verbatim. No user-supplied content flows into these strings,
+      // so the XSS guard would only produce a mandatory suppression on
+      // every renderer mount.
+      'svelte/no-at-html-tags': 'off',
+    },
+  },
+];

--- a/app/package.json
+++ b/app/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",
-    "lint": "eslint . --ext .ts,.svelte",
+    "lint": "eslint .",
     "format": "prettier --write 'src/**/*.{ts,svelte,html,css}'",
     "tauri": "tauri",
     "test": "vitest run",

--- a/app/src/App.svelte
+++ b/app/src/App.svelte
@@ -370,9 +370,6 @@
   let browserDropHint: string | null = null;
   let browserDropHintTimer: ReturnType<typeof setTimeout> | null = null;
   let unlistenDragDrop: (() => void) | null = null;
-  /// True while we're applying an MCP-driven state change. Prevents the
-  /// resulting load() from re-publishing and triggering an event loop.
-  let applyingExternal = false;
 
   // Whenever selectedClass changes (from sidebar click *or* a diagram drilldown)
   // load the source for the right-hand viewer.
@@ -675,7 +672,6 @@
   async function applyState(s: UiState) {
     if (s.seq <= lastSeq) return;
     lastSeq = s.seq;
-    applyingExternal = true;
     try {
       // Switch repos if needed. Swallow open errors silently — a stale
       // statefile (e.g. a test run that left behind a tmp path) shouldn't
@@ -751,8 +747,6 @@
       }
     } catch (err) {
       errorMessage.set(String(err));
-    } finally {
-      applyingExternal = false;
     }
   }
 

--- a/app/src/components/DiagramView.svelte
+++ b/app/src/components/DiagramView.svelte
@@ -291,8 +291,6 @@
   $: scale = $viewport.scale;
   $: tx = $viewport.tx;
   $: ty = $viewport.ty;
-  $: baseW = $viewport.baseW;
-  $: baseH = $viewport.baseH;
 
   let dragging = false;
   let dragStartX = 0;

--- a/app/src/components/PresenterView.svelte
+++ b/app/src/components/PresenterView.svelte
@@ -10,7 +10,7 @@
   import { onMount, onDestroy } from 'svelte';
   import { marked } from 'marked';
   import { currentWalkthrough, setWalkthroughStep, showClass, readFileText } from '../lib/api';
-  import type { Walkthrough, WalkthroughStep, LineRange, ClassEntry } from '../lib/api';
+  import type { Walkthrough, LineRange, ClassEntry } from '../lib/api';
   import { presenterActive, walkthroughCursor, errorMessage } from '../lib/store';
   import {
     initPresenter,

--- a/app/src/components/RiskAtlasView.svelte
+++ b/app/src/components/RiskAtlasView.svelte
@@ -3,13 +3,7 @@
   import { riskAtlas, type RiskScore, type RiskWeights } from '../lib/api';
   import { classes, selectedClass, viewMode } from '../lib/store';
   import { get } from 'svelte/store';
-  import {
-    treemap,
-    tileValue as val,
-    colorForScore as colorFor,
-    shortName,
-    type TreemapRect,
-  } from '../lib/treemap';
+  import { treemap, tileValue as val, colorForScore as colorFor, shortName } from '../lib/treemap';
 
   // Cockpit 2.1 — Risk Atlas (Issue #157):
   //   Treemap (Fläche = SLOC, Farbe = Score) auf dem bereits gemergten risk_atlas-Backend.
@@ -34,8 +28,6 @@
   // Container-Pixelmasse (für das Treemap-Layout).
   let boxW = 0;
   let boxH = 0;
-
-  type Rect = TreemapRect;
 
   function loadWeights(): RiskWeights {
     try {

--- a/app/src/components/WalkthroughView.svelte
+++ b/app/src/components/WalkthroughView.svelte
@@ -5,7 +5,6 @@
     currentWalkthrough,
     showClass,
     readFileText,
-    showDiff,
     ackWalkthrough,
     currentWalkthroughFeedback,
     requestMoreWalkthrough,
@@ -69,7 +68,6 @@
   let classMeta: { file: string; line_start: number; line_end: number } | null = null;
   let plainSource = '';
   let plainHighlight: LineRange[] = [];
-  let diffText = '';
   let targetLoading = false;
   let targetError: string | null = null;
   // Auto-annotation (Cockpit 2.4, #160): risk badges for the current `class`
@@ -280,7 +278,6 @@
     classMeta = null;
     plainSource = '';
     plainHighlight = [];
-    diffText = '';
     classBadges = [];
     targetError = null;
 
@@ -303,7 +300,8 @@
           // Markdown: FileView handles its own loading.
           break;
         case 'diff':
-          diffText = await showDiff(t.reference, t.to ?? undefined);
+          // DiffView self-loads the unified diff for the step — nothing to
+          // preload here (the old eager showDiff() fetch was never read).
           break;
         case 'artifact':
           // ArtifactView fetches its own body by id — nothing to preload.

--- a/app/src/lib/diagrams/folderMap.ts
+++ b/app/src/lib/diagrams/folderMap.ts
@@ -152,7 +152,6 @@ export function renderFolderTopDown(map: FolderMap, fillFor: FillFor = noFill): 
 
 export function renderFolderSolar(map: FolderMap, fillFor: FillFor = noFill): string {
   const nodes = map.nodes;
-  const byParent = groupByParent(nodes);
   const width = 1400;
   const height = 900;
   const cx = width / 2;


### PR DESCRIPTION
Fund #1 aus der Verbesserungs-Analyse (Desktop: ANALYSE-projectmind-verbesserungen-1.md).

- **ESLint 9 flat config** (`app/eslint.config.js`): typescript-eslint + eslint-plugin-svelte, `<script lang="ts">`-Blöcke laufen durch den TS-Parser. `pnpm lint` funktioniert wieder (war seit ESLint-9-Upgrade kaputt: kein flat config, `--ext` entfernt).
- **Alle Findings gefixt statt unterdrückt** — darunter zwei echte Funde:
  - `folderMap.ts`: tote `byParent`-Map entfernt
  - `App.svelte`: `applyingExternal` wurde gesetzt, aber **nie gelesen** — die dokumentierte MCP-Loop-Prevention lief in Wahrheit über den `lastSeq`-Guard; toter Alt-Mechanismus entfernt
- **Bewusste Regel-Entscheide (im Config kommentiert):** `^_`-Platzhalter-Konvention für no-unused-vars; `svelte/no-at-html-tags` off, weil `{@html}` der Kern-Renderpfad ist (eigene SVG-Renderer mit `esc()`, kein User-Content).
- **CI:** ubuntu-Job führt jetzt `pnpm lint` + `pnpm check` aus → Regressions blocken PRs.

Gates lokal: lint 0 · svelte-check 0/0 (855 Files) · vitest 474 · build grün.