### PR TITLE
chore(ci): reduce artifact retention-days to fix org storage quota

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,4 +127,7 @@ jobs:
         with:
           name: projectmind-mcp-linux
           path: target/release/projectmind-mcp
-          retention-days: 7
+          # Runs on every push to master AND every PR — 7 days was accumulating
+          # fast. 3 days still covers "grab yesterday's/this week's build for
+          # ad-hoc testing" without the steady-state storage cost.
+          retention-days: 3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,13 @@ jobs:
           path: |
             projectmind-mcp-${{ matrix.asset_suffix }}.tar.gz
             projectmind-mcp-${{ matrix.asset_suffix }}.tar.gz.sha256
-          retention-days: 30
+          # Purely a hand-off to the `publish` job later in this SAME run — the
+          # actual distributable lives in the GitHub Release afterward (which
+          # doesn't count against Actions artifact storage). 30 days here was
+          # needlessly burning storage quota for something dead within minutes
+          # of `publish` succeeding; 1 day (GitHub's minimum) still gives a
+          # window to inspect a failed `publish` step without rebuilding.
+          retention-days: 1
 
   app:
     name: desktopApp / ${{ matrix.asset_suffix }}
@@ -290,7 +296,9 @@ jobs:
           path: |
             projectmind-app-${{ matrix.asset_suffix }}.tar.gz
             projectmind-app-${{ matrix.asset_suffix }}.tar.gz.sha256
-          retention-days: 30
+          # See the mcp job's identical comment: hand-off to `publish` in this
+          # same run, superseded by the GitHub Release within minutes.
+          retention-days: 1
 
       - name: Upload updater assets
         if: always()
@@ -298,7 +306,7 @@ jobs:
         with:
           name: projectmind-updater-${{ matrix.asset_suffix }}
           path: updater-stage/
-          retention-days: 30
+          retention-days: 1
           if-no-files-found: ignore
 
   publish:


### PR DESCRIPTION
## Zusammenfassung
Der Org-Deploy von `plaintext-app` PR #441 zeigte: `Failed to CreateArtifact: Artifact storage quota has been hit.` Untersuchung ergab: **`projectmind` allein steht für ~1.58GB der ~1.7GB org-weiten Actions-Artifact-Storage** (geprüft via `gh api repos/.../actions/artifacts` über alle Org-Repos), fast ausschliesslich aus `release.yml`s 30-Tage-Retention auf den Release-Build-Binaries.

## Root Cause
`release.yml`s `mcp`/`app`/`updater`-Artefakte sind reine Zwischenablage-Uploads für den `publish`-Job **im selben Workflow-Lauf** — das eigentliche Distributable landet Minuten später als GitHub-Release-Asset (zählt NICHT gegen die Actions-Storage-Quota). 30 Tage Retention auf etwas, das nach dem erfolgreichen `publish` nutzlos ist, war reine Verschwendung — bei 3 Plattformen × 2 Upload-Schritten pro getaggtem Release (Tauri-Desktop-Bundles sind gross).

## Fix
- `release.yml`: `retention-days: 30` → `1` (GitHub-Minimum) für alle 3 Upload-Steps in `mcp`/`app` — reicht als Debug-Fenster falls `publish` mal fehlschlägt.
- `ci.yml`: `retention-days: 7` → `3` für den Smoke-Build (läuft bei JEDEM Push+PR, nicht nur bei Tags — verschärft die Akkumulation zusätzlich).

## Nicht in diesem PR
Das bereits existierende `housekeeping.yml` (`deleteLogs5`/`deleteLogAll`, manuell per `workflow_dispatch`) kann die ~1.58GB bereits gespeicherter alter Artefakte aufräumen — das habe ich bewusst nicht selbst ausgelöst (löscht Workflow-Run-Historie), das überlasse ich dir:
```
gh workflow run housekeeping.yml -f task=deleteLogs5 --repo Plaintext-Gmbh/projectmind
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)