### PR TITLE
feat(code-city): tour waypoints — auto camera flight to the active walkthrough step (#66 stage 3)

### DIFF
--- a/app/src/components/CodeCity.svelte
+++ b/app/src/components/CodeCity.svelte
@@ -10,15 +10,19 @@
   /// `codeCityLayout.ts` — this component only maps the model onto
   /// InstancedMesh instances and wires orbit + picking.
   ///
-  /// Stage 2/3 of the #66 flythrough: orbit camera + click-drill, plus a
-  /// first-person walk mode (V4.6b) — PointerLockControls own the look,
+  /// Stage 3/3 of the #66 flythrough: orbit camera + click-drill (V4.6a),
+  /// a first-person walk mode (V4.6b) — PointerLockControls own the look,
   /// the pure `cityWalk.ts` owns movement/collision/terrain, and a
-  /// crosshair raycast reuses the exact same drill codepath as orbit.
-  /// Tour waypoints (V4.6c) come on top.
+  /// crosshair raycast reuses the exact same drill codepath as orbit —
+  /// plus tour waypoints (V4.6c): while a walkthrough runs, the active
+  /// step is mapped onto its building (pure `cityTour.ts`), the building
+  /// is highlighted, and the orbit camera flies to it. Deliberately no
+  /// view hijacking — the flight only happens while the city is the open
+  /// view; a step arriving while another view is up does nothing here.
   import { onDestroy, onMount } from 'svelte';
   import { get } from 'svelte/store';
-  import { codeCityData } from '../lib/api';
-  import type { ClassEntry } from '../lib/api';
+  import { codeCityData, currentWalkthrough } from '../lib/api';
+  import type { ClassEntry, Walkthrough } from '../lib/api';
   import {
     cameraFitFor,
     codeCityLayout,
@@ -26,7 +30,22 @@
     type CityModel,
   } from '../lib/diagrams/codeCityLayout';
   import { groundHeightAt, stepMovement, WALK_DEFAULTS } from '../lib/diagrams/cityWalk';
-  import { classes, fileView, followingMcp, repo, selectedClass, viewMode } from '../lib/store';
+  import {
+    cameraFlightTo,
+    resolveTourTarget,
+    tweenPose,
+    type CameraPose,
+  } from '../lib/diagrams/cityTour';
+  import {
+    classes,
+    fileView,
+    followingMcp,
+    repo,
+    selectedClass,
+    viewMode,
+    walkthroughCursor,
+    type WalkthroughCursor,
+  } from '../lib/store';
   import { t } from '../lib/i18n';
 
   let container: HTMLDivElement;
@@ -83,6 +102,33 @@
   /// red high-risk tower still reads red when freshly committed.
   const GLOW_MIX = 0.55;
 
+  // --- Tour waypoints (V4.6c) ------------------------------------------------
+  /// Cool accent the active tour step's building lerps towards — same
+  /// colour-lerp technique as the recency glow, but cold so the two reads
+  /// stay distinguishable. The mix is stronger than GLOW_MIX: the tour
+  /// target must pop even on a red high-risk tower.
+  const TOUR_COLOR = '#59c2ff';
+  const TOUR_MIX = 0.65;
+  /// Flight duration of the camera tween towards a step's building.
+  const FLIGHT_MS = 1200;
+
+  /// Last cursor seen from the walkthrough store (null = no active tour).
+  let tourCursor: WalkthroughCursor | null = null;
+  /// Tour body cache — fetched once per tour id, steps looked up locally.
+  let tourBody: Walkthrough | null = null;
+  /// Guards the async body fetch against out-of-order responses.
+  let tourFetchSeq = 0;
+  /// Resolved building of the active step (highlight + beacon + chip),
+  /// plus its instance index for the colour restore.
+  let tourBuilding: CityBuilding | null = null;
+  let tourIndex = -1;
+  /// In-progress camera flight (orbit mode only). `start` is set on the
+  /// first animation frame; any user interaction aborts the flight.
+  let flight: { from: CameraPose; to: CameraPose; start: number | null } | null = null;
+  /// Walk-mode beacon: a translucent light pillar over the target building
+  /// (flying the pointer-locked camera around would be disorienting).
+  let beacon: import('three').Mesh | null = null;
+
   async function mountCity() {
     loading = true;
     error = null;
@@ -110,6 +156,9 @@
       }
 
       buildScene(three, OrbitControls, model);
+      // A tour may already be running when the city opens — apply its
+      // active step now that model + scene exist (V4.6c).
+      applyTour();
       loading = false;
     } catch (err) {
       error = String(err);
@@ -198,6 +247,20 @@
     scene.add(buildingsMesh);
     disposables.push(buildingsMesh);
 
+    // Tour beacon (V4.6c): shares the unit cube, scaled per target into a
+    // translucent light pillar. Basic material — the beacon is light, not
+    // architecture, so it must not react to the sun.
+    const beaconMat = new T.MeshBasicMaterial({
+      color: TOUR_COLOR,
+      transparent: true,
+      opacity: 0.3,
+      depthWrite: false,
+    });
+    disposables.push(beaconMat);
+    beacon = new T.Mesh(box, beaconMat);
+    beacon.visible = false;
+    scene.add(beacon);
+
     raycaster = new T.Raycaster();
 
     resizeObserver = new ResizeObserver(() => {
@@ -214,12 +277,19 @@
     renderer.domElement.addEventListener('pointerdown', onPointerDown);
     renderer.domElement.addEventListener('pointerup', onPointerUp);
     renderer.domElement.addEventListener('pointerleave', onPointerLeave);
+    renderer.domElement.addEventListener('wheel', onWheel, { passive: true });
 
     // Continuous loop — damping needs per-frame control updates anyway;
-    // torn down via setAnimationLoop(null) in onDestroy.
+    // torn down via setAnimationLoop(null) in onDestroy. During a tour
+    // flight the tween writes the pose first; controls.update() is a
+    // no-op then (any user input cancels the flight before it applies).
     renderer.setAnimationLoop((time: number) => {
-      if (walkMode) stepWalkFrame(time);
-      else controls?.update();
+      if (walkMode) {
+        stepWalkFrame(time);
+      } else {
+        stepFlight(time);
+        controls?.update();
+      }
       if (renderer && scene && camera) renderer.render(scene, camera);
     });
   }
@@ -227,10 +297,124 @@
   /// Fly the orbit camera back to the establishing shot.
   export function resetCamera() {
     if (!camera || !controls || !model || walkMode) return;
+    flight = null; // user intent beats an in-progress tour flight
     const fit = cameraFitFor(model);
     camera.position.set(...fit.position);
     controls.target.set(...fit.target);
     controls.update();
+  }
+
+  // --- Tour waypoints (V4.6c) -------------------------------------------------
+
+  /// Store subscription: every cursor move re-resolves the active step.
+  /// The body is fetched once per tour id; a stale response (tour switched
+  /// mid-fetch) is dropped via the sequence guard.
+  const unsubscribeTour = walkthroughCursor.subscribe((cur) => {
+    void onTourCursor(cur);
+  });
+
+  async function onTourCursor(cur: WalkthroughCursor | null) {
+    tourCursor = cur;
+    const seq = ++tourFetchSeq;
+    if (cur && (!tourBody || tourBody.id !== cur.id)) {
+      try {
+        const body = await currentWalkthrough();
+        if (seq !== tourFetchSeq) return; // superseded by a newer cursor
+        tourBody = body;
+      } catch {
+        tourBody = null; // no body → steps can't resolve; visuals clear below
+      }
+    }
+    applyTour();
+  }
+
+  /// Resolve the active step onto a building and drive the visuals:
+  /// highlight (both modes), camera flight (orbit) or beacon (walk).
+  /// Steps without city geometry (diff/note/…) are stopovers — the camera
+  /// holds its position and no building is marked.
+  function applyTour() {
+    if (!model) return; // city still loading; mountCity re-applies
+    const step =
+      tourCursor && tourBody && tourBody.id === tourCursor.id
+        ? (tourBody.steps[tourCursor.step] ?? null)
+        : null;
+    const hit = step ? resolveTourTarget(model, step.target, get(repo)?.root ?? null) : null;
+    const idx = hit ? model.buildings.findIndex((b) => b.id === hit.buildingId) : -1;
+    setTourBuilding(idx);
+    if (tourBuilding && !walkMode) startFlight(tourBuilding);
+  }
+
+  /// Swap the highlighted building: restore the previous instance colour,
+  /// lerp the new one towards the tour accent (same technique as the glow).
+  /// The highlight persists until the next step replaces or clears it.
+  function setTourBuilding(idx: number) {
+    if (idx === tourIndex) {
+      tourBuilding = idx >= 0 ? (model?.buildings[idx] ?? null) : null;
+      updateBeacon();
+      return;
+    }
+    if (tourIndex >= 0) paintBuilding(tourIndex, false);
+    tourIndex = idx;
+    tourBuilding = idx >= 0 ? (model?.buildings[idx] ?? null) : null;
+    if (idx >= 0) paintBuilding(idx, true);
+    updateBeacon();
+  }
+
+  /// Recompute one instance colour from scratch (base risk colour + glow
+  /// lerp — mirrors buildScene), optionally lerped towards the tour accent.
+  function paintBuilding(i: number, highlighted: boolean) {
+    if (!three || !buildingsMesh || !model) return;
+    const b = model.buildings[i];
+    if (!b) return;
+    const color = new three.Color(b.color);
+    if (b.glow > 0) color.lerp(new three.Color(GLOW_COLOR), b.glow * GLOW_MIX);
+    if (highlighted) color.lerp(new three.Color(TOUR_COLOR), TOUR_MIX);
+    buildingsMesh.setColorAt(i, color);
+    if (buildingsMesh.instanceColor) buildingsMesh.instanceColor.needsUpdate = true;
+  }
+
+  /// Walk-mode beacon: a translucent pillar rising from the target's roof.
+  /// Orbit mode hides it — the flight + highlight already carry the read.
+  function updateBeacon() {
+    if (!beacon) return;
+    const b = tourBuilding;
+    if (!b || !walkMode) {
+      beacon.visible = false;
+      return;
+    }
+    const thickness = Math.max(Math.min(b.w, b.d) * 0.6, 0.6);
+    const pillar = 16;
+    beacon.scale.set(thickness, pillar, thickness);
+    beacon.position.set(b.x + b.w / 2, b.y + b.h + pillar / 2, b.z + b.d / 2);
+    beacon.visible = true;
+  }
+
+  /// Tween the orbit camera towards the building's waypoint pose. The
+  /// flight starts from wherever the camera currently is, so repeated
+  /// steps re-centre smoothly; any user input (drag/wheel/walk) aborts it.
+  function startFlight(b: CityBuilding) {
+    if (!camera || !controls || !model) return;
+    const from: CameraPose = {
+      position: camera.position.toArray() as [number, number, number],
+      target: controls.target.toArray() as [number, number, number],
+    };
+    flight = { from, to: cameraFlightTo(model, b, from), start: null };
+  }
+
+  /// One flight frame, driven by the shared animation loop (orbit branch).
+  function stepFlight(now: number) {
+    if (!flight || !camera || !controls) return;
+    if (flight.start === null) flight.start = now;
+    const t = (now - flight.start) / FLIGHT_MS;
+    const pose = tweenPose(flight.from, flight.to, t);
+    camera.position.set(...pose.position);
+    controls.target.set(...pose.target);
+    if (t >= 1) flight = null;
+  }
+
+  /// Wheel zoom is user intent — abort a running tour flight.
+  function onWheel() {
+    flight = null;
   }
 
   // --- First-person walk (V4.6b) ---------------------------------------------
@@ -266,6 +450,8 @@
     hover = null;
     walkTarget = null;
     walkMode = true;
+    flight = null; // walking takes over — no camera flights at street level
+    updateBeacon(); // …the beacon marks the tour target instead
     lastTick = 0;
     document.addEventListener('keydown', onWalkKeyDown);
     document.addEventListener('keyup', onWalkKeyUp);
@@ -299,6 +485,7 @@
       controls.enabled = true;
       controls.update();
     }
+    updateBeacon(); // beacon is walk-only; orbit shows highlight + flight
   }
 
   /// Pointer lock released (Esc or focus loss) → back to orbit.
