### PR TITLE
fix(activity): join module ids via manifest coordinates + skip merge commits in history walks

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -285,7 +285,9 @@ export interface CommitDrop {
 
 /// Commit activity for one module. Mirrors `git::ModuleActivity`.
 export interface ModuleActivity {
-  /// Module id (Maven artifactId / Cargo crate name, or top-level dir).
+  /// Module id — the manifest coordinate (Maven `groupId:artifactId` /
+  /// Cargo `name@version`), matching `BeanNode.module`, or a top-level
+  /// directory as fallback.
   module: string;
   /// Commits that touched this module, newest-first.
   commits: CommitDrop[];

--- a/app/src/lib/diagrams/activityPulse.test.ts
+++ b/app/src/lib/diagrams/activityPulse.test.ts
@@ -43,15 +43,15 @@ function drop(secs_ago: number): { secs_ago: number; sha: string; summary: strin
 
 const DAY = 86_400;
 
-describe('planActivityPulse — join (suffix match)', () => {
-  it('joins Maven groupId:artifactId nodes against bare artifactId activity', () => {
+describe('planActivityPulse — join (exact module-id match)', () => {
+  it('joins Maven nodes and activity on the full groupId:artifactId coordinate', () => {
     const plan = planActivityPulse(
       els(twoModules()),
-      activity([{ module: 'web', commits: [drop(1 * DAY)] }]),
+      activity([{ module: 'com.acme:web', commits: [drop(1 * DAY)] }]),
     );
     // Both `com.acme:web` classes pulse; `com.acme:core` has no activity entry.
     expect(plan.pulses).toEqual([{ intensity: 'hot', nodeIds: ['a.Ctrl', 'a.View'] }]);
-    expect(plan.hotModules).toEqual(['web']);
+    expect(plan.hotModules).toEqual(['com.acme:web']);
     expect(plan.animate).toBe(true);
   });
 
@@ -66,6 +66,18 @@ describe('planActivityPulse — join (suffix match)', () => {
     expect(plan.pulses).toEqual([{ intensity: 'hot', nodeIds: ['core::Engine'] }]);
   });
 
+  it('joins Cargo name@version coordinates (regression: version suffix used to kill the join)', () => {
+    const plan = planActivityPulse(
+      els({
+        nodes: [{ id: 'core::Engine', label: 'Engine', module: 'core@0.1.0', stereotype: null, path: 'engine.rs' }],
+        edges: [],
+      }),
+      activity([{ module: 'core@0.1.0', commits: [drop(2 * DAY)] }]),
+    );
+    expect(plan.pulses).toEqual([{ intensity: 'hot', nodeIds: ['core::Engine'] }]);
+    expect(plan.hotModules).toEqual(['core@0.1.0']);
+  });
+
   it('a join miss yields no pulse and no error (silent fallback)', () => {
     // Activity attributed the commits to a top-level dir the graph never uses.
     const plan = planActivityPulse(
@@ -77,10 +89,20 @@ describe('planActivityPulse — join (suffix match)', () => {
   });
 
   it('does not join on the groupId half of the coordinate', () => {
-    // `com.acme` is the groupId, not the artifactId — must NOT match.
+    // `com.acme` is the groupId, not the module id — must NOT match.
     const plan = planActivityPulse(
       els(twoModules()),
       activity([{ module: 'com.acme', commits: [drop(1 * DAY)] }]),
+    );
+    expect(plan.pulses).toEqual([]);
+  });
+
+  it('a bare artifactId does not match — the join is exact, not a suffix match', () => {
+    // Pre-fix backends shipped bare artifactIds; the contract is now the
+    // full coordinate on both sides.
+    const plan = planActivityPulse(
+      els(twoModules()),
+      activity([{ module: 'web', commits: [drop(1 * DAY)] }]),
     );
     expect(plan.pulses).toEqual([]);
   });
@@ -95,18 +117,18 @@ describe('planActivityPulse — bucket boundaries', () => {
     });
 
   it('strictly below hotSecs is hot', () => {
-    const plan = planActivityPulse(oneNode(), activity([{ module: 'm', commits: [drop(99)] }]), buckets);
+    const plan = planActivityPulse(oneNode(), activity([{ module: 'g:m', commits: [drop(99)] }]), buckets);
     expect(plan.pulses).toEqual([{ intensity: 'hot', nodeIds: ['N'] }]);
   });
 
   it('exactly hotSecs falls into warm (half-open buckets)', () => {
-    const plan = planActivityPulse(oneNode(), activity([{ module: 'm', commits: [drop(100)] }]), buckets);
+    const plan = planActivityPulse(oneNode(), activity([{ module: 'g:m', commits: [drop(100)] }]), buckets);
     expect(plan.pulses).toEqual([{ intensity: 'warm', nodeIds: ['N'] }]);
-    expect(plan.warmModules).toEqual(['m']);
+    expect(plan.warmModules).toEqual(['g:m']);
   });
 
   it('exactly warmSecs is cool — no pulse', () => {
-    const plan = planActivityPulse(oneNode(), activity([{ module: 'm', commits: [drop(200)] }]), buckets);
+    const plan = planActivityPulse(oneNode(), activity([{ module: 'g:m', commits: [drop(200)] }]), buckets);
     expect(plan.pulses).toEqual([]);
     expect(plan.animate).toBe(false);
   });
@@ -114,7 +136,7 @@ describe('planActivityPulse — bucket boundaries', () => {
   it('the freshest commit decides — one fresh commit outweighs old history', () => {
     const plan = planActivityPulse(
       oneNode(),
-      activity([{ module: 'm', commits: [drop(9_999), drop(50), drop(150)] }]),
+      activity([{ module: 'g:m', commits: [drop(9_999), drop(50), drop(150)] }]),
       buckets,
     );
     expect(plan.pulses).toEqual([{ intensity: 'hot', nodeIds: ['N'] }]);
@@ -123,9 +145,9 @@ describe('planActivityPulse — bucket boundaries', () => {
   it('defaults are 7 / 30 days', () => {
     expect(DEFAULT_PULSE_BUCKETS.hotSecs).toBe(7 * DAY);
     expect(DEFAULT_PULSE_BUCKETS.warmSecs).toBe(30 * DAY);
-    const hot = planActivityPulse(oneNode(), activity([{ module: 'm', commits: [drop(6 * DAY)] }]));
-    const warm = planActivityPulse(oneNode(), activity([{ module: 'm', commits: [drop(8 * DAY)] }]));
-    const cool = planActivityPulse(oneNode(), activity([{ module: 'm', commits: [drop(31 * DAY)] }]));
+    const hot = planActivityPulse(oneNode(), activity([{ module: 'g:m', commits: [drop(6 * DAY)] }]));
+    const warm = planActivityPulse(oneNode(), activity([{ module: 'g:m', commits: [drop(8 * DAY)] }]));
+    const cool = planActivityPulse(oneNode(), activity([{ module: 'g:m', commits: [drop(31 * DAY)] }]));
     expect(hot.pulses[0]?.intensity).toBe('hot');
     expect(warm.pulses[0]?.intensity).toBe('warm');
     expect(cool.pulses).toEqual([]);
@@ -137,22 +159,22 @@ describe('planActivityPulse — bucket grouping', () => {
     const plan = planActivityPulse(
       els(twoModules()),
       activity([
-        { module: 'web', commits: [drop(1 * DAY)] },
-        { module: 'core', commits: [drop(10 * DAY)] },
+        { module: 'com.acme:web', commits: [drop(1 * DAY)] },
+        { module: 'com.acme:core', commits: [drop(10 * DAY)] },
       ]),
     );
     expect(plan.pulses).toEqual([
       { intensity: 'hot', nodeIds: ['a.Ctrl', 'a.View'] },
       { intensity: 'warm', nodeIds: ['a.Repo'] },
     ]);
-    expect(plan.hotModules).toEqual(['web']);
-    expect(plan.warmModules).toEqual(['core']);
+    expect(plan.hotModules).toEqual(['com.acme:web']);
+    expect(plan.warmModules).toEqual(['com.acme:core']);
   });
 
   it('omits empty buckets instead of emitting them empty', () => {
     const plan = planActivityPulse(
       els(twoModules()),
-      activity([{ module: 'core', commits: [drop(10 * DAY)] }]),
+      activity([{ module: 'com.acme:core', commits: [drop(10 * DAY)] }]),
     );
     expect(plan.pulses).toEqual([{ intensity: 'warm', nodeIds: ['a.Repo'] }]);
     expect(plan.hotModules).toEqual([]);
@@ -174,19 +196,22 @@ describe('planActivityPulse — degenerate inputs', () => {
   it('an empty graph plans no animation even with hot activity', () => {
     const plan = planActivityPulse(
       els({ nodes: [], edges: [] }),
-      activity([{ module: 'web', commits: [drop(1 * DAY)] }]),
+      activity([{ module: 'com.acme:web', commits: [drop(1 * DAY)] }]),
     );
     expect(plan).toEqual({ pulses: [], hotModules: [], warmModules: [], animate: false });
   });
 
   it('a module with an empty commit list is cool', () => {
-    const plan = planActivityPulse(els(twoModules()), activity([{ module: 'web', commits: [] }]));
+    const plan = planActivityPulse(
+      els(twoModules()),
+      activity([{ module: 'com.acme:web', commits: [] }]),
+    );
     expect(plan.pulses).toEqual([]);
   });
 
   it('does not mutate the inputs it is handed', () => {
     const elements = els(twoModules());
-    const act = activity([{ module: 'web', commits: [drop(9_999), drop(50)] }]);
+    const act = activity([{ module: 'com.acme:web', commits: [drop(9_999), drop(50)] }]);
     const commitsBefore = [...act.modules[0].commits];
     planActivityPulse(elements, act);
     expect(elements.nodes.length).toBe(3);

--- a/app/src/lib/diagrams/activityPulse.ts
+++ b/app/src/lib/diagrams/activityPulse.ts
@@ -33,21 +33,19 @@
 /// warm, exactly 30 days old is cool. The limits are injectable (`buckets`
 /// param) so tests can pin the boundaries without faking 7-day timestamps.
 ///
-/// ## The join (and its trap)
+/// ## The join
 ///
-/// The two sides name modules differently:
-/// - `BeanNode.module` is `groupId:artifactId` for Maven (or the bare crate
-///   name for Cargo) — see `crates/core/src/diagram.rs` `BeanNode`.
-/// - `ModuleActivity.module` is the bare `artifactId` / crate name, or a
-///   top-level directory as fallback — see `crates/core/src/git.rs`
-///   `ModuleActivity`.
+/// Both sides carry the engine's module id — the manifest coordinate
+/// (Maven `groupId:artifactId` / Cargo `name@version`):
+/// - `BeanNode.module` — see `crates/core/src/diagram.rs` `BeanNode`.
+/// - `ModuleActivity.module` — see `crates/core/src/git.rs`
+///   `ModuleActivity` (`commit_activity` derives it from the same manifest
+///   discovery the engine uses).
 ///
-/// So the join is a **suffix match**: `beanModule.split(':').pop()` must
-/// equal the activity module id. For Cargo (no colon) that is the identity,
-/// for Maven it strips the groupId. A bean module with no matching activity
-/// entry simply gets no pulse — silent, never an error (e.g. the activity
-/// walker attributed the files to a top-level dir instead, or the module had
-/// no commits in the window).
+/// So the join is an **exact match** on the module id. A bean module with
+/// no matching activity entry simply gets no pulse — silent, never an error
+/// (e.g. the activity walker attributed the files to a top-level dir
+/// instead, or the module had no commits in the window).
 ///
 /// Kept dependency-free (no `cytoscape` import) so the plan stays a plain
 /// function — same pattern as `beanGraphFlow.ts` / `beanGraphMorph.ts`.
@@ -92,13 +90,6 @@ export interface ActivityPulsePlan {
   animate: boolean;
 }
 
-/// The bean side of the join: `groupId:artifactId` → `artifactId`; a bare
-/// crate name (no colon) passes through unchanged.
-function beanModuleSuffix(beanModule: string): string {
-  const parts = beanModule.split(':');
-  return parts[parts.length - 1];
-}
-
 /// Bucket one module by the age of its freshest commit. The backend sorts
 /// commits newest-first, but we take the minimum defensively so the plan
 /// never depends on that ordering. Empty commit lists are `cool`.
@@ -111,8 +102,9 @@ function bucketOf(secsAgoList: number[], buckets: PulseBuckets): PulseIntensity 
 }
 
 /// Build the activity-pulse plan: join every graph node against the repo's
-/// commit activity (suffix match, see module header) and group the matched
-/// nodes into `hot` / `warm` buckets by their module's freshest commit.
+/// commit activity (exact module-id match, see module header) and group the
+/// matched nodes into `hot` / `warm` buckets by their module's freshest
+/// commit.
 ///
 /// Pure: empty graph or empty/`no_git` activity → `{ pulses: [], animate:
 /// false }`, deterministic, never throws, does not mutate its inputs.
@@ -136,15 +128,14 @@ export function planActivityPulse(
   const warmModules = new Set<string>();
 
   for (const n of els.nodes) {
-    const suffix = beanModuleSuffix(n.data.module);
-    const intensity = intensityOf.get(suffix);
+    const intensity = intensityOf.get(n.data.module);
     // No activity entry (join miss) or a cool module → no pulse, silently.
     if (intensity === 'hot') {
       hotNodeIds.push(n.data.id);
-      hotModules.add(suffix);
+      hotModules.add(n.data.module);
     } else if (intensity === 'warm') {
       warmNodeIds.push(n.data.id);
-      warmModules.add(suffix);
+      warmModules.add(n.data.module);
     }
   }
 

--- a/crates/core/src/diagram.rs
+++ b/crates/core/src/diagram.rs
@@ -153,7 +153,9 @@ pub struct BeanNode {
     pub id: String,
     /// Simple class name shown on the node.
     pub label: String,
-    /// Module id the class belongs to (Maven `groupId:artifactId` / Cargo crate).
+    /// Module id the class belongs to (Maven `groupId:artifactId` / Cargo
+    /// `name@version`). Same id `commit_activity` reports, so activity joins
+    /// onto graph nodes by equality.
     pub module: String,
     /// Primary stereotype (`service`, `rest-controller`, …) or `null` when the
     /// class has none. Matches the priority order the Mermaid `classDef` uses.

--- a/crates/core/src/git.rs
+++ b/crates/core/src/git.rs
@@ -327,27 +327,11 @@ pub fn file_recency(repo_root: &Path) -> Result<Vec<FileRecency>, GitError> {
         let author_name = author.name().map(str::to_string).filter(|s| !s.is_empty());
         let author_email = author.email().map(str::to_string).filter(|s| !s.is_empty());
 
-        let Ok(tree) = commit.tree() else { continue };
-        // Compare each parent against this commit's tree. For the root
-        // commit (no parent) we diff against an empty tree so every file
-        // gets an "added" delta.
-        let parent_trees: Vec<git2::Tree<'_>> =
-            commit.parents().filter_map(|p| p.tree().ok()).collect();
-
-        let touched = if parent_trees.is_empty() {
-            paths_in_diff(
-                repo.diff_tree_to_tree(None, Some(&tree), None)
-                    .ok()
-                    .as_ref(),
-            )
-        } else {
-            let mut paths: Vec<PathBuf> = Vec::new();
-            for parent in &parent_trees {
-                if let Ok(diff) = repo.diff_tree_to_tree(Some(parent), Some(&tree), None) {
-                    paths.extend(paths_in_diff(Some(&diff)));
-                }
-            }
-            paths
+        // First-parent diff; merge commits are skipped entirely (see
+        // `first_parent_touched_paths`) so the "last edit" stays the real
+        // authoring commit, never the merge that brought it in.
+        let Some(touched) = first_parent_touched_paths(&repo, &commit) else {
+            continue;
         };
 
         for path in touched {
@@ -399,8 +383,9 @@ pub struct CommitDrop {
 /// (within the window / cap) that touched a file attributed to it.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModuleActivity {
-    /// Module identifier. Either a Maven `artifactId` / Cargo crate name
-    /// (when the file falls inside a discovered module root) or, as a
+    /// Module identifier. Either the module's manifest coordinate — Maven
+    /// `groupId:artifactId` / Cargo `name@version`, matching the engine's
+    /// `Module::id` so activity joins onto module-keyed data — or, as a
     /// fallback, the file's top-level directory (`.` for repo-root files).
     pub module: String,
     /// Commits that touched this module, newest-first. A single commit that
@@ -454,12 +439,16 @@ pub const ACTIVITY_MAX_MODULES: usize = 500;
 ///
 /// Walks HEAD backwards over the last [`ACTIVITY_WINDOW_SECS`] (capped at
 /// [`ACTIVITY_MAX_COMMITS`] visited commits). For each commit it diffs
-/// against its parent(s), attributes every touched file to a module, and
-/// records a [`CommitDrop`] on that module's band.
+/// against its first parent (merge commits are skipped — their changes are
+/// counted at the original commits, so a merge-PR workflow isn't doubled),
+/// attributes every touched file to a module, and records a [`CommitDrop`]
+/// on that module's band.
 ///
 /// Module attribution reuses the same discovery the engine uses when
 /// opening a repo: Maven modules (`pom.xml`) first, then Cargo crates
-/// (`Cargo.toml`). A file is attributed to the deepest discovered module
+/// (`Cargo.toml`). Module ids are the manifest coordinates (Maven
+/// `groupId:artifactId` / Cargo `name@version`), identical to the engine's
+/// `Module::id`. A file is attributed to the deepest discovered module
 /// whose root contains it; files outside any module (or in a repo with no
 /// build manifests) fall back to their top-level directory, with `.` for
 /// files sitting directly in the repo root.
@@ -525,23 +514,11 @@ pub fn commit_activity(repo_root: &Path) -> CommitActivity {
             .map(ToString::to_string)
             .unwrap_or_default();
 
-        let Ok(tree) = commit.tree() else { continue };
-        let parent_trees: Vec<git2::Tree<'_>> =
-            commit.parents().filter_map(|p| p.tree().ok()).collect();
-        let touched = if parent_trees.is_empty() {
-            paths_in_diff(
-                repo.diff_tree_to_tree(None, Some(&tree), None)
-                    .ok()
-                    .as_ref(),
-            )
-        } else {
-            let mut paths: Vec<PathBuf> = Vec::new();
-            for parent in &parent_trees {
-                if let Ok(diff) = repo.diff_tree_to_tree(Some(parent), Some(&tree), None) {
-                    paths.extend(paths_in_diff(Some(&diff)));
-                }
-            }
-            paths
+        // First-parent diff; merge commits are skipped entirely (see
+        // `first_parent_touched_paths`) so a merge-PR workflow doesn't
+        // count every change twice (branch commit + merge diff).
+        let Some(touched) = first_parent_touched_paths(&repo, &commit) else {
+            continue;
         };
 
         // Which modules did this commit touch? A commit that changes two
@@ -624,6 +601,13 @@ struct ModuleRoot {
 /// shows. `base` is the canonicalised repo root; each module root is
 /// reduced to a repo-relative prefix. Returns roots deepest-first; an empty
 /// vec means "attribute by top-level directory" (a manifest-less repo).
+///
+/// Module ids are the full manifest coordinates (`MavenModule::coordinate`
+/// / `CargoCrate::coordinate`) — exactly what the engine assigns to
+/// `Module::id` — so consumers joining activity onto module-keyed data
+/// (`tour_suggest`, the frontend activity pulse) match on equal ids. Bare
+/// `artifact_id` / crate `name` here silently killed those joins for Maven
+/// modules with a `groupId` and Cargo crates with a literal version.
 fn discover_module_roots(base: &Path) -> Vec<ModuleRoot> {
     let rel = |root: &Path| root.strip_prefix(base).unwrap_or(root).to_path_buf();
     let maven = crate::maven::discover(base);
@@ -632,7 +616,7 @@ fn discover_module_roots(base: &Path) -> Vec<ModuleRoot> {
             .into_iter()
             .map(|m| ModuleRoot {
                 rel_root: rel(&m.root),
-                id: m.artifact_id,
+                id: m.coordinate(),
             })
             .collect();
     }
@@ -640,7 +624,7 @@ fn discover_module_roots(base: &Path) -> Vec<ModuleRoot> {
         .into_iter()
         .map(|c| ModuleRoot {
             rel_root: rel(&c.root),
-            id: c.name,
+            id: c.coordinate(),
         })
         .collect()
 }
@@ -668,6 +652,26 @@ fn module_of(path: &Path, module_roots: &[ModuleRoot]) -> String {
         .map_or_else(|| ".".to_string(), ToString::to_string)
 }
 
+/// Paths touched by `commit`, diffed against its first parent (or against
+/// the empty tree for a root commit, so every file counts as added).
+///
+/// Merge commits return `None`: their branch-side changes are already
+/// counted at the original commits the revwalk visits anyway, so diffing a
+/// merge against its parents would double every activity metric on
+/// merge-PR workflows. Skipping them matches `git log`'s default of
+/// showing no patch for merges.
+fn first_parent_touched_paths(repo: &GitRepo, commit: &git2::Commit<'_>) -> Option<Vec<PathBuf>> {
+    if commit.parent_count() > 1 {
+        return None;
+    }
+    let tree = commit.tree().ok()?;
+    let parent_tree = commit.parent(0).ok().and_then(|p| p.tree().ok());
+    let diff = repo
+        .diff_tree_to_tree(parent_tree.as_ref(), Some(&tree), None)
+        .ok()?;
+    Some(paths_in_diff(Some(&diff)))
+}
+
 /// Helper: collect paths from a diff. Returns an empty list when `diff` is
 /// `None` (let callers stay terse).
 fn paths_in_diff(diff: Option<&Diff<'_>>) -> Vec<PathBuf> {
@@ -681,8 +685,142 @@ fn paths_in_diff(diff: Option<&Diff<'_>>) -> Vec<PathBuf> {
     out
 }
 
+/// Test-only git fixtures shared with the sibling modules that walk history
+/// (`crate::risk` reuses the merge-history builder for its churn tests).
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::GitRepo;
+    use std::fs;
+    use std::path::Path;
+
+    pub(crate) fn init_repo(dir: &Path) -> GitRepo {
+        let repo = GitRepo::init(dir).unwrap();
+        // libgit2 requires user.name + user.email for commits.
+        let mut cfg = repo.config().unwrap();
+        cfg.set_str("user.name", "Test").unwrap();
+        cfg.set_str("user.email", "test@example.com").unwrap();
+        repo
+    }
+
+    pub(crate) fn commit_file(
+        repo: &GitRepo,
+        dir: &Path,
+        rel: &str,
+        content: &str,
+        msg: &str,
+        when: i64,
+    ) {
+        commit_file_as(
+            repo,
+            dir,
+            rel,
+            content,
+            msg,
+            when,
+            "Test",
+            "test@example.com",
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn commit_file_as(
+        repo: &GitRepo,
+        dir: &Path,
+        rel: &str,
+        content: &str,
+        msg: &str,
+        when: i64,
+        author_name: &str,
+        author_email: &str,
+    ) {
+        fs::write(dir.join(rel), content).unwrap();
+        let mut idx = repo.index().unwrap();
+        idx.add_path(Path::new(rel)).unwrap();
+        idx.write().unwrap();
+        let tree_id = idx.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let sig =
+            git2::Signature::new(author_name, author_email, &git2::Time::new(when, 0)).unwrap();
+        let parent = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
+        let parents: Vec<&git2::Commit<'_>> = parent.iter().collect();
+        repo.commit(Some("HEAD"), &sig, &sig, msg, &tree, &parents)
+            .unwrap();
+    }
+
+    /// Root tree = `base` plus a one-file subtree `dir_name/file_name`, so
+    /// the merge tests can synthesise side-branch commits without touching
+    /// the shared on-disk index.
+    fn tree_with_subdir_file<'r>(
+        repo: &'r GitRepo,
+        base: &git2::Tree<'_>,
+        dir_name: &str,
+        file_name: &str,
+        content: &str,
+    ) -> git2::Tree<'r> {
+        let blob = repo.blob(content.as_bytes()).unwrap();
+        let mut sub = repo.treebuilder(None).unwrap();
+        sub.insert(file_name, blob, 0o100_644).unwrap();
+        let sub_id = sub.write().unwrap();
+        let mut root = repo.treebuilder(Some(base)).unwrap();
+        root.insert(dir_name, sub_id, 0o040_000).unwrap();
+        let root_id = root.write().unwrap();
+        repo.find_tree(root_id).unwrap()
+    }
+
+    /// Build a merge-PR-style history on an initialised repo:
+    ///
+    /// ```text
+    /// A "base" (base.txt) ── B "feat work" (feat/x.rs) ── M "merge feature"
+    ///        └────────── C "main work" (main/y.rs) ──────────┘
+    /// ```
+    ///
+    /// `M` is a true two-parent merge (first parent `B`, second `C`) whose
+    /// tree contains both sides' files. Timestamps ascend `base_when` →
+    /// `base_when + 300`, so a TIME-sorted revwalk visits `M` first.
+    pub(crate) fn build_merge_history(repo: &GitRepo, dir: &Path, base_when: i64) {
+        commit_file(repo, dir, "base.txt", "1", "base", base_when);
+        fs::create_dir_all(dir.join("feat")).unwrap();
+        commit_file(repo, dir, "feat/x.rs", "1", "feat work", base_when + 100);
+
+        let b = repo.head().unwrap().peel_to_commit().unwrap();
+        let a = b.parent(0).unwrap();
+
+        // Side commit C: parented on A, touches main/y.rs only.
+        let sig_c = git2::Signature::new(
+            "Test",
+            "test@example.com",
+            &git2::Time::new(base_when + 200, 0),
+        )
+        .unwrap();
+        let tree_c = tree_with_subdir_file(repo, &a.tree().unwrap(), "main", "y.rs", "1");
+        let c_oid = repo
+            .commit(None, &sig_c, &sig_c, "main work", &tree_c, &[&a])
+            .unwrap();
+        let c = repo.find_commit(c_oid).unwrap();
+
+        // Merge M: union tree of B and C, parents (B, C).
+        let sig_m = git2::Signature::new(
+            "Test",
+            "test@example.com",
+            &git2::Time::new(base_when + 300, 0),
+        )
+        .unwrap();
+        let tree_m = tree_with_subdir_file(repo, &b.tree().unwrap(), "main", "y.rs", "1");
+        repo.commit(
+            Some("HEAD"),
+            &sig_m,
+            &sig_m,
+            "merge feature",
+            &tree_m,
+            &[&b, &c],
+        )
+        .unwrap();
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::test_support::{build_merge_history, commit_file, commit_file_as, init_repo};
     use super::*;
     use std::fs;
     use std::path::PathBuf;
@@ -708,53 +846,6 @@ mod tests {
         fn drop(&mut self) {
             let _ = fs::remove_dir_all(&self.0);
         }
-    }
-
-    fn init_repo(dir: &Path) -> GitRepo {
-        let repo = GitRepo::init(dir).unwrap();
-        // libgit2 requires user.name + user.email for commits.
-        let mut cfg = repo.config().unwrap();
-        cfg.set_str("user.name", "Test").unwrap();
-        cfg.set_str("user.email", "test@example.com").unwrap();
-        repo
-    }
-
-    fn commit_file(repo: &GitRepo, dir: &Path, rel: &str, content: &str, msg: &str, when: i64) {
-        commit_file_as(
-            repo,
-            dir,
-            rel,
-            content,
-            msg,
-            when,
-            "Test",
-            "test@example.com",
-        );
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn commit_file_as(
-        repo: &GitRepo,
-        dir: &Path,
-        rel: &str,
-        content: &str,
-        msg: &str,
-        when: i64,
-        author_name: &str,
-        author_email: &str,
-    ) {
-        fs::write(dir.join(rel), content).unwrap();
-        let mut idx = repo.index().unwrap();
-        idx.add_path(Path::new(rel)).unwrap();
-        idx.write().unwrap();
-        let tree_id = idx.write_tree().unwrap();
-        let tree = repo.find_tree(tree_id).unwrap();
-        let sig =
-            git2::Signature::new(author_name, author_email, &git2::Time::new(when, 0)).unwrap();
-        let parent = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
-        let parents: Vec<&git2::Commit<'_>> = parent.iter().collect();
-        repo.commit(Some("HEAD"), &sig, &sig, msg, &tree, &parents)
-            .unwrap();
     }
 
     #[test]
@@ -946,6 +1037,122 @@ mod tests {
             !modules.contains(&"old"),
             "ancient commit dropped by window"
         );
+    }
+
+    #[test]
+    fn commit_activity_skips_merge_commits() {
+        let tmp = TempDir::new();
+        let repo = init_repo(tmp.path());
+        let now = i64::try_from(
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        )
+        .unwrap();
+        build_merge_history(&repo, tmp.path(), now - 400);
+
+        let out = commit_activity(tmp.path());
+        let by_module: HashMap<_, _> = out.modules.iter().map(|m| (m.module.clone(), m)).collect();
+
+        // Exactly one drop per module — the merge commit must not re-count
+        // the branch's changes (pre-fix: feat and main showed 2 drops each).
+        assert_eq!(by_module.get("feat").unwrap().commits.len(), 1);
+        assert_eq!(by_module.get("main").unwrap().commits.len(), 1);
+        assert_eq!(by_module.get(".").unwrap().commits.len(), 1);
+        assert_eq!(out.total_commits, 3);
+
+        // The merge itself never surfaces as a drop on any band.
+        for m in &out.modules {
+            assert!(
+                m.commits.iter().all(|c| c.summary != "merge feature"),
+                "merge commit leaked into module {}",
+                m.module
+            );
+        }
+    }
+
+    #[test]
+    fn file_recency_attributes_merged_files_to_their_real_commits() {
+        let tmp = TempDir::new();
+        let repo = init_repo(tmp.path());
+        let now = i64::try_from(
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        )
+        .unwrap();
+        build_merge_history(&repo, tmp.path(), now - 400);
+
+        let result = file_recency(tmp.path()).unwrap();
+        let by_path: HashMap<_, _> = result.iter().map(|r| (r.path.clone(), r)).collect();
+
+        // The TIME-sorted walk sees the merge first; it must not claim the
+        // files the branch commits authored (pre-fix both showed "merge
+        // feature" as their last edit).
+        let x = by_path.get(&PathBuf::from("feat/x.rs")).expect("feat/x.rs");
+        assert_eq!(x.summary, "feat work");
+        let y = by_path.get(&PathBuf::from("main/y.rs")).expect("main/y.rs");
+        assert_eq!(y.summary, "main work");
+    }
+
+    #[test]
+    fn commit_activity_maven_module_ids_are_full_coordinates() {
+        // The id must be `MavenModule::coordinate()` (`groupId:artifactId`)
+        // — the same id the engine assigns to `Module::id` — or every
+        // module-keyed join (tour ranking, activity pulse) silently misses.
+        let tmp = TempDir::new();
+        let repo = init_repo(tmp.path());
+        fs::write(
+            tmp.path().join("pom.xml"),
+            "<project><groupId>com.acme</groupId><artifactId>demo</artifactId></project>",
+        )
+        .unwrap();
+        let now = i64::try_from(
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        )
+        .unwrap();
+        commit_file(&repo, tmp.path(), "A.java", "class A {}", "init", now - 100);
+
+        let out = commit_activity(tmp.path());
+        let ids: Vec<&str> = out.modules.iter().map(|m| m.module.as_str()).collect();
+        assert_eq!(ids, vec!["com.acme:demo"]);
+    }
+
+    #[test]
+    fn commit_activity_cargo_module_ids_include_version() {
+        // Same for Cargo: `CargoCrate::coordinate()` is `name@version` when
+        // the manifest carries a literal version.
+        let tmp = TempDir::new();
+        let repo = init_repo(tmp.path());
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        let now = i64::try_from(
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        )
+        .unwrap();
+        commit_file(
+            &repo,
+            tmp.path(),
+            "lib.rs",
+            "pub fn f() {}",
+            "init",
+            now - 100,
+        );
+
+        let out = commit_activity(tmp.path());
+        let ids: Vec<&str> = out.modules.iter().map(|m| m.module.as_str()).collect();
+        assert_eq!(ids, vec!["demo@0.1.0"]);
     }
 
     #[test]

--- a/crates/core/src/risk.rs
+++ b/crates/core/src/risk.rs
@@ -353,23 +353,21 @@ pub fn churn_per_file(
         if commit.time().seconds() < cutoff {
             break;
         }
+        // Merge commits are skipped: their branch-side changes are counted
+        // at the original commits the walk visits anyway, so diffing a
+        // merge against its parents would double the churn of every file
+        // that arrives via a merge-PR workflow (same convention as
+        // `git::commit_activity` / `git::file_recency`).
+        if commit.parent_count() > 1 {
+            continue;
+        }
         let Ok(tree) = commit.tree() else { continue };
-        let parent_trees: Vec<git2::Tree<'_>> =
-            commit.parents().filter_map(|p| p.tree().ok()).collect();
-
-        if parent_trees.is_empty() {
-            if let Ok(diff) = repo.diff_tree_to_tree(None, Some(&tree), None) {
-                for path in paths(&diff) {
-                    *counts.entry(path).or_default() += 1;
-                }
-            }
-        } else {
-            for parent in &parent_trees {
-                if let Ok(diff) = repo.diff_tree_to_tree(Some(parent), Some(&tree), None) {
-                    for path in paths(&diff) {
-                        *counts.entry(path).or_default() += 1;
-                    }
-                }
+        // First parent, or the empty tree for a root commit (every file
+        // counts as added).
+        let parent_tree = commit.parent(0).ok().and_then(|p| p.tree().ok());
+        if let Ok(diff) = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&tree), None) {
+            for path in paths(&diff) {
+                *counts.entry(path).or_default() += 1;
             }
         }
     }
@@ -623,6 +621,45 @@ mod tests {
             to: to.into(),
             kind: projectmind_plugin_api::RelationKind::Uses,
         }
+    }
+
+    #[test]
+    fn churn_per_file_skips_merge_commits() {
+        use crate::git::test_support::{build_merge_history, init_repo};
+
+        let dir = std::env::temp_dir().join(format!(
+            "projectmind-risk-churn-merge-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        struct Guard(PathBuf);
+        impl Drop for Guard {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+        let _guard = Guard(dir.clone());
+
+        let repo = init_repo(&dir);
+        let now = i64::try_from(
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        )
+        .unwrap();
+        build_merge_history(&repo, &dir, now - 400);
+
+        let counts = churn_per_file(&dir, 365).unwrap();
+        // One touch per file — the merge commit must not re-count the
+        // branch's changes (pre-fix: feat/x.rs and main/y.rs showed 2).
+        assert_eq!(counts.get(Path::new("feat/x.rs")).copied(), Some(1));
+        assert_eq!(counts.get(Path::new("main/y.rs")).copied(), Some(1));
+        assert_eq!(counts.get(Path::new("base.txt")).copied(), Some(1));
     }
 
     #[test]

--- a/crates/core/src/tour_suggest.rs
+++ b/crates/core/src/tour_suggest.rs
@@ -795,6 +795,76 @@ mod tests {
     }
 
     #[test]
+    fn activity_signal_joins_chord_and_git_module_ids_maven() {
+        // Regression for the dead activity signal: the chord side keys
+        // modules by the engine id (`MavenModule::coordinate()`, i.e.
+        // `groupId:artifactId`), while `commit_activity` runs its own
+        // manifest discovery. Both sides must produce the same id or
+        // `commits_90d` is always 0 and the 0.3 ranking weight is dead.
+        let git = TempGitRepo::new("join-maven");
+        std::fs::write(
+            git.dir.join("pom.xml"),
+            "<project><groupId>com.acme</groupId><artifactId>core</artifactId></project>",
+        )
+        .unwrap();
+        let hub = klass("core.Hub");
+        let core = mk_module_at("com.acme:core", git.dir.clone(), vec![hub]);
+        git.commit_classes(std::slice::from_ref(&core));
+
+        let mut repo = Repository::new(git.dir.clone());
+        repo.insert_module(core);
+        let scaffold = suggest_tour(&repo, &DummyFw { relations: vec![] }, 5, Persona::NewDev);
+
+        let ranked = scaffold
+            .ranking
+            .iter()
+            .find(|m| m.module == "com.acme:core")
+            .expect("ranked module");
+        assert_eq!(
+            ranked.commits_90d, 1,
+            "commit_activity ids must join onto the chord module id"
+        );
+        assert!(
+            ranked
+                .facts
+                .iter()
+                .any(|f| f.contains("1 commit(s) in 90d")),
+            "facts must report the joined activity, got {:?}",
+            ranked.facts
+        );
+    }
+
+    #[test]
+    fn activity_signal_joins_chord_and_git_module_ids_cargo() {
+        // Same join for Cargo with a literal version: the engine id is
+        // `name@version` (`CargoCrate::coordinate()`); a bare crate name on
+        // the activity side never matched it.
+        let git = TempGitRepo::new("join-cargo");
+        std::fs::write(
+            git.dir.join("Cargo.toml"),
+            "[package]\nname = \"core\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        let engine = klass("core.Engine");
+        let core = mk_module_at("core@0.1.0", git.dir.clone(), vec![engine]);
+        git.commit_classes(std::slice::from_ref(&core));
+
+        let mut repo = Repository::new(git.dir.clone());
+        repo.insert_module(core);
+        let scaffold = suggest_tour(&repo, &DummyFw { relations: vec![] }, 5, Persona::NewDev);
+
+        let ranked = scaffold
+            .ranking
+            .iter()
+            .find(|m| m.module == "core@0.1.0")
+            .expect("ranked module");
+        assert_eq!(
+            ranked.commits_90d, 1,
+            "cargo `name@version` ids must join onto the chord module id"
+        );
+    }
+
+    #[test]
     fn persona_parse_falls_back_to_new_dev() {
         assert_eq!(Persona::parse("architect"), Persona::Architect);
         assert_eq!(Persona::parse("new-dev"), Persona::NewDev);

--- a/crates/mcp-server/src/tools.rs
+++ b/crates/mcp-server/src/tools.rs
@@ -457,7 +457,7 @@ pub(crate) fn list() -> Value {
             },
             {
                 "name": "commit_activity",
-                "description": "Per-module commit activity over the last 24 months (timeline river, #63 concept 4). Groups commits by module (Maven artifactId / Cargo crate name, or top-level directory as fallback); each module lists its commit drops (age in seconds, sha, summary), newest-first. Modules sorted freshest-first. Capped at 5,000 commits walked. Answers 'when did module X go active/quiet'.",
+                "description": "Per-module commit activity over the last 24 months (timeline river, #63 concept 4). Groups commits by module (manifest coordinate: Maven groupId:artifactId / Cargo name@version, or top-level directory as fallback); each module lists its commit drops (age in seconds, sha, summary), newest-first. Modules sorted freshest-first. Capped at 5,000 commits walked. Answers 'when did module X go active/quiet'.",
                 "inputSchema": no_args_schema()
             },
             {


### PR DESCRIPTION
Implements findings #1 (D1) and #3 (D2) from the round-2 improvement analysis.

## Bug 1 — dead module-id join (analysis Top-5 #1 / D1)

`commit_activity` (`crates/core/src/git.rs`, `discover_module_roots`) attributed commits to **bare** Maven `artifact_id`s / Cargo crate `name`s, while everything module-keyed on the other side uses the engine id from the manifest coordinate:

- `module_chord` / `tour_suggest` join on `Module::id` = `MavenModule::coordinate()` (`groupId:artifactId`) resp. `CargoCrate::coordinate()` (`name@version`)
- `BeanNode.module` in the bean graph carries the same id

The exact-string join in `tour_suggest.rs` (`commits_90d_for`) therefore never matched on Maven repos with a `groupId` or Cargo repos with a literal version: `commits_90d` was always 0, the 0.3 activity ranking weight was dead, and materialized tour narrations claimed "0 commit(s) in 90d". ProjectMind itself only escaped via `version.workspace = true`.

**Fix:** `discover_module_roots` now emits `coordinate()` on both discovery paths — one backend change heals every consumer.

**Frontend follow-up (required by the id change):** `app/src/lib/diagrams/activityPulse.ts` joined via suffix match (`beanModule.split(':').pop()`) against the bare ids — that would have broken for Maven under the new ids and never worked for `name@version`. The join is now an **exact module-id match**; `hotModules`/`warmModules` echo full coordinates. Tests updated + new `name@version` regression case + a test pinning that bare artifactIds no longer match.

## Bug 2 — merge commits doubled all activity metrics (analysis Top-5 #3 / D2)

`commit_activity` and `file_recency` (`git.rs`) and `churn_per_file` (`risk.rs`) diffed every commit against **every** parent. On merge-PR workflows the branch changes counted twice (original commit + merge-vs-parent diff), so pulse/glow/churn/cinematics/tour ranking showed modules ~2× as hot, and file recency attributed "last edit" to the merge commit instead of the real authoring commit.

**Fix:** all three walks skip merge commits and diff non-merges against their first parent (empty tree for root commits) — matching `git log`'s default of showing no patch for merges. Shared helper `first_parent_touched_paths` in `git.rs`.

## Regression tests

- `tour_suggest`: cross-source join tests (chord ids from `Repository` modules vs `commit_activity` discovery over a temp git repo with real `pom.xml` / `Cargo.toml`) asserting `commits_90d == 1` for `com.acme:core` and `core@0.1.0`
- `git.rs`: coordinate-id tests for both ecosystems; merge-history tests for `commit_activity` (1 drop per module, merge never surfaces) and `file_recency` (merged files attribute to their authoring commits)
- `risk.rs`: `churn_per_file_skips_merge_commits` (counts stay 1, not 2) via a shared `git::test_support::build_merge_history` fixture (true two-parent merge built with tree builders)
- Verified the 6 new tests fail against the pre-fix behavior

## Docs synced

`ModuleActivity`/`BeanNode` rustdoc, `api.ts` mirror types, `commit_activity` MCP tool description.

## Gates

- `cargo fmt --all --check` clean
- `./scripts/ci.sh check` (fmt + clippy `--workspace --exclude projectmind-app --all-targets -- -D warnings`) clean
- `./scripts/ci.sh test` (workspace tests + doctests, app excluded): all green (core 271 passed)
- Frontend: `pnpm lint` 0, `pnpm check` 0 errors/0 warnings, `pnpm test` 516 passed, `pnpm build` OK

Note: the timeline-river band labels now show full coordinates (e.g. `com.acme:web` instead of `web`); labels >20 chars are ellipsized as before. Left as-is for id consistency — shorten for display in a follow-up if it bothers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJuL4nSq1EvgahTJe1hom1