### PR TITLE
fix(code-city): ClassEntry join for tour targets + nonce-aware body refetch

### DIFF
--- a/app/src/components/CodeCity.svelte
+++ b/app/src/components/CodeCity.svelte
@@ -33,6 +33,7 @@
   import {
     cameraFlightTo,
     resolveTourTarget,
+    shouldRefetchTourBody,
     tweenPose,
     type CameraPose,
   } from '../lib/diagrams/cityTour';
@@ -40,6 +41,7 @@
     classes,
     fileView,
     followingMcp,
+    modules,
     repo,
     selectedClass,
     viewMode,
@@ -118,8 +120,13 @@
 
   /// Last cursor seen from the walkthrough store (null = no active tour).
   let tourCursor: WalkthroughCursor | null = null;
-  /// Tour body cache — fetched once per tour id, steps looked up locally.
+  /// Tour body cache — re-fetched when the tour id *or* the cursor nonce
+  /// changes (`shouldRefetchTourBody`), steps looked up locally.
   let tourBody: Walkthrough | null = null;
+  /// Cursor nonce the cached body was fetched under. A bumped nonce means
+  /// the body may have changed behind the same id (`walkthrough_append`,
+  /// step rewrite) — matching on id alone would keep flying the stale tour.
+  let tourBodyNonce = -1;
   /// Guards the async body fetch against out-of-order responses.
   let tourFetchSeq = 0;
   /// Resolved building of the active step (highlight + beacon + chip),
@@ -343,8 +350,10 @@
   // --- Tour waypoints (V4.6c) -------------------------------------------------
 
   /// Store subscription: every cursor move re-resolves the active step.
-  /// The body is fetched once per tour id; a stale response (tour switched
-  /// mid-fetch) is dropped via the sequence guard.
+  /// The body is re-fetched whenever the tour id or the cursor nonce moved
+  /// (`shouldRefetchTourBody` — the same nonce contract WalkthroughView
+  /// follows); a stale response (a newer cursor arrived mid-fetch) is
+  /// dropped via the sequence guard.
   const unsubscribeTour = walkthroughCursor.subscribe((cur) => {
     void onTourCursor(cur);
   });