@@ -407,6 +594,7 @@
   let downAt: { x: number; y: number } | null = null;
   function onPointerDown(e: PointerEvent) {
     if (walkMode) return; // walk clicks drill via onWalkMouseDown
+    flight = null; // any press (drag start) takes the camera back
     if (e.button === 0) downAt = { x: e.clientX, y: e.clientY };
   }
 
@@ -457,6 +645,10 @@
   });
 
   onDestroy(() => {
+    // Tour plumbing first: stop reacting to cursor moves, drop the flight.
+    unsubscribeTour();
+    tourFetchSeq++; // poison in-flight body fetches
+    flight = null;
     // A drill out of walk mode destroys this component while the pointer is
     // still locked — release it (and the key listeners) first.
     exitWalk();
@@ -468,6 +660,7 @@
       renderer.domElement.removeEventListener('pointerdown', onPointerDown);
       renderer.domElement.removeEventListener('pointerup', onPointerUp);
       renderer.domElement.removeEventListener('pointerleave', onPointerLeave);
+      renderer.domElement.removeEventListener('wheel', onWheel);
       renderer.domElement.remove();
     }
     resizeObserver?.disconnect();
@@ -481,6 +674,7 @@
     controls = null;
     buildingsMesh = null;
     raycaster = null;
+    beacon = null;
     three = null;
   });
 </script>
@@ -516,6 +710,11 @@
     </span>
     {#if truncated}
       <span class="truncated" title={$t('diagram.codeCity.truncated')}>⚠ {$t('diagram.codeCity.truncated')}</span>
+    {/if}
+    {#if tourBuilding}
+      <span class="tour-chip" title={$t('diagram.codeCity.tourHint')}>
+        ▶ {$t('diagram.codeCity.tour')} · {tourBuilding.label}
+      </span>
     {/if}
     <span class="hint">{$t('diagram.drillHint')}</span>
   </div>
@@ -634,6 +833,18 @@
   .truncated {
     font-size: 11px;
     color: #f0b429;
+  }
+  /* --- Tour chip (V4.6c) — the accent matches TOUR_COLOR in the scene. --- */
+  .tour-chip {
+    font-size: 11px;
+    color: #59c2ff;
+    border: 1px solid color-mix(in srgb, #59c2ff 40%, transparent);
+    border-radius: 10px;
+    padding: 1px 8px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 220px;
   }
   .hint {
     margin-left: auto;

--- a/app/src/i18n/de.json
+++ b/app/src/i18n/de.json
@@ -96,6 +96,8 @@
   "diagram.codeCity.legendGlow": "Glühen = Commits < 7d",
   "diagram.codeCity.walk": "Begehen",
   "diagram.codeCity.walkHud": "WASD bewegen · Maus umsehen · Shift rennen · Esc beendet",
+  "diagram.codeCity.tour": "Tour",
+  "diagram.codeCity.tourHint": "Folgt dem aktiven Tour-Schritt — im Orbit fliegt die Kamera zum Gebäude, zu Fuß markiert es ein Leuchtfeuer; Ziehen übernimmt",
   "diagram.drillHint": "Klicke auf einen Knoten, um hineinzuspringen",
   "diagram.colourBy": "einfärben nach",
   "diagram.colourBy.structure": "Nach Knotenart einfärben (Standard)",

--- a/app/src/i18n/en.json
+++ b/app/src/i18n/en.json
@@ -96,6 +96,8 @@
   "diagram.codeCity.legendGlow": "glow = commits < 7d",
   "diagram.codeCity.walk": "Walk",
   "diagram.codeCity.walkHud": "WASD move · mouse look · Shift run · Esc exit",
+  "diagram.codeCity.tour": "Tour",
+  "diagram.codeCity.tourHint": "Following the active tour step — in orbit the camera flies to its building, on foot a beacon marks it; drag to take over",
   "diagram.drillHint": "Click a node to drill into it",
   "diagram.colourBy": "colour by",
   "diagram.colourBy.structure": "Colour by node kind (default)",

--- a/app/src/i18n/es.json
+++ b/app/src/i18n/es.json
@@ -96,6 +96,8 @@
   "diagram.codeCity.legendGlow": "brillo = commits < 7d",
   "diagram.codeCity.walk": "Caminar",
   "diagram.codeCity.walkHud": "WASD moverse · ratón mirar · Mayús correr · Esc salir",
+  "diagram.codeCity.tour": "Tour",
+  "diagram.codeCity.tourHint": "Sigue el paso activo del tour — en órbita la cámara vuela hasta su edificio, a pie lo marca una baliza; arrastra para retomar el control",
   "diagram.drillHint": "Haz clic en un nodo para explorar",
   "diagram.colourBy": "colorear por",
   "diagram.colourBy.structure": "Colorear por tipo de nodo (predeterminado)",

--- a/app/src/i18n/fr.json
+++ b/app/src/i18n/fr.json
@@ -96,6 +96,8 @@
   "diagram.codeCity.legendGlow": "lueur = commits < 7j",
   "diagram.codeCity.walk": "Marcher",
   "diagram.codeCity.walkHud": "WASD se déplacer · souris regarder · Maj courir · Échap quitter",
+  "diagram.codeCity.tour": "Visite",
+  "diagram.codeCity.tourHint": "Suit l'étape active de la visite — en orbite la caméra vole vers son bâtiment, à pied une balise le signale ; glisser pour reprendre la main",
   "diagram.drillHint": "Cliquez sur un noeud pour explorer",
   "diagram.colourBy": "colorer par",
   "diagram.colourBy.structure": "Colorer par type de noeud (par défaut)",

--- a/app/src/i18n/it.json
+++ b/app/src/i18n/it.json
@@ -96,6 +96,8 @@
   "diagram.codeCity.legendGlow": "bagliore = commit < 7g",
   "diagram.codeCity.walk": "Cammina",
   "diagram.codeCity.walkHud": "WASD muoversi · mouse guardare · Maiusc correre · Esc esce",
+  "diagram.codeCity.tour": "Tour",
+  "diagram.codeCity.tourHint": "Segue il passo attivo del tour — in orbita la camera vola verso il suo edificio, a piedi lo segnala un faro; trascina per riprendere il controllo",
   "diagram.drillHint": "Fai clic su un nodo per esplorarlo",
   "diagram.colourBy": "colora per",
   "diagram.colourBy.structure": "Colora per tipo di nodo (predefinito)",

--- a/app/src/lib/diagrams/cityTour.test.ts
+++ b/app/src/lib/diagrams/cityTour.test.ts
@@ -1,0 +1,245 @@
+/// Tests for the pure tour-waypoint logic (V4.6c, #66). No DOM, no WebGL —
+/// vitest under happy-dom must stay green on the Linux CI runner, so nothing
+/// here (nor in cityTour.ts) may import three.
+
+import { describe, expect, it } from 'vitest';
+import type { WalkthroughTarget } from '../api';
+import type { CityBuilding, CityModel } from './codeCityLayout';
+import {
+  cameraFlightTo,
+  normalizeStepPath,
+  resolveTourTarget,
+  smoothstep,
+  TOUR_CAMERA_DEFAULTS,
+  tweenPose,
+  type CameraPose,
+} from './cityTour';
+
+function building(
+  partial: Partial<CityBuilding> & Pick<CityBuilding, 'id' | 'x' | 'z' | 'w' | 'd' | 'h'>,
+): CityBuilding {
+  return {
+    label: partial.id,
+    fqn: null,
+    module: null,
+    y: 0,
+    color: 'hsl(215, 15%, 40%)',
+    glow: 0,
+    score: null,
+    sloc: null,
+    bytes: 100,
+    ...partial,
+  };
+}
+
+/// Two buildings: a parsed Rust tower with an fqn (hottest class) and a
+/// plain Svelte file without one.
+const tower = building({
+  id: 'crates/core/src/engine.rs',
+  fqn: 'core::engine::Engine',
+  module: 'core',
+  x: 30,
+  z: 30,
+  w: 4,
+  d: 4,
+  y: 0.6,
+  h: 20,
+});
+const shed = building({ id: 'app/src/App.svelte', x: 80, z: 10, w: 1, d: 1, h: 0.5 });
+
+const model: CityModel = {
+  world: 200,
+  truncated: false,
+  districts: [],
+  buildings: [tower, shed],
+};
+
+const ROOT = '/home/user/projects/demo';
+
+describe('normalizeStepPath', () => {
+  it('strips the repo root off an absolute step path', () => {
+    expect(normalizeStepPath(`${ROOT}/app/src/App.svelte`, ROOT)).toBe('app/src/App.svelte');
+  });
+
+  it('tolerates a trailing slash on the root', () => {
+    expect(normalizeStepPath(`${ROOT}/a.ts`, `${ROOT}/`)).toBe('a.ts');
+  });
+
+  it('passes an already repo-relative path through', () => {
+    expect(normalizeStepPath('app/src/App.svelte', ROOT)).toBe('app/src/App.svelte');
+    expect(normalizeStepPath('./app/src/App.svelte', ROOT)).toBe('app/src/App.svelte');
+  });
+
+  it('folds Windows separators', () => {
+    expect(normalizeStepPath('C:\\repo\\src\\a.ts', 'C:\\repo')).toBe('src/a.ts');
+  });
+
+  it('leaves paths outside the root untouched (they match no building)', () => {
+    expect(normalizeStepPath('/elsewhere/x.ts', ROOT)).toBe('/elsewhere/x.ts');
+  });
+
+  it('works without a root (null)', () => {
+    expect(normalizeStepPath('app/a.ts', null)).toBe('app/a.ts');
+  });
+});
+
+describe('resolveTourTarget', () => {
+  it('maps a class step onto the building carrying that fqn', () => {
+    const t: WalkthroughTarget = { kind: 'class', fqn: 'core::engine::Engine' };
+    expect(resolveTourTarget(model, t, ROOT)).toEqual({ buildingId: tower.id });
+  });
+
+  it('maps a risk step like a class step', () => {
+    const t: WalkthroughTarget = { kind: 'risk', fqn: 'core::engine::Engine' };
+    expect(resolveTourTarget(model, t, ROOT)).toEqual({ buildingId: tower.id });
+  });
+
+  it('misses on an unknown fqn', () => {
+    const t: WalkthroughTarget = { kind: 'class', fqn: 'no.such.Class' };
+    expect(resolveTourTarget(model, t, ROOT)).toBeNull();
+  });
+
+  it('maps an absolute file step onto the repo-relative building id', () => {
+    const t: WalkthroughTarget = { kind: 'file', path: `${ROOT}/app/src/App.svelte` };
+    expect(resolveTourTarget(model, t, ROOT)).toEqual({ buildingId: shed.id });
+  });
+
+  it('maps a repo-relative file step directly', () => {
+    const t: WalkthroughTarget = { kind: 'file', path: 'app/src/App.svelte' };
+    expect(resolveTourTarget(model, t, null)).toEqual({ buildingId: shed.id });
+  });
+
+  it('misses on a file outside the city', () => {
+    const t: WalkthroughTarget = { kind: 'file', path: `${ROOT}/README.adoc` };
+    expect(resolveTourTarget(model, t, ROOT)).toBeNull();
+  });
+
+  it('returns null for kinds without city geometry', () => {
+    const targets: WalkthroughTarget[] = [
+      { kind: 'note' },
+      { kind: 'diff', reference: 'HEAD~1' },
+      { kind: 'artifact', id: 'a1' },
+      { kind: 'pattern', pattern: 'layering' },
+      { kind: 'atlas' },
+      { kind: 'diagram-diff', from: 'HEAD~5' },
+    ];
+    for (const t of targets) {
+      expect(resolveTourTarget(model, t, ROOT)).toBeNull();
+    }
+  });
+});
+
+describe('cameraFlightTo', () => {
+  const centreOf = (b: CityBuilding): [number, number, number] => [
+    b.x + b.w / 2,
+    b.y + b.h / 2,
+    b.z + b.d / 2,
+  ];
+
+  it('looks at the building centre at half height', () => {
+    const pose = cameraFlightTo(model, tower, null);
+    expect(pose.target).toEqual(centreOf(tower));
+  });
+
+  it('approaches from the configured elevation', () => {
+    const pose = cameraFlightTo(model, tower, null);
+    const dy = pose.position[1] - pose.target[1];
+    const horizontal = Math.hypot(
+      pose.position[0] - pose.target[0],
+      pose.position[2] - pose.target[2],
+    );
+    expect(Math.atan2(dy, horizontal)).toBeCloseTo(TOUR_CAMERA_DEFAULTS.elevation, 9);
+  });
+
+  it('scales the distance with the building size, clamped below by minDistance', () => {
+    const dist = (b: CityBuilding): number => {
+      const pose = cameraFlightTo(model, b, null);
+      return Math.hypot(
+        pose.position[0] - pose.target[0],
+        pose.position[1] - pose.target[1],
+        pose.position[2] - pose.target[2],
+      );
+    };
+    // Tower: height 20 dominates → 20 · 2.4 = 48.
+    expect(dist(tower)).toBeCloseTo(20 * TOUR_CAMERA_DEFAULTS.distanceFactor, 9);
+    // Shed: everything tiny → clamped to minDistance.
+    expect(dist(shed)).toBeCloseTo(TOUR_CAMERA_DEFAULTS.minDistance, 9);
+    // Never further out than the world edge length.
+    const skyscraper = building({ id: 'big', x: 0, z: 0, w: 100, d: 100, h: 30 });
+    expect(dist(skyscraper)).toBeCloseTo(model.world, 9);
+  });
+
+  it('ends up outside the building footprint', () => {
+    const pose = cameraFlightTo(model, tower, null);
+    const [x, , z] = pose.position;
+    const inside = x > tower.x && x < tower.x + tower.w && z > tower.z && z < tower.z + tower.d;
+    expect(inside).toBe(false);
+  });
+
+  it('keeps the approach azimuth of the current pose', () => {
+    // Camera due north of the target (−z side) → stays on that side.
+    const current: CameraPose = { position: [32, 50, -100], target: [0, 0, 0] };
+    const pose = cameraFlightTo(model, tower, current);
+    expect(pose.position[2]).toBeLessThan(pose.target[2]);
+    expect(pose.position[0]).toBeCloseTo(pose.target[0], 9);
+  });
+
+  it('falls back to the establishing-shot diagonal without a usable azimuth', () => {
+    const overhead: CameraPose = { position: [32, 90, 32], target: [32, 0, 32] };
+    for (const current of [null, overhead]) {
+      const pose = cameraFlightTo(model, tower, current);
+      const dx = pose.position[0] - pose.target[0];
+      const dz = pose.position[2] - pose.target[2];
+      expect(Math.atan2(dx, dz)).toBeCloseTo(Math.PI / 4, 9);
+    }
+  });
+});
+
+describe('smoothstep / tweenPose', () => {
+  const a: CameraPose = { position: [0, 10, 20], target: [1, 2, 3] };
+  const b: CameraPose = { position: [100, 50, -20], target: [7, 8, 9] };
+
+  it('hits the endpoints exactly (including out-of-range t)', () => {
+    expect(tweenPose(a, b, 0)).toEqual(a);
+    expect(tweenPose(a, b, 1)).toEqual(b);
+    expect(tweenPose(a, b, -0.5)).toEqual(a);
+    expect(tweenPose(a, b, 1.5)).toEqual(b);
+  });
+
+  it('returns copies, never aliases of the input arrays', () => {
+    const startPose = tweenPose(a, b, 0);
+    expect(startPose.position).not.toBe(a.position);
+    startPose.position[0] = 999;
+    expect(a.position[0]).toBe(0);
+  });
+
+  it('passes the halfway point at t = 0.5 (smoothstep symmetry)', () => {
+    const mid = tweenPose(a, b, 0.5);
+    expect(mid.position[0]).toBeCloseTo(50, 9);
+    expect(mid.target[1]).toBeCloseTo(5, 9);
+  });
+
+  it('progresses monotonically with zero slope at the ends', () => {
+    let prev = -1;
+    for (let i = 0; i <= 20; i++) {
+      const s = smoothstep(i / 20);
+      expect(s).toBeGreaterThanOrEqual(prev);
+      prev = s;
+    }
+    // Ease-in/out: the first and last 5 % move less than a linear ramp.
+    expect(smoothstep(0.05)).toBeLessThan(0.05);
+    expect(1 - smoothstep(0.95)).toBeLessThan(0.05);
+  });
+
+  it('every position component moves monotonically towards the destination', () => {
+    let prevX = a.position[0];
+    let prevZ = a.position[2];
+    for (let i = 1; i <= 10; i++) {
+      const pose = tweenPose(a, b, i / 10);
+      expect(pose.position[0]).toBeGreaterThanOrEqual(prevX); // 0 → 100
+      expect(pose.position[2]).toBeLessThanOrEqual(prevZ); // 20 → −20
+      prevX = pose.position[0];
+      prevZ = pose.position[2];
+    }
+  });
+});

--- a/app/src/lib/diagrams/cityTour.ts
+++ b/app/src/lib/diagrams/cityTour.ts
@@ -1,0 +1,169 @@
+/// Tour waypoints for the code city (V4.6c, #66) — pure math + string
+/// mapping, no DOM, no WebGL, no three import (Linux CI runs vitest without
+/// WebGL). Stage 3/3 of the #66 flythrough.
+///
+/// `CodeCity.svelte` drives this from its walkthrough-store subscription:
+/// while a tour runs, the active step's target is mapped onto a building
+/// (`resolveTourTarget`), the orbit camera gets a destination pose
+/// (`cameraFlightTo`) and the animation loop eases towards it
+/// (`tweenPose`). Deliberately **frontend-only**: the Rust
+/// `WalkthroughTarget` enum stays untouched — the city reads the existing
+/// class/file/risk targets and maps them itself.
+///
+/// Mapping rules (see `resolveTourTarget`):
+/// - `class` / `risk` → the building whose `fqn` (the file's hottest class,
+///   from the risk join) equals the step's fqn.
+/// - `file` → the building whose repo-relative `id` equals the step path.
+///   Step paths are absolute (the MCP schema wants them that way), building
+///   ids are repo-relative — the repo root is stripped first, the exact
+///   inverse of the drill's `${root}/${b.id}` join in `CodeCity.svelte`.
+/// - every other kind (diff / artifact / pattern / atlas / diagram-diff /
+///   note) has no city geometry → `null`; the camera holds its position and
+///   the step is a stopover in the flyover.
+
+import type { WalkthroughTarget } from '../api';
+import type { CityBuilding, CityModel } from './codeCityLayout';
+
+/// Orbit camera pose: eye position + look-at target, both world-space
+/// `[x, y, z]` — exactly the shape `cameraFitFor` returns, so a flight can
+/// start from (and end on) any pose the component already knows.
+export interface CameraPose {
+  position: [number, number, number];
+  target: [number, number, number];
+}
+
+export interface TourCameraOptions {
+  /// Elevation of the approach above the horizon, in radians.
+  elevation?: number;
+  /// Camera distance as a multiple of the building's dominant dimension.
+  distanceFactor?: number;
+  /// Lower distance clamp — a 0.5-unit shed must not fill the screen.
+  minDistance?: number;
+}
+
+/// Camera heuristic (default 50° FOV): an object of size S fills the frame
+/// at ≈ 1.07·S, so `distanceFactor` 2.4 shows the building at roughly 40 %
+/// of the frame height with its district as context. 35° elevation keeps
+/// both the facade colour (risk) and the roof footprint readable — flatter
+/// hides the layout, steeper hides the height. `minDistance` 12 stops tiny
+/// buildings from becoming wall-filling close-ups.
+export const TOUR_CAMERA_DEFAULTS: Required<TourCameraOptions> = {
+  elevation: (35 * Math.PI) / 180,
+  distanceFactor: 2.4,
+  minDistance: 12,
+};
+
+/// Normalise a walkthrough file path onto the building-id scale: absolute
+/// step path → repo-relative forward-slashed path (the inverse of the
+/// drill's `${root}/${b.id}` join). Windows separators are folded, an
+/// already-relative path passes through, and a path outside the repo root
+/// is returned as-is (it will simply match no building).
+export function normalizeStepPath(path: string, repoRoot: string | null): string {
+  const slashed = path.replace(/\\/g, '/');
+  if (repoRoot) {
+    const root = repoRoot.replace(/\\/g, '/').replace(/\/+$/, '');
+    if (root && slashed.startsWith(root + '/')) {
+      return slashed.slice(root.length + 1);
+    }
+  }
+  return slashed.replace(/^\.\//, '');
+}
+
+/// Map the active step's target onto a city building. Returns `null` for
+/// misses and for kinds without city geometry — the caller then holds the
+/// camera (stopover) instead of flying. See the module header for the
+/// per-kind rules.
+export function resolveTourTarget(
+  model: CityModel,
+  target: WalkthroughTarget,
+  repoRoot: string | null,
+): { buildingId: string } | null {
+  switch (target.kind) {
+    case 'class':
+    case 'risk': {
+      const hit = model.buildings.find((b) => b.fqn === target.fqn);
+      return hit ? { buildingId: hit.id } : null;
+    }
+    case 'file': {
+      const rel = normalizeStepPath(target.path, repoRoot);
+      const hit = model.buildings.find((b) => b.id === rel);
+      return hit ? { buildingId: hit.id } : null;
+    }
+    default:
+      return null;
+  }
+}
+
+/// Destination pose for a flight to `building`: look at the building's
+/// centre (half height — facade and roof share the frame), from
+/// `elevation` above the horizon at a distance proportional to the
+/// building's dominant dimension (max of footprint diagonal and height —
+/// see `TOUR_CAMERA_DEFAULTS` for the numbers). The approach azimuth is
+/// kept from `currentPose` — the camera swings around the *shortest* arc
+/// instead of always circling to a fixed compass side. Degenerate current
+/// poses (no pose yet, or camera directly above the target) fall back to
+/// the π/4 diagonal of the establishing shot (`cameraFitFor`).
+export function cameraFlightTo(
+  model: CityModel,
+  building: CityBuilding,
+  currentPose: CameraPose | null,
+  opts?: TourCameraOptions,
+): CameraPose {
+  const o: Required<TourCameraOptions> = { ...TOUR_CAMERA_DEFAULTS, ...opts };
+  const target: [number, number, number] = [
+    building.x + building.w / 2,
+    building.y + building.h / 2,
+    building.z + building.d / 2,
+  ];
+
+  const size = Math.max(Math.hypot(building.w, building.d), building.h);
+  const distance = Math.min(Math.max(size * o.distanceFactor, o.minDistance), model.world);
+
+  // Approach azimuth: keep the camera on its current side of the target.
+  let azimuth = Math.PI / 4;
+  if (currentPose) {
+    const dx = currentPose.position[0] - target[0];
+    const dz = currentPose.position[2] - target[2];
+    // Below ~1 world unit of horizontal offset the direction is noise
+    // (e.g. hovering directly above) — use the establishing-shot diagonal.
+    if (Math.hypot(dx, dz) > 1) azimuth = Math.atan2(dx, dz);
+  }
+
+  const horizontal = Math.cos(o.elevation) * distance;
+  return {
+    position: [
+      target[0] + Math.sin(azimuth) * horizontal,
+      target[1] + Math.sin(o.elevation) * distance,
+      target[2] + Math.cos(azimuth) * horizontal,
+    ],
+    target,
+  };
+}
+
+/// Smoothstep 3t² − 2t³ on the clamped unit interval: zero slope at both
+/// ends (the camera departs and arrives gently), strictly monotonic in
+/// between.
+export function smoothstep(t: number): number {
+  const x = Math.min(Math.max(t, 0), 1);
+  return x * x * (3 - 2 * x);
+}
+
+/// Interpolate between two camera poses with smoothstep easing. `t` ≤ 0
+/// returns exactly `a`, `t` ≥ 1 exactly `b` (no floating-point drift at the
+/// endpoints — the flight must land on the computed pose). Positions and
+/// look-at targets are lerped component-wise; the orbit camera derives its
+/// orientation from `lookAt(target)`, so no yaw wrapping is needed here.
+export function tweenPose(a: CameraPose, b: CameraPose, t: number): CameraPose {
+  if (t <= 0) return { position: [...a.position], target: [...a.target] };
+  if (t >= 1) return { position: [...b.position], target: [...b.target] };
+  const s = smoothstep(t);
+  const lerp3 = (
+    from: [number, number, number],
+    to: [number, number, number],
+  ): [number, number, number] => [
+    from[0] + (to[0] - from[0]) * s,
+    from[1] + (to[1] - from[1]) * s,
+    from[2] + (to[2] - from[2]) * s,
+  ];
+  return { position: lerp3(a.position, b.position), target: lerp3(a.target, b.target) };
+}


### PR DESCRIPTION
Refs #66 — Stufe 3/3 — schließt die Code-City-Trilogie (Orbit #206 → Walk #207 → Tour).

## Was

Läuft eine Walkthrough-Tour, folgt die 3D-Code-City dem aktiven Step:

- **Neu `app/src/lib/diagrams/cityTour.ts`** (pure, DOM-/WebGL-frei, 24 Tests):
  - `resolveTourTarget(model, target, repoRoot)` — Step-Target → Gebäude:
    - `class` / `risk` → fqn-Match auf `CityBuilding.fqn` (die hotteste Klasse der Datei aus dem Risk-Join)
    - `file` → absoluter Step-Pfad wird via repo.root auf die repo-relative Gebäude-id gestrippt (exakte Umkehrung des Drill-Joins `${root}/${b.id}`); Windows-Separatoren gefaltet, bereits relative Pfade passieren
    - alle anderen Kinds (diff/note/artifact/pattern/atlas/diagram-diff) → `null` = Zwischenstopp, Kamera hält Position
  - `cameraFlightTo` — Zielpose: Blick auf Gebäudemitte (halbe Höhe), **35° Elevation**, Abstand = `max(Grundriss-Diagonale, Höhe) × 2.4` (bei 50° FOV füllt das Gebäude ~40 % der Bildhöhe, District als Kontext), geklemmt auf [12, world]. Anflug-Azimut bleibt auf der aktuellen Kameraseite (kürzester Schwenk); degenerierte Posen fallen auf die π/4-Diagonale des Establishing-Shots zurück.
  - `tweenPose` / `smoothstep` — 3t²−2t³, Endpunkte exakt (t≤0 → a, t≥1 → b), monotone Komponenten.
- **`CodeCity.svelte`**: Subscription auf `walkthroughCursor` (Body via `currentWalkthrough()` einmal pro Tour-id gecacht, Sequence-Guard gegen stale Fetches):
  - **Orbit**: ~1,2 s Kamerafahrt im bestehenden `setAnimationLoop`; **Abbruch bei User-Input** (Pointer-Down/Wheel/Walk-Toggle/Reset).
  - **Walk**: keine Fahrt (Pointer-Lock-Kamera fremdzusteuern wäre desorientierend) — stattdessen dezenter Beacon: transluzente Lichtsäule über dem Zielgebäude.
  - **Highlight**: Instanzfarbe des Zielgebäudes wird zur kühlen Akzentfarbe gelerpt (gleiche Technik wie der Recency-Glow, kalt statt warm, stärkerer Mix) — bleibt bis zum nächsten Step; Toolbar-Chip nennt das Ziel.
  - Hygiene: `onDestroy` unsubscribed, poisont laufende Fetches, räumt Wheel-Listener + Beacon-Material ab.
- **i18n**: `diagram.codeCity.tour` + `diagram.codeCity.tourHint` in allen 5 Locales (en/de/fr/it/es — `i18nParity.test.ts` grün).

## Bewusste Entscheidungen

- **Frontend-only**: kein neues Rust-`WalkthroughTarget`, kein Schema-Bump, kein MCP-Change — die City liest die vorhandenen Steps und mappt selbst (Plan V4.6c).
- **Kein View-Hijacking**: Die Fahrt passiert nur, wenn die City gerade die offene View ist. Ein Step, der bei anderer View eintrifft, ändert nichts — öffnet man die City später, wird der aktive Step sofort angeflogen (`applyTour()` nach dem Scene-Build).
- Steps, deren Klasse nicht die hotteste ihrer Datei ist, lösen nicht auf (bewusst: `CityBuilding.fqn` trägt nur eine Klasse pro Datei) — die Tour hält dann einfach die Position.

## Gates

- `pnpm lint` — 0 Findings (ESLint 9)
- `pnpm check` — 0 errors / 0 warnings (svelte-check, 861 Dateien)
- `pnpm test` — 504/504 grün (34 Files, inkl. 24 neue cityTour-Tests + i18nParity)
- `pnpm build` — ok (three bleibt eigener Lazy-Chunk; cityTour ist pure TS im Hauptbundle)

Kein Rust angefasst, keine neue Dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJuL4nSq1EvgahTJe1hom1