@@ -352,16 +361,44 @@
   async function onTourCursor(cur: WalkthroughCursor | null) {
     tourCursor = cur;
     const seq = ++tourFetchSeq;
-    if (cur && (!tourBody || tourBody.id !== cur.id)) {
+    if (cur && shouldRefetchTourBody(cur, tourBody, tourBodyNonce)) {
       try {
         const body = await currentWalkthrough();
         if (seq !== tourFetchSeq) return; // superseded by a newer cursor
         tourBody = body;
+        tourBodyNonce = cur.nonce;
       } catch {
         tourBody = null; // no body → steps can't resolve; visuals clear below
       }
     }
     applyTour();
+  }
+
+  /// fqn → absolute source file, the ClassEntry join for
+  /// `resolveTourTarget`: `building.fqn` only knows the hottest class per
+  /// file (risk join) and knows nothing without git history — this index
+  /// resolves every parsed class via `module.root + class.file` instead.
+  /// Rebuilt lazily on store identity change (load() swaps the arrays
+  /// wholesale, so a reference check is a correct invalidation).
+  let classIndexCache: {
+    classesRef: ClassEntry[];
+    modulesRef: unknown;
+    map: Map<string, string>;
+  } | null = null;
+  function tourClassIndex(): Map<string, string> {
+    const cls = get(classes);
+    const mods = get(modules);
+    if (classIndexCache && classIndexCache.classesRef === cls && classIndexCache.modulesRef === mods) {
+      return classIndexCache.map;
+    }
+    const rootById = new Map(mods.map((m) => [m.id, m.root.replace(/\/+$/, '')]));
+    const map = new Map<string, string>();
+    for (const c of cls) {
+      const mroot = rootById.get(c.module);
+      if (mroot) map.set(c.fqn, `${mroot}/${c.file}`);
+    }
+    classIndexCache = { classesRef: cls, modulesRef: mods, map };
+    return map;
   }
 
   /// Resolve the active step onto a building and drive the visuals:
@@ -374,7 +411,9 @@
       tourCursor && tourBody && tourBody.id === tourCursor.id
         ? (tourBody.steps[tourCursor.step] ?? null)
         : null;
-    const hit = step ? resolveTourTarget(model, step.target, get(repo)?.root ?? null) : null;
+    const hit = step
+      ? resolveTourTarget(model, step.target, get(repo)?.root ?? null, tourClassIndex())
+      : null;
     const idx = hit ? model.buildings.findIndex((b) => b.id === hit.buildingId) : -1;
     setTourBuilding(idx);
     if (tourBuilding && !walkMode) startFlight(tourBuilding);

--- a/app/src/lib/diagrams/cityTour.test.ts
+++ b/app/src/lib/diagrams/cityTour.test.ts
@@ -9,6 +9,7 @@ import {
   cameraFlightTo,
   normalizeStepPath,
   resolveTourTarget,
+  shouldRefetchTourBody,
   smoothstep,
   TOUR_CAMERA_DEFAULTS,
   tweenPose,
@@ -126,6 +127,67 @@ describe('resolveTourTarget', () => {
     for (const t of targets) {
       expect(resolveTourTarget(model, t, ROOT)).toBeNull();
     }
+  });
+
+  // --- ClassEntry join fallback (R2 fix): the risk join only tags the
+  // hottest class per file (and nothing at all without git history) —
+  // the classIndex resolves every other class via its source file.
+  it('resolves a non-hottest class via the classIndex (fqn → file → building)', () => {
+    const idx = new Map([['app::App', `${ROOT}/app/src/App.svelte`]]);
+    const t: WalkthroughTarget = { kind: 'class', fqn: 'app::App' };
+    expect(resolveTourTarget(model, t, ROOT, idx)).toEqual({ buildingId: shed.id });
+  });
+
+  it('prefers the direct fqn match over the classIndex', () => {
+    // Index deliberately points the hottest class at the WRONG building —
+    // the direct building.fqn hit must keep winning.
+    const idx = new Map([['core::engine::Engine', `${ROOT}/app/src/App.svelte`]]);
+    const t: WalkthroughTarget = { kind: 'class', fqn: 'core::engine::Engine' };
+    expect(resolveTourTarget(model, t, ROOT, idx)).toEqual({ buildingId: tower.id });
+  });
+
+  it('still misses when the classIndex maps to a file outside the city', () => {
+    const idx = new Map([['app::Ghost', `${ROOT}/generated/Ghost.svelte`]]);
+    const t: WalkthroughTarget = { kind: 'class', fqn: 'app::Ghost' };
+    expect(resolveTourTarget(model, t, ROOT, idx)).toBeNull();
+  });
+
+  it('misses unknown fqns without an index exactly like before', () => {
+    const t: WalkthroughTarget = { kind: 'risk', fqn: 'app::App' };
+    expect(resolveTourTarget(model, t, ROOT, null)).toBeNull();
+  });
+
+  it('folds Windows drive-letter casing when stripping the root', () => {
+    const winModel: CityModel = {
+      ...model,
+      buildings: [building({ id: 'src/a.ts', x: 1, z: 1, w: 1, d: 1, h: 1 })],
+    };
+    const t: WalkthroughTarget = { kind: 'file', path: 'C:/repo/src/a.ts' };
+    expect(resolveTourTarget(winModel, t, 'c:/repo')).toEqual({ buildingId: 'src/a.ts' });
+  });
+});
+
+describe('shouldRefetchTourBody', () => {
+  const cursor = { id: 'tour-1', nonce: 3 };
+
+  it('never refetches without a cursor', () => {
+    expect(shouldRefetchTourBody(null, { id: 'tour-1' }, 3)).toBe(false);
+  });
+
+  it('fetches when nothing is cached (first cursor or failed fetch)', () => {
+    expect(shouldRefetchTourBody(cursor, null, -1)).toBe(true);
+  });
+
+  it('fetches when the tour id changed', () => {
+    expect(shouldRefetchTourBody(cursor, { id: 'tour-0' }, 3)).toBe(true);
+  });
+
+  it('fetches when the nonce moved behind the same id (append/rewrite)', () => {
+    expect(shouldRefetchTourBody(cursor, { id: 'tour-1' }, 2)).toBe(true);
+  });
+
+  it('keeps the cache when id and nonce both match', () => {
+    expect(shouldRefetchTourBody(cursor, { id: 'tour-1' }, 3)).toBe(false);
   });
 });
 

--- a/app/src/lib/diagrams/cityTour.ts
+++ b/app/src/lib/diagrams/cityTour.ts
@@ -12,7 +12,11 @@
 ///
 /// Mapping rules (see `resolveTourTarget`):
 /// - `class` / `risk` → the building whose `fqn` (the file's hottest class,
-///   from the risk join) equals the step's fqn.
+///   from the risk join) equals the step's fqn; on a miss the optional
+///   ClassEntry join (fqn → source file → building id) resolves the rest.
+///   The risk join only tags the *hottest* class per file and is entirely
+///   empty without git history — without the join fallback every other
+///   class would silently strand the camera.
 /// - `file` → the building whose repo-relative `id` equals the step path.
 ///   Step paths are absolute (the MCP schema wants them that way), building
 ///   ids are repo-relative — the repo root is stripped first, the exact
@@ -62,27 +66,49 @@ export function normalizeStepPath(path: string, repoRoot: string | null): string
   const slashed = path.replace(/\\/g, '/');
   if (repoRoot) {
     const root = repoRoot.replace(/\\/g, '/').replace(/\/+$/, '');
-    if (root && slashed.startsWith(root + '/')) {
+    if (root && foldDriveLetter(slashed).startsWith(foldDriveLetter(root) + '/')) {
       return slashed.slice(root.length + 1);
     }
   }
   return slashed.replace(/^\.\//, '');
 }
 
+/// Windows drive letters are case-insensitive (`c:\repo` and `C:\repo` are
+/// the same directory, and tools disagree on the casing they emit) — fold a
+/// leading drive letter to lower case so the root comparison above doesn't
+/// silently miss. Only the drive letter is folded: POSIX paths stay
+/// case-sensitive.
+function foldDriveLetter(p: string): string {
+  return /^[A-Za-z]:\//.test(p) ? p.charAt(0).toLowerCase() + p.slice(1) : p;
+}
+
 /// Map the active step's target onto a city building. Returns `null` for
 /// misses and for kinds without city geometry — the caller then holds the
 /// camera (stopover) instead of flying. See the module header for the
 /// per-kind rules.
+///
+/// `classIndex` (fqn → source file, any scale `normalizeStepPath` accepts)
+/// is the ClassEntry join: `building.fqn` comes exclusively from the risk
+/// join, which tags only the hottest class per file and yields nothing at
+/// all on repos without git history — the index resolves every parsed
+/// class via its file instead. The direct fqn match stays first so the
+/// exact building keeps winning when both know the class.
 export function resolveTourTarget(
   model: CityModel,
   target: WalkthroughTarget,
   repoRoot: string | null,
+  classIndex?: ReadonlyMap<string, string> | null,
 ): { buildingId: string } | null {
   switch (target.kind) {
     case 'class':
     case 'risk': {
       const hit = model.buildings.find((b) => b.fqn === target.fqn);
-      return hit ? { buildingId: hit.id } : null;
+      if (hit) return { buildingId: hit.id };
+      const file = classIndex?.get(target.fqn);
+      if (!file) return null;
+      const rel = normalizeStepPath(file, repoRoot);
+      const viaFile = model.buildings.find((b) => b.id === rel);
+      return viaFile ? { buildingId: viaFile.id } : null;
     }
     case 'file': {
       const rel = normalizeStepPath(target.path, repoRoot);
@@ -92,6 +118,23 @@ export function resolveTourTarget(
     default:
       return null;
   }
+}
+
+/// Fetch policy for the tour-body cache in `CodeCity.svelte`: refetch when
+/// the tour id changed (new tour), no body is cached (first cursor, or the
+/// previous fetch failed), or the cursor `nonce` moved. The store bumps the
+/// nonce on every applied intent precisely so views can re-fetch when
+/// `(id, step)` is unchanged but the body may not be —
+/// `walkthrough_append` / a step rewrite mid-tour. Matching on id alone
+/// (the old behaviour) served those a stale body: the city flew to the old
+/// step or, past the stale end, silently held the camera.
+export function shouldRefetchTourBody(
+  cursor: { id: string; nonce: number } | null,
+  cachedBody: { id: string } | null,
+  cachedNonce: number,
+): boolean {
+  if (!cursor) return false;
+  return !cachedBody || cachedBody.id !== cursor.id || cursor.nonce !== cachedNonce;
 }
 
 /// Destination pose for a flight to `building`: look at the building's


### PR DESCRIPTION
Fund #2 aus der Verbesserungs-Analyse Runde 2 (Desktop: ANALYSE-projectmind-verbesserungen-2.md).

**Klassen-Join:** `resolveTourTarget` kannte nur `building.fqn` (= hotteste Klasse pro Datei aus dem Risk-Join; ohne Git-History komplett leer) → Tour-Steps auf andere Klassen strandeten die Kamera. Neuer optionaler `classIndex` (fqn → `module.root + class.file`, lazy aus den classes/modules-Stores mit Referenz-Invalidierung) löst **jede** geparste Klasse über ihre Quelldatei auf; der direkte fqn-Treffer behält Vorrang. Windows-Drive-Letter-Casing wird beim Root-Strip gefaltet.

**nonce-Refetch:** Der Tour-Body wurde pro Tour-id gecacht — `walkthrough_append`/Step-Rewrites hinter derselben id flogen die veraltete Tour. Neues pures `shouldRefetchTourBody()` refetcht bei nonce-Bewegung (derselbe Kontrakt wie WalkthroughView).

+10 vitest-Fälle. Gates: lint 0 · svelte-check 0/0 · **514 Tests** · build grün.

(Agent lief ins Session-Limit; Verdrahtung + Tests inline fertiggestellt.)